### PR TITLE
feat(code-server): add machine settings option

### DIFF
--- a/registry/coder/modules/code-server/main.tf
+++ b/registry/coder/modules/code-server/main.tf
@@ -44,6 +44,12 @@ variable "settings" {
   default     = {}
 }
 
+variable "machine-settings" {
+  type        = any
+  description = "A map of template level machine settings to apply to code-server. This will be overwritten at each container start."
+  default     = {}
+}
+
 variable "folder" {
   type        = string
   description = "The folder to open in code-server."
@@ -149,6 +155,7 @@ resource "coder_script" "code-server" {
     INSTALL_PREFIX : var.install_prefix,
     // This is necessary otherwise the quotes are stripped!
     SETTINGS : replace(jsonencode(var.settings), "\"", "\\\""),
+    MACHINE_SETTINGS : replace(jsonencode(var.machine-settings), "\"", "\\\""),
     OFFLINE : var.offline,
     USE_CACHED : var.use_cached,
     USE_CACHED_EXTENSIONS : var.use_cached_extensions,

--- a/registry/coder/modules/code-server/run.sh
+++ b/registry/coder/modules/code-server/run.sh
@@ -23,7 +23,20 @@ function run_code_server() {
 if [ ! -f ~/.local/share/code-server/User/settings.json ]; then
   echo "⚙️ Creating settings file..."
   mkdir -p ~/.local/share/code-server/User
-  echo "${SETTINGS}" > ~/.local/share/code-server/User/settings.json
+  if command -v jq &> /dev/null; then
+    echo "${SETTINGS}" | jq '.' > ~/.local/share/code-server/User/settings.json
+  else
+    echo "${SETTINGS}" > ~/.local/share/code-server/User/settings.json
+  fi
+fi
+
+# Apply/overwrite template based settings
+echo "⚙️ Creating machine settings file..."
+mkdir -p ~/.local/share/code-server/Machine
+if command -v jq &> /dev/null; then
+  echo "${MACHINE_SETTINGS}" | jq '.' > ~/.local/share/code-server/Machine/settings.json
+else
+  echo "${MACHINE_SETTINGS}" > ~/.local/share/code-server/Machine/settings.json
 fi
 
 # Check if code-server is already installed for offline


### PR DESCRIPTION
Should resolve https://github.com/coder/registry/issues/27

The goal is to provide a method for template owners to configure default `Machine Settings` that can be overridden by developers via `User Settings` and repositories via `Workspace Settings`.
This option allows template owners to push new settings options with a template release that would not be ignored because the setting file already exists.
This also formats the `settings.json` file if `jq` is installed.

Eventually, I would imagine the current `settings` option will be depreciated in favor of this option.