### PR TITLE
chore: remove support email

### DIFF
--- a/registry/coder/README.md
+++ b/registry/coder/README.md
@@ -4,7 +4,6 @@ bio: Coder provisions cloud development environments via Terraform, supporting L
 github: coder
 linkedin: https://www.linkedin.com/company/coderhq
 website: https://www.coder.com
-support_email: support@coder.com
 status: official
 ---
 


### PR DESCRIPTION
The email is only for paying customers. Removing this will help us get random support requests.