### PR TITLE
feat(vault-token): add optional vault enterprise namespace variable

### DIFF
--- a/registry/coder/modules/vault-token/README.md
+++ b/registry/coder/modules/vault-token/README.md
@@ -20,11 +20,12 @@ variable "vault_token" {
 }
 
 module "vault" {
-  source      = "registry.coder.com/coder/vault-token/coder"
-  version     = "1.1.0"
-  agent_id    = coder_agent.example.id
-  vault_token = var.token # optional
-  vault_addr  = "https://vault.example.com"
+  source          = "registry.coder.com/coder/vault-token/coder"
+  version         = "1.1.0"
+  agent_id        = coder_agent.example.id
+  vault_token     = var.token # optional
+  vault_addr      = "https://vault.example.com"
+  vault_namespace = "prod" # optional, vault enterprise only
 }
 ```
 

--- a/registry/coder/modules/vault-token/main.tf
+++ b/registry/coder/modules/vault-token/main.tf
@@ -26,6 +26,11 @@ variable "vault_token" {
   sensitive   = true
   default     = null
 }
+variable "vault_namespace" {
+  type        = string
+  description = "The Vault namespace to use."
+  default     = null
+}
 
 variable "vault_cli_version" {
   type        = string
@@ -61,4 +66,11 @@ resource "coder_env" "vault_token" {
   agent_id = var.agent_id
   name     = "VAULT_TOKEN"
   value    = var.vault_token
+}
+
+resource "coder_env" "vault_namespace" {
+  count    = var.vault_namespace != null ? 1 : 0
+  agent_id = var.agent_id
+  name     = "VAULT_NAMESPACE"
+  value    = var.vault_namespace
 }


### PR DESCRIPTION
Added an optional envvar to vault-token module to handle communicating with a non default vault namespace.

in vault enterprise, you can run multiple secure isolated vault environments from the one vault server. 
each namespace has it's own authentication methods and secrets engines. 
vault uses the VAULT_NAMESPACE envvar to determine the namespace to use.
no value, or either `root` or `/` will use the root (default) namespace, any other value will use a different namespace

in vault community edition, the only supported namespace is "root", no other namespaces can be used.

in HCP vault dedicated (the saas hosted version), you cant access vault without a namespace set

this defaults to not setting the env var, so is backwards compatible, and works with vault CE