### PR TITLE
fix: update tf highlight example in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,11 +179,11 @@ The following criteria exists for two reasons:
 - When increasing the level of a header, the header's level must be incremented by one each time.
 - Any `.hcl` code snippets must be labeled as `.tf` snippets instead
 
-  ```txt
-  \`\`\`tf
+  ````txt
+  ```tf
   Content
-  \`\`\`
   ```
+  ````
 
 #### Namespace (contributor profile) criteria
 


### PR DESCRIPTION
Leveraging an extra backtick in the wrapper to encourage the middle sample to render properly.