### PR TITLE
fix(claude-code): run post-install script after configuring MCP and remove `send-keys` workaround

### DIFF
--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -14,7 +14,7 @@ Run the [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "1.3.0"
+  version             = "1.3.1"
   agent_id            = coder_agent.example.id
   folder              = "/home/coder"
   install_claude_code = true
@@ -88,7 +88,7 @@ resource "coder_agent" "main" {
 module "claude-code" {
   count               = data.coder_workspace.me.start_count
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "1.1.0"
+  version             = "1.3.1"
   agent_id            = coder_agent.example.id
   folder              = "/home/coder"
   install_claude_code = true
@@ -107,7 +107,7 @@ Run Claude Code as a standalone app in your workspace. This will install Claude 
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "1.3.0"
+  version             = "1.3.1"
   agent_id            = coder_agent.example.id
   folder              = "/home/coder"
   install_claude_code = true

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -203,15 +203,9 @@ resource "coder_script" "claude_code" {
 
       screen -U -dmS claude-code bash -c '
         cd ${var.folder}
-        claude --dangerously-skip-permissions | tee -a "$HOME/.claude-code.log"
+        claude --dangerously-skip-permissions "$CODER_MCP_CLAUDE_TASK_PROMPT" | tee -a "$HOME/.claude-code.log"
         exec bash
       '
-      # Extremely hacky way to send the prompt to the screen session
-      # This will be fixed in the future, but `claude` was not sending MCP
-      # tasks when an initial prompt is provided.
-      screen -S claude-code -X stuff "$CODER_MCP_CLAUDE_TASK_PROMPT"
-      sleep 5
-      screen -S claude-code -X stuff "^M"
     else
       # Check if claude is installed before running
       if ! command_exists claude; then

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -131,17 +131,17 @@ resource "coder_script" "claude_code" {
       npm install -g @anthropic-ai/claude-code@${var.claude_code_version}
     fi
 
+    if [ "${var.experiment_report_tasks}" = "true" ]; then
+      echo "Configuring Claude Code to report tasks via Coder MCP..."
+      coder exp mcp configure claude-code ${var.folder}
+    fi
+
     # Run post-install script if provided
     if [ -n "${local.encoded_post_install_script}" ]; then
       echo "Running post-install script..."
       echo "${local.encoded_post_install_script}" | base64 -d > /tmp/post_install.sh
       chmod +x /tmp/post_install.sh
       /tmp/post_install.sh
-    fi
-
-    if [ "${var.experiment_report_tasks}" = "true" ]; then
-      echo "Configuring Claude Code to report tasks via Coder MCP..."
-      coder exp mcp configure claude-code ${var.folder}
     fi
 
     # Handle terminal multiplexer selection (tmux or screen)
@@ -171,6 +171,7 @@ resource "coder_script" "claude_code" {
 
       # Send the prompt to the tmux session if needed
       if [ -n "$CODER_MCP_CLAUDE_TASK_PROMPT" ]; then
+        echo "Sending prompt to tmux session..."
         tmux send-keys -t claude-code "$CODER_MCP_CLAUDE_TASK_PROMPT"
         sleep 5
         tmux send-keys -t claude-code Enter

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -167,7 +167,7 @@ resource "coder_script" "claude_code" {
       export LC_ALL=en_US.UTF-8
 
       # Create a new tmux session in detached mode
-      tmux new-session -d -s claude-code -c ${var.folder} "claude --dangerously-skip-permissions \"${CODER_MCP_CLAUDE_TASK_PROMPT}\""
+      tmux new-session -d -s claude-code -c ${var.folder} "claude --dangerously-skip-permissions \"$CODER_MCP_CLAUDE_TASK_PROMPT\""
 
     fi
 

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -167,15 +167,8 @@ resource "coder_script" "claude_code" {
       export LC_ALL=en_US.UTF-8
 
       # Create a new tmux session in detached mode
-      tmux new-session -d -s claude-code -c ${var.folder} "claude --dangerously-skip-permissions"
+      tmux new-session -d -s claude-code -c ${var.folder} "claude --dangerously-skip-permissions \"${CODER_MCP_CLAUDE_TASK_PROMPT}\""
 
-      # Send the prompt to the tmux session if needed
-      if [ -n "$CODER_MCP_CLAUDE_TASK_PROMPT" ]; then
-        echo "Sending prompt to tmux session..."
-        tmux send-keys -t claude-code "$CODER_MCP_CLAUDE_TASK_PROMPT"
-        sleep 5
-        tmux send-keys -t claude-code Enter
-      fi
     fi
 
     # Run with screen if enabled


### PR DESCRIPTION
- needed to install MCP servers
- workaround sucked