### PR TITLE
Query agentapi for claude-code status

### DIFF
--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -138,7 +138,7 @@ resource "coder_script" "claude_code" {
 
     if [ "${var.experiment_report_tasks}" = "true" ]; then
       echo "Configuring Claude Code to report tasks via Coder MCP..."
-      coder exp mcp configure claude-code ${var.folder}
+      coder exp mcp configure claude-code ${var.folder} --ai-agentapi-url http://localhost:3284
     fi
 
     # Run post-install script if provided


### PR DESCRIPTION
Depends on https://github.com/coder/registry/pull/135 and https://github.com/coder/coder/pull/18262

~As discussed, this adds a bash script that gets the status from agentapi then relays that to coderd. I wonder if we should make it part of `coder exp` though?  Handling JSON in Bash is pretty janky.  Or we could do it in JS since we already have Node available.~

Refactored into `coder exp`.

~In any case, it looks like `/status` just reports `stable` or `running`. Do we need to modify this endpoint or is there something else I should be using? Initially I thought the endpoint we need already existed but I may have misunderstood.~

We decided to just update the status and preserve the last message if any for now.