### PR TITLE
fix: disable UDP connections on windows-rdp module

### DIFF
--- a/registry/coder/modules/windows-rdp/README.md
+++ b/registry/coder/modules/windows-rdp/README.md
@@ -16,7 +16,7 @@ Enable Remote Desktop + a web based client on Windows workspaces, powered by [de
 module "windows_rdp" {
   count       = data.coder_workspace.me.start_count
   source      = "registry.coder.com/coder/windows-rdp/coder"
-  version     = "1.2.0"
+  version     = "1.2.1"
   agent_id    = resource.coder_agent.main.id
   resource_id = resource.aws_instance.dev.id
 }
@@ -34,7 +34,7 @@ module "windows_rdp" {
 module "windows_rdp" {
   count       = data.coder_workspace.me.start_count
   source      = "registry.coder.com/coder/windows-rdp/coder"
-  version     = "1.2.0"
+  version     = "1.2.1"
   agent_id    = resource.coder_agent.main.id
   resource_id = resource.aws_instance.dev.id
 }
@@ -46,7 +46,7 @@ module "windows_rdp" {
 module "windows_rdp" {
   count       = data.coder_workspace.me.start_count
   source      = "registry.coder.com/coder/windows-rdp/coder"
-  version     = "1.2.0"
+  version     = "1.2.1"
   agent_id    = resource.coder_agent.main.id
   resource_id = resource.google_compute_instance.dev[0].id
 }
@@ -58,7 +58,7 @@ module "windows_rdp" {
 module "windows_rdp" {
   count                       = data.coder_workspace.me.start_count
   source                      = "registry.coder.com/coder/windows-rdp/coder"
-  version                     = "1.2.0"
+  version                     = "1.2.1"
   agent_id                    = resource.coder_agent.main.id
   resource_id                 = resource.aws_instance.dev.id
   devolutions_gateway_version = "2025.1.6" # Specify a specific version

--- a/registry/coder/modules/windows-rdp/powershell-installation-script.tftpl
+++ b/registry/coder/modules/windows-rdp/powershell-installation-script.tftpl
@@ -16,6 +16,11 @@ function Configure-RDP {
     New-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -Name "SecurityLayer" -Value 1 -PropertyType DWORD -Force
     # Enable RDP through Windows Firewall
     Enable-NetFirewallRule -DisplayGroup "Remote Desktop"
+
+    # Disable UDP. It doesn't work via `coder port-forward` and is broken due to MTU issues in Coder Connect.
+    # Requires a restart to take effect. c.f. https://github.com/coder/internal/issues/608#issuecomment-2965923672
+    New-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services' -Name "SelectTransport" -Value 1 -PropertyType DWORD -Force
+    Restart-Service -Name "TermService" -Force
 }
 
 function Install-DevolutionsGateway {


### PR DESCRIPTION
## Description

Relates to 

Fixes an issue where RDP doesn't function properly over Coder Connect, by disabling UDP and relying only on TCP. c.f. https://github.com/coder/internal/issues/608#issuecomment-2965923672 for a detailed description of the problem.

---

## Type of Change

- [ ] New module
- [X] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

---

## Module Information

<!-- Delete this section if not applicable -->

**Path:** `registry/coder/modules/windows-rdp`  
**New version:** `v1.0.19`  
**Breaking change:** [ ] Yes [x] No

---

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun run fmt`)
- [x] Changes tested locally

---

## Related Issues

https://github.com/coder/internal/issues/608

Closes #
