### PR TITLE
Use AgentAPI for additional status reporting

### DIFF
--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -138,7 +138,7 @@ resource "coder_script" "claude_code" {
 
     if [ "${var.experiment_report_tasks}" = "true" ]; then
       echo "Configuring Claude Code to report tasks via Coder MCP..."
-      coder exp mcp configure claude-code ${var.folder}
+      coder exp mcp configure claude-code ${var.folder} --ai-agentapi-url http://localhost:3284
     fi
 
     # Run post-install script if provided


### PR DESCRIPTION
Is it OK to add the flag like this or do we need to check the cli version to determine whether the flag is set?  Or I could just throw in an `||` to run the command again without the flag if it fails.