### PR TITLE
fix: clean up version-bump workflow script output handling

### DIFF
--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -47,7 +47,6 @@ jobs:
       - name: Check version bump requirements
         id: version-check
         run: |
-          # Run the script to check what versions should be
           output_file=$(mktemp)
           if ./.github/scripts/version-bump.sh "${{ steps.bump-type.outputs.type }}" origin/main > "$output_file" 2>&1; then
             echo "Script completed successfully"
@@ -57,17 +56,14 @@ jobs:
             exit 1
           fi
 
-          # Store output for PR comment
           {
             echo "output<<EOF"
             cat "$output_file"
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
-          # Show output
           cat "$output_file"
 
-          # Check if any files would be modified by the script
           if git diff --quiet; then
             echo "versions_up_to_date=true" >> $GITHUB_OUTPUT
             echo "✅ All module versions are already up to date"
@@ -79,6 +75,10 @@ jobs:
             echo ""
             echo "Diff preview:"
             git diff
+            
+            git checkout .
+            git clean -fd
+            
             exit 1
           fi
 
@@ -86,6 +86,7 @@ jobs:
         if: failure() && steps.version-check.outputs.versions_up_to_date == 'false'
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const output = `${{ steps.version-check.outputs.output }}`;
             const bumpType = `${{ steps.bump-type.outputs.type }}`;


### PR DESCRIPTION
## Description

Removed unnecessary comments and added commands to reset the working directory and clean untracked files in the version-bump workflow. This improves the script's reliability by ensuring a clean state after executing version checks.

---

## Type of Change

- [ ] New module
- [X] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

---

## Related Issues

None
