### PR TITLE
fix: update release action to match new registry-server dev flow

### DIFF
--- a/.github/workflows/deploy-registry.yaml
+++ b/.github/workflows/deploy-registry.yaml
@@ -28,8 +28,5 @@ jobs:
         uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a
       - name: Deploy to dev.registry.coder.com
         run: gcloud builds triggers run 29818181-126d-4f8a-a937-f228b27d3d34 --branch main
-      # garrett!: We don't have a good way to target this right now, so I'm commenting it out
-      # so we don't accidently deploy to production.
-      # - name: Deploy to registry.coder.com
-      #   run: |
-      #     gcloud builds triggers run 106610ff-41fb-4bd0-90a2-7643583fb9c0 --branch main
+      - name: Deploy to registry.coder.com
+        run: gcloud builds triggers run 106610ff-41fb-4bd0-90a2-7643583fb9c0 --tag production


### PR DESCRIPTION
## Description

This PR updates the CI release flow to match the registry-server's new development flow.
The "dev" registry now deploys directly from the main branch of registry-server.
The "production" registry now deploys from tagged releases of registry-server. We have added a "production" tag that will
track the same commit as the latest semver release of the registry-server.

---

## Type of Change

- [ ] New module
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

---

## Related Issues

Fixes https://github.com/coder/registry/pull/170

Closes #
