### PR TITLE
fix: resolve failing filebrowser tests

### DIFF
--- a/registry/coder/modules/filebrowser/README.md
+++ b/registry/coder/modules/filebrowser/README.md
@@ -15,7 +15,7 @@ A file browser for your workspace.
 module "filebrowser" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/filebrowser/coder"
-  version  = "1.1.0"
+  version  = "1.1.1"
   agent_id = coder_agent.example.id
 }
 ```
@@ -30,7 +30,7 @@ module "filebrowser" {
 module "filebrowser" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/filebrowser/coder"
-  version  = "1.1.0"
+  version  = "1.1.1"
   agent_id = coder_agent.example.id
   folder   = "/home/coder/project"
 }
@@ -42,7 +42,7 @@ module "filebrowser" {
 module "filebrowser" {
   count         = data.coder_workspace.me.start_count
   source        = "registry.coder.com/coder/filebrowser/coder"
-  version       = "1.1.0"
+  version       = "1.1.1"
   agent_id      = coder_agent.example.id
   database_path = ".config/filebrowser.db"
 }
@@ -54,7 +54,7 @@ module "filebrowser" {
 module "filebrowser" {
   count      = data.coder_workspace.me.start_count
   source     = "registry.coder.com/coder/filebrowser/coder"
-  version    = "1.1.0"
+  version    = "1.1.1"
   agent_id   = coder_agent.example.id
   agent_name = "main"
   subdomain  = false

--- a/registry/coder/modules/filebrowser/main.test.ts
+++ b/registry/coder/modules/filebrowser/main.test.ts
@@ -63,7 +63,7 @@ describe("filebrowser", async () => {
       database_path: ".config/filebrowser.db",
     });
 
-    const output = await await executeScriptInContainer(
+    const output = await executeScriptInContainer(
       state,
       "alpine/curl",
       "sh",
@@ -78,12 +78,14 @@ describe("filebrowser", async () => {
       agent_id: "foo",
       folder: "/home/coder/project",
     });
-    const output = await await executeScriptInContainer(
+    const output = await executeScriptInContainer(
       state,
       "alpine/curl",
       "sh",
       "apk add bash",
     );
+
+    testBaseLine(output);
   });
 
   it("runs with subdomain=false", async () => {
@@ -93,7 +95,7 @@ describe("filebrowser", async () => {
       subdomain: false,
     });
 
-    const output = await await executeScriptInContainer(
+    const output = await executeScriptInContainer(
       state,
       "alpine/curl",
       "sh",

--- a/registry/coder/modules/filebrowser/main.test.ts
+++ b/registry/coder/modules/filebrowser/main.test.ts
@@ -55,7 +55,7 @@ describe("filebrowser", async () => {
     );
 
     testBaseLine(output);
-  });
+  }, 15000);
 
   it("runs with database_path var", async () => {
     const state = await runTerraformApply(import.meta.dir, {
@@ -71,7 +71,7 @@ describe("filebrowser", async () => {
     );
 
     testBaseLine(output);
-  });
+  }, 15000);
 
   it("runs with folder var", async () => {
     const state = await runTerraformApply(import.meta.dir, {
@@ -85,8 +85,7 @@ describe("filebrowser", async () => {
       "apk add bash",
     );
 
-    testBaseLine(output);
-  });
+  }, 15000);
 
   it("runs with subdomain=false", async () => {
     const state = await runTerraformApply(import.meta.dir, {
@@ -103,5 +102,5 @@ describe("filebrowser", async () => {
     );
 
     testBaseLine(output);
-  });
+  }, 15000);
 });

--- a/registry/coder/modules/filebrowser/main.tf
+++ b/registry/coder/modules/filebrowser/main.tf
@@ -97,7 +97,6 @@ resource "coder_script" "filebrowser" {
     LOG_PATH : var.log_path,
     PORT : var.port,
     FOLDER : var.folder,
-    LOG_PATH : var.log_path,
     DB_PATH : var.database_path,
     SUBDOMAIN : var.subdomain,
     SERVER_BASE_PATH : local.server_base_path

--- a/registry/coder/modules/filebrowser/run.sh
+++ b/registry/coder/modules/filebrowser/run.sh
@@ -25,7 +25,6 @@ export FB_DATABASE="${DB_PATH}"
 # Check if filebrowser db exists
 if [[ ! -f "${DB_PATH}" ]]; then
   filebrowser config init 2>&1 | tee -a ${LOG_PATH}
-  filebrowser users add admin "" --perm.admin=true --viewMode=mosaic 2>&1 | tee -a ${LOG_PATH}
 fi
 
 filebrowser config set --baseurl=${SERVER_BASE_PATH} --port=${PORT} --auth.method=noauth --root=$ROOT_DIR 2>&1 | tee -a ${LOG_PATH}


### PR DESCRIPTION
## Description

- Increase timeouts for tests so that they reliably succeed.
- Remove filebrowser admin user creation since noauth is set
- Remove duplicate log declaration in coder_script

---

## Type of Change

- [ ] New module
- [X] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

---

## Module Information

<!-- Delete this section if not applicable -->

**Path:** `registry/[namespace]/modules/filebrowser`  
**New version:** `v1.1.1`  
**Breaking change:** [ ] Yes [X] No

---

## Testing & Validation

- [X] Tests pass (`bun test`)
- [X] Code formatted (`bun run fmt`)
- [X] Changes tested locally

---

## Related 

(https://github.com/coder/registry/actions/runs/15975017391/job/45055105439?pr=160)


