### PR TITLE
fix: update icon path for tasks-docker

### DIFF
--- a/registry/coder-labs/templates/tasks-docker/README.md
+++ b/registry/coder-labs/templates/tasks-docker/README.md
@@ -1,7 +1,7 @@
 ---
 display_name: Tasks on Docker
 description: Run Coder Tasks on Docker with an example application
-icon: ./.images/tasks.svg
+icon: ../.images/tasks.svg
 maintainer_github: coder
 verified: false
 tags: [docker, container, ai, tasks]


### PR DESCRIPTION
## Description

Updated the path for the icon in `tasks-docker`. The CI in the Registry didn't catch this, but the CI in the Registry Server did.

## Type of Change

- [ ] New module
- [ ] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [x] Other

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun run fmt`)
- [x] Changes tested locally

---

## Related Issues

None
