### PR TITLE
chore: bump claude-code to v2.0.2

### DIFF
--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -14,7 +14,7 @@ Run the [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "2.0.1"
+  version             = "2.0.2"
   agent_id            = coder_agent.example.id
   folder              = "/home/coder"
   install_claude_code = true
@@ -85,7 +85,7 @@ resource "coder_agent" "main" {
 module "claude-code" {
   count               = data.coder_workspace.me.start_count
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "2.0.1"
+  version             = "2.0.2"
   agent_id            = coder_agent.example.id
   folder              = "/home/coder"
   install_claude_code = true
@@ -103,7 +103,7 @@ Run Claude Code as a standalone app in your workspace. This will install Claude 
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "2.0.1"
+  version             = "2.0.2"
   agent_id            = coder_agent.example.id
   folder              = "/home/coder"
   install_claude_code = true


### PR DESCRIPTION
A `tasks` tag was added to the claude-code module in https://github.com/coder/registry/pull/182/files#diff-3f433388cb775dcc77c38911e23acbd2eb64e26e26c25d46b045724dfe5136bbL7, so I'm bumping the version in order to publish the module in the registry.