### PR TITLE
fix: update namespace for coder-labs template

### DIFF
--- a/registry/coder-labs/templates/tasks-docker/README.md
+++ b/registry/coder-labs/templates/tasks-docker/README.md
@@ -2,7 +2,7 @@
 display_name: Tasks on Docker
 description: Run Coder Tasks on Docker with an example application
 icon: ../../../../.icons/tasks.svg
-maintainer_github: coder
+maintainer_github: coder-labs
 verified: false
 tags: [docker, container, ai, tasks]
 ---


### PR DESCRIPTION
## Description

This PR updates the `maintainer_github` field for the new Coder Labs template to use the value of `coder-labs`. This shouldn't be necessary (`maintainer_github` should be deprecated), but something is off with our build step.

## Type of Change

- [ ] New module
- [ ] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [x] Other

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun run fmt`)
- [x] Changes tested locally

---

## Related Issues

None
