### PR TITLE
docs(hcp-vault-secrets): 1.0.32 final version for hcp-vault-secrets

### DIFF
--- a/registry/coder/modules/hcp-vault-secrets/README.md
+++ b/registry/coder/modules/hcp-vault-secrets/README.md
@@ -28,7 +28,7 @@ This module lets you fetch all or selective secrets from a [HCP Vault Secrets](h
 ```tf
 module "vault" {
   source     = "registry.coder.com/coder/hcp-vault-secrets/coder"
-  version    = "1.0.8"
+  version    = "1.0.32"
   agent_id   = coder_agent.example.id
   app_name   = "demo-app"
   project_id = "aaa-bbb-ccc"
@@ -54,7 +54,7 @@ To fetch all secrets from the HCP Vault Secrets app, skip the `secrets` input.
 ```tf
 module "vault" {
   source     = "registry.coder.com/coder/hcp-vault-secrets/coder"
-  version    = "1.0.8"
+  version    = "1.0.32"
   agent_id   = coder_agent.example.id
   app_name   = "demo-app"
   project_id = "aaa-bbb-ccc"
@@ -68,7 +68,7 @@ To fetch selective secrets from the HCP Vault Secrets app, set the `secrets` inp
 ```tf
 module "vault" {
   source     = "registry.coder.com/coder/hcp-vault-secrets/coder"
-  version    = "1.0.8"
+  version    = "1.0.32"
   agent_id   = coder_agent.example.id
   app_name   = "demo-app"
   project_id = "aaa-bbb-ccc"
@@ -83,7 +83,7 @@ Set `client_id` and `client_secret` as module inputs.
 ```tf
 module "vault" {
   source        = "registry.coder.com/coder/hcp-vault-secrets/coder"
-  version       = "1.0.8"
+  version       = "1.0.32"
   agent_id      = coder_agent.example.id
   app_name      = "demo-app"
   project_id    = "aaa-bbb-ccc"


### PR DESCRIPTION
## Description

Updates README for final version of hcp-vault-secrets. Previous version was tagged and documented wrong
<!-- Briefly describe what this PR does and why -->

## Type of Change

- [ ] New module
- [ ] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [X] Other

## Module Information

<!-- Delete this section if not applicable -->

**Path:** `registry/coder/modules/hcp-vault-secrets`  
**New version:** `v1.0.32`  
**Breaking change:** [ ] Yes [X] No
