### PR TITLE
feat(tag_release): add script for automatically tagging and releasing modules

### DIFF
--- a/.github/scripts/tag_release.sh
+++ b/.github/scripts/tag_release.sh
@@ -195,7 +195,7 @@ create_and_push_tags() {
   for module_info in "${MODULES_TO_TAG[@]}"; do
     IFS=':' read -r module_path namespace module_name version <<< "$module_info"
     local tag_name="release/$namespace/$module_name/v$version"
-    
+
     if git rev-parse --verify "$tag_name" > /dev/null 2>&1; then
       tags_to_push+=("$tag_name")
     fi


### PR DESCRIPTION
## Description

This PR introduces a script `.github/scripts/tag_release.sh` which allows the maintainer and other org members to automatically tag and release modules based on the checked out commit id. This script relies on the README's for the updated modules to accurately reflect the version bump to work properly.
<!-- Briefly describe what this PR does and why -->

## Type of Change

- [ ] New module
- [ ] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [X] Other

## Testing & Validation

- [NA] Tests pass (`bun test`)
- [X] Code formatted (`bun run fmt`)
- [X] Changes tested locally

## Reference

Run on this Commit: https://github.com/coder/registry/commit/9ed5084bfbad9266469a9d189635d7fccb1ed277

### Script Output:

```
coder@tagging-test:~/workspace/registry$ ./.github/scripts/tag_release.sh 
🚀 Coder Registry Tag Release Script
Operating on commit: 9ed5084bfbad9266469a9d189635d7fccb1ed277

🔍 Scanning all modules for missing release tags...

find: warning: you have specified the global option -mindepth after the argument -type, but global options are not positional, i.e., -mindepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.
find: warning: you have specified the global option -maxdepth after the argument -type, but global options are not positional, i.e., -maxdepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.
📦 coder/agentapi: v1.0.1 (needs tag)
📦 coder/aider: v1.1.1 (needs tag)
📦 coder/amazon-dcv-windows: v1.1.1 (needs tag)
📦 coder/amazon-q: v1.1.1 (needs tag)
📦 coder/aws-region: v1.0.31 (needs tag)
📦 coder/azure-region: v1.0.31 (needs tag)
✅ coder/claude-code: v2.0.3 (already tagged)
📦 coder/coder-login: v1.0.31 (needs tag)
📦 coder/code-server: v1.3.1 (needs tag)
📦 coder/cursor: v1.2.1 (needs tag)
📦 coder/devcontainers-cli: v1.0.31 (needs tag)
📦 coder/dotfiles: v1.2.1 (needs tag)
📦 coder/filebrowser: v1.1.2 (needs tag)
📦 coder/fly-region: v1.0.31 (needs tag)
📦 coder/gcp-region: v1.0.31 (needs tag)
📦 coder/git-clone: v1.1.1 (needs tag)
📦 coder/git-commit-signing: v1.0.31 (needs tag)
📦 coder/git-config: v1.0.31 (needs tag)
📦 coder/github-upload-public-key: v1.0.31 (needs tag)
📦 coder/goose: v2.0.1 (needs tag)
📦 coder/hcp-vault-secrets: v1.0.33 (needs tag)
📦 coder/jetbrains: v1.0.1 (needs tag)
✅ coder/jetbrains-fleet: v1.0.1 (already tagged)
📦 coder/jetbrains-gateway: v1.2.2 (needs tag)
📦 coder/jfrog-oauth: v1.0.31 (needs tag)
📦 coder/jfrog-token: v1.0.31 (needs tag)
📦 coder/jupyterlab: v1.1.1 (needs tag)
📦 coder/jupyter-notebook: v1.1.1 (needs tag)
📦 coder/kasmvnc: v1.2.1 (needs tag)
✅ coder/kiro: v1.0.0 (already tagged)
📦 coder/local-windows-rdp: v1.0.2 (needs tag)
📦 coder/personalize: v1.0.31 (needs tag)
📦 coder/slackme: v1.0.31 (needs tag)
📦 coder/vault-github: v1.0.31 (needs tag)
📦 coder/vault-jwt: v1.1.1 (needs tag)
📦 coder/vault-token: v1.2.1 (needs tag)
📦 coder/vscode-desktop: v1.1.1 (needs tag)
📦 coder/vscode-web: v1.3.1 (needs tag)
📦 coder/windows-rdp: v1.2.3 (needs tag)
📦 coder/windsurf: v1.1.1 (needs tag)
📦 coder/zed: v1.0.1 (needs tag)
✅ nataindata/apache-airflow: v1.0.14 (already tagged)
✅ thezoker/nodejs: v1.0.11 (already tagged)
✅ whizus/exoscale-instance-type: v1.0.13 (already tagged)
✅ whizus/exoscale-zone: v1.0.13 (already tagged)

📊 Summary: 38 of 45 modules need tagging

## Tags to be created:
- `release/coder/agentapi/v1.0.1`
- `release/coder/aider/v1.1.1`
- `release/coder/amazon-dcv-windows/v1.1.1`
- `release/coder/amazon-q/v1.1.1`
- `release/coder/aws-region/v1.0.31`
- `release/coder/azure-region/v1.0.31`
- `release/coder/coder-login/v1.0.31`
- `release/coder/code-server/v1.3.1`
- `release/coder/cursor/v1.2.1`
- `release/coder/devcontainers-cli/v1.0.31`
- `release/coder/dotfiles/v1.2.1`
- `release/coder/filebrowser/v1.1.2`
- `release/coder/fly-region/v1.0.31`
- `release/coder/gcp-region/v1.0.31`
- `release/coder/git-clone/v1.1.1`
- `release/coder/git-commit-signing/v1.0.31`
- `release/coder/git-config/v1.0.31`
- `release/coder/github-upload-public-key/v1.0.31`
- `release/coder/goose/v2.0.1`
- `release/coder/hcp-vault-secrets/v1.0.33`
- `release/coder/jetbrains/v1.0.1`
- `release/coder/jetbrains-gateway/v1.2.2`
- `release/coder/jfrog-oauth/v1.0.31`
- `release/coder/jfrog-token/v1.0.31`
- `release/coder/jupyterlab/v1.1.1`
- `release/coder/jupyter-notebook/v1.1.1`
- `release/coder/kasmvnc/v1.2.1`
- `release/coder/local-windows-rdp/v1.0.2`
- `release/coder/personalize/v1.0.31`
- `release/coder/slackme/v1.0.31`
- `release/coder/vault-github/v1.0.31`
- `release/coder/vault-jwt/v1.1.1`
- `release/coder/vault-token/v1.2.1`
- `release/coder/vscode-desktop/v1.1.1`
- `release/coder/vscode-web/v1.3.1`
- `release/coder/windows-rdp/v1.2.3`
- `release/coder/windsurf/v1.1.1`
- `release/coder/zed/v1.0.1`


❓ Do you want to proceed with creating and pushing these release tags?
   This will create git tags and push them to the remote repository.

Continue? [y/N]: y

🏷️  Creating release tags for commit: 9ed5084bfbad9266469a9d189635d7fccb1ed277

Creating tag: release/coder/agentapi/v1.0.1
✅ Created: release/coder/agentapi/v1.0.1
Creating tag: release/coder/aider/v1.1.1
✅ Created: release/coder/aider/v1.1.1
Creating tag: release/coder/amazon-dcv-windows/v1.1.1
✅ Created: release/coder/amazon-dcv-windows/v1.1.1
Creating tag: release/coder/amazon-q/v1.1.1
✅ Created: release/coder/amazon-q/v1.1.1
Creating tag: release/coder/aws-region/v1.0.31
✅ Created: release/coder/aws-region/v1.0.31
Creating tag: release/coder/azure-region/v1.0.31
✅ Created: release/coder/azure-region/v1.0.31
Creating tag: release/coder/coder-login/v1.0.31
✅ Created: release/coder/coder-login/v1.0.31
Creating tag: release/coder/code-server/v1.3.1
✅ Created: release/coder/code-server/v1.3.1
Creating tag: release/coder/cursor/v1.2.1
✅ Created: release/coder/cursor/v1.2.1
Creating tag: release/coder/devcontainers-cli/v1.0.31
✅ Created: release/coder/devcontainers-cli/v1.0.31
Creating tag: release/coder/dotfiles/v1.2.1
✅ Created: release/coder/dotfiles/v1.2.1
Creating tag: release/coder/filebrowser/v1.1.2
✅ Created: release/coder/filebrowser/v1.1.2
Creating tag: release/coder/fly-region/v1.0.31
✅ Created: release/coder/fly-region/v1.0.31
Creating tag: release/coder/gcp-region/v1.0.31
✅ Created: release/coder/gcp-region/v1.0.31
Creating tag: release/coder/git-clone/v1.1.1
✅ Created: release/coder/git-clone/v1.1.1
Creating tag: release/coder/git-commit-signing/v1.0.31
✅ Created: release/coder/git-commit-signing/v1.0.31
Creating tag: release/coder/git-config/v1.0.31
✅ Created: release/coder/git-config/v1.0.31
Creating tag: release/coder/github-upload-public-key/v1.0.31
✅ Created: release/coder/github-upload-public-key/v1.0.31
Creating tag: release/coder/goose/v2.0.1
✅ Created: release/coder/goose/v2.0.1
Creating tag: release/coder/hcp-vault-secrets/v1.0.33
✅ Created: release/coder/hcp-vault-secrets/v1.0.33
Creating tag: release/coder/jetbrains/v1.0.1
✅ Created: release/coder/jetbrains/v1.0.1
Creating tag: release/coder/jetbrains-gateway/v1.2.2
✅ Created: release/coder/jetbrains-gateway/v1.2.2
Creating tag: release/coder/jfrog-oauth/v1.0.31
✅ Created: release/coder/jfrog-oauth/v1.0.31
Creating tag: release/coder/jfrog-token/v1.0.31
✅ Created: release/coder/jfrog-token/v1.0.31
Creating tag: release/coder/jupyterlab/v1.1.1
✅ Created: release/coder/jupyterlab/v1.1.1
Creating tag: release/coder/jupyter-notebook/v1.1.1
✅ Created: release/coder/jupyter-notebook/v1.1.1
Creating tag: release/coder/kasmvnc/v1.2.1
✅ Created: release/coder/kasmvnc/v1.2.1
Creating tag: release/coder/local-windows-rdp/v1.0.2
✅ Created: release/coder/local-windows-rdp/v1.0.2
Creating tag: release/coder/personalize/v1.0.31
✅ Created: release/coder/personalize/v1.0.31
Creating tag: release/coder/slackme/v1.0.31
✅ Created: release/coder/slackme/v1.0.31
Creating tag: release/coder/vault-github/v1.0.31
✅ Created: release/coder/vault-github/v1.0.31
Creating tag: release/coder/vault-jwt/v1.1.1
✅ Created: release/coder/vault-jwt/v1.1.1
Creating tag: release/coder/vault-token/v1.2.1
✅ Created: release/coder/vault-token/v1.2.1
Creating tag: release/coder/vscode-desktop/v1.1.1
✅ Created: release/coder/vscode-desktop/v1.1.1
Creating tag: release/coder/vscode-web/v1.3.1
✅ Created: release/coder/vscode-web/v1.3.1
Creating tag: release/coder/windows-rdp/v1.2.3
✅ Created: release/coder/windows-rdp/v1.2.3
Creating tag: release/coder/windsurf/v1.1.1
✅ Created: release/coder/windsurf/v1.1.1
Creating tag: release/coder/zed/v1.0.1
✅ Created: release/coder/zed/v1.0.1

📊 Tag creation summary:
  Created: 38
  Failed: 0

🚀 Pushing tags to origin...
Pushing: release/coder/agentapi/v1.0.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 187 bytes | 26.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/agentapi/v1.0.1 -> release/coder/agentapi/v1.0.1
✅ Pushed: release/coder/agentapi/v1.0.1
Pushing: release/coder/aider/v1.1.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 184 bytes | 26.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/aider/v1.1.1 -> release/coder/aider/v1.1.1
✅ Pushed: release/coder/aider/v1.1.1
Pushing: release/coder/amazon-dcv-windows/v1.1.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 195 bytes | 65.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/amazon-dcv-windows/v1.1.1 -> release/coder/amazon-dcv-windows/v1.1.1
✅ Pushed: release/coder/amazon-dcv-windows/v1.1.1
Pushing: release/coder/amazon-q/v1.1.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 187 bytes | 26.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/amazon-q/v1.1.1 -> release/coder/amazon-q/v1.1.1
✅ Pushed: release/coder/amazon-q/v1.1.1
Pushing: release/coder/aws-region/v1.0.31
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 190 bytes | 23.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/aws-region/v1.0.31 -> release/coder/aws-region/v1.0.31
✅ Pushed: release/coder/aws-region/v1.0.31
Pushing: release/coder/azure-region/v1.0.31
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 192 bytes | 27.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/azure-region/v1.0.31 -> release/coder/azure-region/v1.0.31
✅ Pushed: release/coder/azure-region/v1.0.31
Pushing: release/coder/coder-login/v1.0.31
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 189 bytes | 31.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/coder-login/v1.0.31 -> release/coder/coder-login/v1.0.31
✅ Pushed: release/coder/coder-login/v1.0.31
Pushing: release/coder/code-server/v1.3.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 188 bytes | 31.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/code-server/v1.3.1 -> release/coder/code-server/v1.3.1
✅ Pushed: release/coder/code-server/v1.3.1
Pushing: release/coder/cursor/v1.2.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 186 bytes | 62.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/cursor/v1.2.1 -> release/coder/cursor/v1.2.1
✅ Pushed: release/coder/cursor/v1.2.1
Pushing: release/coder/devcontainers-cli/v1.0.31
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 194 bytes | 32.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/devcontainers-cli/v1.0.31 -> release/coder/devcontainers-cli/v1.0.31
✅ Pushed: release/coder/devcontainers-cli/v1.0.31
Pushing: release/coder/dotfiles/v1.2.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 187 bytes | 31.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/dotfiles/v1.2.1 -> release/coder/dotfiles/v1.2.1
✅ Pushed: release/coder/dotfiles/v1.2.1
Pushing: release/coder/filebrowser/v1.1.2
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 190 bytes | 63.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/filebrowser/v1.1.2 -> release/coder/filebrowser/v1.1.2
✅ Pushed: release/coder/filebrowser/v1.1.2
Pushing: release/coder/fly-region/v1.0.31
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 190 bytes | 63.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/fly-region/v1.0.31 -> release/coder/fly-region/v1.0.31
✅ Pushed: release/coder/fly-region/v1.0.31
Pushing: release/coder/gcp-region/v1.0.31
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 190 bytes | 63.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/gcp-region/v1.0.31 -> release/coder/gcp-region/v1.0.31
✅ Pushed: release/coder/gcp-region/v1.0.31
Pushing: release/coder/git-clone/v1.1.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 187 bytes | 93.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/git-clone/v1.1.1 -> release/coder/git-clone/v1.1.1
✅ Pushed: release/coder/git-clone/v1.1.1
Pushing: release/coder/git-commit-signing/v1.0.31
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 194 bytes | 38.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/git-commit-signing/v1.0.31 -> release/coder/git-commit-signing/v1.0.31
✅ Pushed: release/coder/git-commit-signing/v1.0.31
Pushing: release/coder/git-config/v1.0.31
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 190 bytes | 38.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/git-config/v1.0.31 -> release/coder/git-config/v1.0.31
✅ Pushed: release/coder/git-config/v1.0.31
Pushing: release/coder/github-upload-public-key/v1.0.31
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 200 bytes | 40.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/github-upload-public-key/v1.0.31 -> release/coder/github-upload-public-key/v1.0.31
✅ Pushed: release/coder/github-upload-public-key/v1.0.31
Pushing: release/coder/goose/v2.0.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 185 bytes | 46.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/goose/v2.0.1 -> release/coder/goose/v2.0.1
✅ Pushed: release/coder/goose/v2.0.1
Pushing: release/coder/hcp-vault-secrets/v1.0.33
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 195 bytes | 39.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/hcp-vault-secrets/v1.0.33 -> release/coder/hcp-vault-secrets/v1.0.33
✅ Pushed: release/coder/hcp-vault-secrets/v1.0.33
Pushing: release/coder/jetbrains/v1.0.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 187 bytes | 46.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/jetbrains/v1.0.1 -> release/coder/jetbrains/v1.0.1
✅ Pushed: release/coder/jetbrains/v1.0.1
Pushing: release/coder/jetbrains-gateway/v1.2.2
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 194 bytes | 97.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/jetbrains-gateway/v1.2.2 -> release/coder/jetbrains-gateway/v1.2.2
✅ Pushed: release/coder/jetbrains-gateway/v1.2.2
Pushing: release/coder/jfrog-oauth/v1.0.31
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 191 bytes | 47.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/jfrog-oauth/v1.0.31 -> release/coder/jfrog-oauth/v1.0.31
✅ Pushed: release/coder/jfrog-oauth/v1.0.31
Pushing: release/coder/jfrog-token/v1.0.31
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 191 bytes | 47.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/jfrog-token/v1.0.31 -> release/coder/jfrog-token/v1.0.31
✅ Pushed: release/coder/jfrog-token/v1.0.31
Pushing: release/coder/jupyterlab/v1.1.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 188 bytes | 47.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/jupyterlab/v1.1.1 -> release/coder/jupyterlab/v1.1.1
✅ Pushed: release/coder/jupyterlab/v1.1.1
Pushing: release/coder/jupyter-notebook/v1.1.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 192 bytes | 96.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/jupyter-notebook/v1.1.1 -> release/coder/jupyter-notebook/v1.1.1
✅ Pushed: release/coder/jupyter-notebook/v1.1.1
Pushing: release/coder/kasmvnc/v1.2.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 187 bytes | 46.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/kasmvnc/v1.2.1 -> release/coder/kasmvnc/v1.2.1
✅ Pushed: release/coder/kasmvnc/v1.2.1
Pushing: release/coder/local-windows-rdp/v1.0.2
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 194 bytes | 97.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/local-windows-rdp/v1.0.2 -> release/coder/local-windows-rdp/v1.0.2
✅ Pushed: release/coder/local-windows-rdp/v1.0.2
Pushing: release/coder/personalize/v1.0.31
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 191 bytes | 63.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/personalize/v1.0.31 -> release/coder/personalize/v1.0.31
✅ Pushed: release/coder/personalize/v1.0.31
Pushing: release/coder/slackme/v1.0.31
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 187 bytes | 62.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/slackme/v1.0.31 -> release/coder/slackme/v1.0.31
✅ Pushed: release/coder/slackme/v1.0.31
Pushing: release/coder/vault-github/v1.0.31
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 192 bytes | 64.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/vault-github/v1.0.31 -> release/coder/vault-github/v1.0.31
✅ Pushed: release/coder/vault-github/v1.0.31
Pushing: release/coder/vault-jwt/v1.1.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 188 bytes | 62.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/vault-jwt/v1.1.1 -> release/coder/vault-jwt/v1.1.1
✅ Pushed: release/coder/vault-jwt/v1.1.1
Pushing: release/coder/vault-token/v1.2.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 190 bytes | 63.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/vault-token/v1.2.1 -> release/coder/vault-token/v1.2.1
✅ Pushed: release/coder/vault-token/v1.2.1
Pushing: release/coder/vscode-desktop/v1.1.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 191 bytes | 191.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/vscode-desktop/v1.1.1 -> release/coder/vscode-desktop/v1.1.1
✅ Pushed: release/coder/vscode-desktop/v1.1.1
Pushing: release/coder/vscode-web/v1.3.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 188 bytes | 47.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/vscode-web/v1.3.1 -> release/coder/vscode-web/v1.3.1
✅ Pushed: release/coder/vscode-web/v1.3.1
Pushing: release/coder/windows-rdp/v1.2.3
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 190 bytes | 63.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/windows-rdp/v1.2.3 -> release/coder/windows-rdp/v1.2.3
✅ Pushed: release/coder/windows-rdp/v1.2.3
Pushing: release/coder/windsurf/v1.1.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 187 bytes | 93.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/windsurf/v1.1.1 -> release/coder/windsurf/v1.1.1
✅ Pushed: release/coder/windsurf/v1.1.1
Pushing: release/coder/zed/v1.0.1
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 183 bytes | 91.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/coder/registry
 * [new tag]         release/coder/zed/v1.0.1 -> release/coder/zed/v1.0.1
✅ Pushed: release/coder/zed/v1.0.1

📊 Push summary:
  Pushed: 38
  Failed: 0

🎉 Successfully created and pushed 38 release tags!

📝 Next steps:
  - Tags will be automatically published to registry.coder.com
  - Monitor the registry website for updates
  - Check GitHub releases for any issues
```
