### PR TITLE
fix: update icon path for k8s-username

### DIFF
--- a/registry/ericpaulsen/templates/k8s-username/README.md
+++ b/registry/ericpaulsen/templates/k8s-username/README.md
@@ -1,7 +1,7 @@
 ---
 display_name: Kubernetes (Deployment) with Dynamic Username
 description: Provision Kubernetes Deployments as Coder workspaces with your Username
-icon: ../../../site/static/icon/k8s.png
+icon: ../../../../.icons/kubernetes.svg
 verified: true
 tags: [kubernetes, container, username]
 ---


### PR DESCRIPTION
Closes #

## Description

This is an issue that doesn't exist within `coder/registry`, but was breaking our build process for the Registry website. We were using an invalid image path. 

## Type of Change

- [ ] New module
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun run fmt`)
- [x] Changes tested locally