### PR TITLE
fix(devcontainers-cli): allow yarn to install when `packageManager` not `yarn`

### DIFF
--- a/registry/coder/modules/devcontainers-cli/README.md
+++ b/registry/coder/modules/devcontainers-cli/README.md
@@ -15,7 +15,7 @@ The devcontainers-cli module provides an easy way to install [`@devcontainers/cl
 ```tf
 module "devcontainers-cli" {
   source   = "registry.coder.com/coder/devcontainers-cli/coder"
-  version  = "1.0.31"
+  version  = "1.0.32"
   agent_id = coder_agent.example.id
 }
 ```

--- a/registry/coder/modules/devcontainers-cli/main.test.ts
+++ b/registry/coder/modules/devcontainers-cli/main.test.ts
@@ -45,12 +45,16 @@ const executeScriptInContainerWithPackageManager = async (
 
   console.log(path);
 
+  await execContainer(id, [shell, "-c", "mkdir -p /tmp/coder-script-data"]);
+
   const resp = await execContainer(
     id,
     [shell, "-c", instance.script],
     [
       "--env",
       "CODER_SCRIPT_BIN_DIR=/tmp/coder-script-data/bin",
+      "--env",
+      "CODER_SCRIPT_DATA_DIR=/tmp/coder-script-data",
       "--env",
       `PATH=${path}:/tmp/coder-script-data/bin`,
     ],

--- a/registry/coder/modules/devcontainers-cli/run.sh
+++ b/registry/coder/modules/devcontainers-cli/run.sh
@@ -38,7 +38,10 @@ install() {
         fi
         pnpm add -g @devcontainers/cli
     elif [ "$PACKAGE_MANAGER" = "yarn" ]; then
-        yarn global add @devcontainers/cli --prefix "$(dirname "$CODER_SCRIPT_BIN_DIR")"
+        # We want to cd into `$CODER_SCRIPT_DATA_DIR` as the current directory
+        # might contain a `package.json` with `packageManager` set to something
+        # other than `yarn`. When this happens, `yarn global add` will fail to install.
+        cd "$CODER_SCRIPT_DATA_DIR" && yarn global add @devcontainers/cli --prefix "$(dirname "$CODER_SCRIPT_BIN_DIR")"
     fi
 }
 


### PR DESCRIPTION
## Description

On our dogfood workspaces, we fail to install `@devcontainers/cli` with `yarn` because our agent directory `/home/coder/coder` contains a `package.json` with `packageManager` being set to `pnpm`. This change instead ensures to run `yarn global add` inside the `$CODER_SCRIPT_DATA_DIR` so that we don't read a `package.json` and cause things to break.

## Type of Change

- [ ] New module
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

<!-- Delete this section if not applicable -->

**Path:** `registry/coder/modules/devcontainers-cli`  
**New version:** `v1.0.32`  
**Breaking change:** [ ] Yes [x] No

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun run fmt`)
- [x] Changes tested locally

## Related Issues

None