### PR TITLE
Fix claude code system prompt 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,0 +1,46 @@
+---
+name: 🐛 Bug Fix
+about: Fix a bug in an existing module or template
+---
+
+Closes #
+
+## Description
+
+<!-- Briefly describe the bug and how you fixed it -->
+
+## Type of Resource
+
+- [ ] Module: `registry/[namespace]/modules/[name]`
+- [ ] Template: `registry/[namespace]/templates/[name]`
+
+## What was broken?
+
+<!-- Describe the issue that was fixed -->
+
+## How was it fixed?
+
+<!-- Describe your solution -->
+
+## Testing & Validation
+
+**For Modules:**
+- [ ] Tests pass (`bun test`)
+- [ ] Code formatted (`bun run fmt`)
+- [ ] Bug reproduction confirmed fixed
+
+**For Templates:**
+- [ ] Template tested with Coder
+- [ ] Infrastructure provisions without errors
+- [ ] Issue no longer reproduces
+
+## Breaking Changes
+
+- [ ] This is a breaking change
+- [ ] This is not a breaking change
+
+<!-- If breaking, explain the impact and migration path -->
+
+## Related Issues
+
+<!-- Link the issue this PR fixes -->

--- a/.github/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,0 +1,38 @@
+---
+name: 📝 Documentation
+about: Improve documentation for modules or templates
+---
+
+Closes #
+
+## Description
+
+<!-- Briefly describe what documentation is being improved -->
+
+## Type of Resource
+
+- [ ] Module: `registry/[namespace]/modules/[name]`
+- [ ] Template: `registry/[namespace]/templates/[name]`
+- [ ] General documentation (README, CONTRIBUTING, etc.)
+
+## What's being improved?
+
+<!-- Describe the documentation changes -->
+
+- [ ] Fixed typos or grammar
+- [ ] Added missing information
+- [ ] Improved clarity
+- [ ] Added examples
+- [ ] Updated outdated information
+- [ ] Other: 
+
+## Testing & Validation
+
+- [ ] Documentation renders correctly
+- [ ] Links work properly
+- [ ] Examples are accurate
+- [ ] Frontmatter is valid
+
+## Related Issues
+
+<!-- Link related issues or write "None" if not applicable -->

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,59 @@
+---
+name: ✨ Feature Enhancement
+about: Add a new feature to an existing module or template
+---
+
+Closes #
+
+## Description
+
+<!-- Briefly describe the new feature and why it's useful -->
+
+## Type of Resource
+
+- [ ] Module: `registry/[namespace]/modules/[name]`
+- [ ] Template: `registry/[namespace]/templates/[name]`
+
+## What's new?
+
+<!-- Describe the feature you're adding -->
+
+## Version Change
+
+**Current version:** `vX.Y.Z`  
+**New version:** `vX.Y.Z`  
+**Change type:** 
+- [ ] Patch (bug fixes)
+- [ ] Minor (new features, backward compatible)
+- [ ] Major (breaking changes)
+
+## Testing & Validation
+
+**For Modules:**
+- [ ] Tests pass (`bun test`)
+- [ ] New tests added for new functionality
+- [ ] Code formatted (`bun run fmt`)
+- [ ] Backward compatibility maintained
+
+**For Templates:**
+- [ ] Template tested with Coder
+- [ ] New features work as expected
+- [ ] Existing functionality unaffected
+- [ ] Documentation updated
+
+## Breaking Changes
+
+- [ ] This is a breaking change
+- [ ] This is not a breaking change
+
+<!-- If breaking, explain the impact and migration path -->
+
+## Documentation
+
+- [ ] README updated with new features
+- [ ] Variable documentation updated
+- [ ] Examples added/updated
+
+## Related Issues
+
+<!-- Link related issues or write "None" if not applicable -->

--- a/.github/PULL_REQUEST_TEMPLATE/new_module.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_module.md
@@ -1,0 +1,37 @@
+---
+name: 🆕 New Module
+about: Add a new module to the registry
+---
+
+Closes #
+
+## Description
+
+<!-- Briefly describe what this module does and why it's useful -->
+
+## Module Information
+
+**Path:** `registry/[namespace]/modules/[module-name]`  
+**New version:** `v1.0.0`  
+**Module type:** <!-- e.g., IDE, tool integration, auth, etc. -->
+
+## Testing & Validation
+
+- [ ] Tests pass (`bun test`)
+- [ ] Code formatted (`bun run fmt`)
+- [ ] Module tested locally
+- [ ] README contains accurate usage examples
+- [ ] All required frontmatter fields included
+
+## Checklist
+
+- [ ] `main.tf` - Terraform implementation
+- [ ] `main.test.ts` - Working tests
+- [ ] `README.md` - Documentation with proper frontmatter
+- [ ] Namespace avatar added (if new namespace)
+- [ ] Icon path is correct
+- [ ] Tags are descriptive and relevant
+
+## Related Issues
+
+<!-- Link related issues or write "None" if not applicable -->

--- a/.github/PULL_REQUEST_TEMPLATE/new_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_template.md
@@ -1,0 +1,61 @@
+---
+name: 📋 New Template
+about: Add a new template to the registry
+---
+
+Closes #
+
+## Description
+
+<!-- Briefly describe what this template provides and which use case it solves -->
+
+## Template Information
+
+**Path:** `registry/[namespace]/templates/[template-name]`  
+**Platform:** <!-- e.g., Docker, AWS, GCP, Kubernetes, etc. -->  
+**Target audience:** <!-- e.g., Web developers, Data scientists, etc. -->
+
+## Infrastructure Details
+
+<!-- Describe the infrastructure this template creates -->
+
+**Resources created:**
+- Resource type 1
+- Resource type 2
+
+**Estimated costs:** $X.XX/month (or "Free" for local resources)
+
+**Prerequisites:**
+- Prerequisite 1
+- Prerequisite 2
+
+## Testing & Validation
+
+- [ ] Template tested with Coder (`coder templates push test-template -d .`)
+- [ ] Infrastructure provisions successfully
+- [ ] Agent connects and workspace functions correctly
+- [ ] All registry modules work as expected
+- [ ] Documentation is complete and accurate
+
+## Checklist
+
+- [ ] `main.tf` - Complete Terraform configuration
+- [ ] `README.md` - Documentation with proper frontmatter
+- [ ] Namespace avatar added (if new namespace)
+- [ ] Icon path is correct
+- [ ] Tags are descriptive and relevant
+- [ ] Infrastructure requirements documented
+- [ ] Variables table is complete
+- [ ] Troubleshooting section included
+
+## Registry Modules Used
+
+<!-- List any registry modules included in this template -->
+
+- [ ] `coder/code-server` - VS Code in browser
+- [ ] `coder/git-config` - Git configuration
+- [ ] Other modules: 
+
+## Related Issues
+
+<!-- Link related issues or write "None" if not applicable -->

--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@
 
 [![Health](https://github.com/coder/registry/actions/workflows/check_registry_site_health.yaml/badge.svg)](https://github.com/coder/registry/actions/workflows/check_registry_site_health.yaml)
 
-Coder Registry is a community-driven platform for extending your Coder workspaces. Publish reusable Terraform as Coder Modules for users all over the world.
-
-> [!NOTE]
-> The Coder Registry repo will be updated to support Coder Templates in the coming weeks. You can currently find all official templates in the official coder/coder repo, [under the `examples/templates` directory](https://github.com/coder/coder/tree/main/examples/templates).
+Coder Registry is a community-driven platform for extending your Coder workspaces. Publish reusable Terraform as Coder Modules and complete workspace Templates for users all over the world.
 
 ## Overview
 
 Coder is built on HashiCorp's open-source Terraform language to provide developers an easy, declarative way to define the infrastructure for their remote development environments. Coder-flavored versions of Terraform allow you to mix in reusable Terraform snippets to add integrations with other popular development tools, such as JetBrains, Cursor, or Visual Studio Code.
+
+The Coder Registry contains two types of resources:
+
+- **Modules**: Reusable Terraform snippets that add specific functionality to your workspaces (IDEs, development tools, integrations)
+- **Templates**: Complete workspace configurations that can be deployed directly to create functional development environments
 
 Simply add the correct import snippet, along with any data dependencies, and your workspace can start using the new functionality immediately.
 
@@ -44,6 +46,21 @@ module "cursor" {
 ```
 
 Simply include that snippet inside your Coder template, defining any data dependencies referenced, and the next time you create a new workspace, the functionality will be ready for you to use.
+
+### Getting started with templates
+
+Templates provide complete workspace configurations that can be deployed directly in your Coder instance. To use a template:
+
+1. Browse templates on the [registry website](https://registry.coder.com/templates) or in the [registry repository](https://github.com/coder/registry/tree/main/registry)
+2. Download the template directory or clone this repository
+3. Navigate to the template directory (e.g., `registry/coder/templates/docker-simple`)
+4. Push the template to your Coder instance:
+
+```bash
+coder templates push my-template -d .
+```
+
+Templates appear as "Community Templates" in your Coder dashboard and provide complete development environments with pre-configured tools, IDEs, and infrastructure.
 
 ## Contributing
 

--- a/examples/templates/README.md
+++ b/examples/templates/README.md
@@ -1,0 +1,83 @@
+---
+display_name: TEMPLATE_NAME
+description: Brief description of what this template provides
+icon: ../../../../.icons/<A_RELEVANT_ICON>.svg
+verified: false
+tags: [platform, use-case, tools]
+---
+
+# TEMPLATE_NAME
+
+<!-- Describe what this template provides and how to use it -->
+
+This template creates a complete development environment with pre-configured tools and infrastructure.
+
+## Features
+
+- Feature 1
+- Feature 2
+- Feature 3
+
+## Prerequisites
+
+<!-- List any requirements for using this template -->
+
+- Requirement 1
+- Requirement 2
+
+## Infrastructure
+
+<!-- Describe the infrastructure this template creates -->
+
+This template provisions:
+
+- Resource type 1
+- Resource type 2
+- Estimated cost: $X.XX/month
+
+## Usage
+
+To use this template:
+
+1. Clone this repository or download the template directory
+2. Navigate to the template directory:
+   ```bash
+   cd registry/NAMESPACE/templates/TEMPLATE_NAME
+   ```
+3. Push the template to your Coder instance:
+   ```bash
+   coder templates push TEMPLATE_NAME -d .
+   ```
+4. Create a workspace using this template in your Coder dashboard
+
+## Variables
+
+<!-- Document any template variables -->
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `variable_name` | Description | `default_value` | Yes/No |
+
+## Registry Modules Used
+
+This template includes the following registry modules:
+
+- [`coder/code-server`](https://registry.coder.com/modules/code-server) - VS Code in the browser
+- [`coder/git-config`](https://registry.coder.com/modules/git-config) - Git configuration
+
+## Troubleshooting
+
+### Common Issues
+
+**Issue 1**: Description
+- Solution: How to fix
+
+**Issue 2**: Description  
+- Solution: How to fix
+
+### Support
+
+For additional support:
+- Check the [Coder documentation](https://coder.com/docs)
+- Join the [Coder Discord](https://discord.gg/coder)
+- Open an issue in this repository

--- a/examples/templates/docker-simple/README.md
+++ b/examples/templates/docker-simple/README.md
@@ -1,0 +1,79 @@
+---
+display_name: "Docker Simple"
+description: "A simple Docker-based development environment with VS Code"
+icon: "../../../../../.icons/docker.svg"
+verified: false
+tags: ["docker", "vscode", "simple"]
+---
+
+# Docker Simple Template
+
+A straightforward Docker-based development environment with VS Code (code-server) and essential development tools.
+
+## Features
+
+- Ubuntu-based Docker container
+- VS Code (code-server) in the browser
+- Git configuration
+- Dotfiles support
+- Resource monitoring
+
+## Prerequisites
+
+- Docker Engine running on the Coder host
+- No additional infrastructure required
+
+## Infrastructure
+
+This template provisions:
+
+- Single Docker container running Ubuntu
+- Estimated cost: Free (uses local Docker)
+
+## Usage
+
+To use this template:
+
+1. Clone this repository or download the template directory
+2. Navigate to the template directory:
+   ```bash
+   cd registry/examples/templates/docker-simple
+   ```
+3. Push the template to your Coder instance:
+   ```bash
+   coder templates push docker-simple -d .
+   ```
+4. Create a workspace using this template in your Coder dashboard
+
+## Variables
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `docker_image` | Docker image to use | `codercom/enterprise-base:ubuntu` | No |
+
+## Registry Modules Used
+
+This template includes the following registry modules:
+
+- [`coder/code-server`](https://registry.coder.com/modules/code-server) - VS Code in the browser
+- [`coder/git-config`](https://registry.coder.com/modules/git-config) - Git configuration
+- [`coder/dotfiles`](https://registry.coder.com/modules/dotfiles) - Dotfiles synchronization
+
+## Troubleshooting
+
+### Common Issues
+
+**Container fails to start**: 
+- Ensure Docker is running on the Coder host
+- Check Docker image availability
+
+**VS Code doesn't load**:
+- Wait for the container to fully start
+- Check agent logs in the Coder dashboard
+
+### Support
+
+For additional support:
+- Check the [Coder documentation](https://coder.com/docs)
+- Join the [Coder Discord](https://discord.gg/coder)
+- Open an issue in this repository

--- a/examples/templates/docker-simple/main.tf
+++ b/examples/templates/docker-simple/main.tf
@@ -1,0 +1,196 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+    docker = {
+      source = "kreuzwerker/docker"
+    }
+  }
+}
+
+provider "coder" {}
+provider "docker" {}
+
+# Coder data sources
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+# Template variables
+data "coder_parameter" "docker_image" {
+  name         = "docker_image"
+  display_name = "Docker Image"
+  description  = "Which Docker image would you like to use for your workspace?"
+  default      = "codercom/enterprise-base:ubuntu"
+  type         = "string"
+  mutable      = false
+  order        = 1
+  
+  option {
+    name  = "Ubuntu (Recommended)"
+    value = "codercom/enterprise-base:ubuntu"
+  }
+  option {
+    name  = "Node.js"
+    value = "codercom/enterprise-node:ubuntu"
+  }
+  option {
+    name  = "Python"
+    value = "codercom/enterprise-base:ubuntu"
+  }
+}
+
+# Coder agent
+resource "coder_agent" "main" {
+  arch           = "amd64"
+  os             = "linux"
+  startup_script = <<-EOT
+    #!/bin/bash
+    
+    # Install common development tools
+    apt-get update
+    apt-get install -y curl wget git vim nano tree htop
+    
+    # Create development directories
+    mkdir -p /home/coder/projects
+    chown -R coder:coder /home/coder/projects
+    
+    echo "Workspace setup complete!"
+  EOT
+
+  # Resource monitoring
+  metadata {
+    key          = "cpu"
+    display_name = "CPU Usage"
+    interval     = 5
+    timeout      = 5
+    script       = "coder stat cpu"
+  }
+  metadata {
+    key          = "memory"
+    display_name = "Memory Usage"
+    interval     = 5
+    timeout      = 5
+    script       = "coder stat mem"
+  }
+  metadata {
+    key          = "disk"
+    display_name = "Disk Usage"
+    interval     = 5
+    timeout      = 5
+    script       = "coder stat disk"
+  }
+}
+
+# Registry modules for development tools
+module "code-server" {
+  count    = data.coder_workspace.me.start_count
+  source   = "registry.coder.com/coder/code-server/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.main.id
+  order    = 1
+}
+
+module "git-config" {
+  count    = data.coder_workspace.me.start_count
+  source   = "registry.coder.com/coder/git-config/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.main.id
+}
+
+module "dotfiles" {
+  count    = data.coder_workspace.me.start_count
+  source   = "registry.coder.com/coder/dotfiles/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.main.id
+}
+
+# Docker container for the workspace
+resource "docker_volume" "home_volume" {
+  name = "coder-${data.coder_workspace.me.id}-home"
+  # Protect the volume from being deleted due to changes in attributes.
+  lifecycle {
+    ignore_changes = all
+  }
+  # Add labels in Docker to keep track of orphan resources.
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace_owner.me.name
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace_owner.me.id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  # This field becomes outdated if the workspace is renamed but can
+  # be useful for debugging or cleaning out dangling volumes.
+  labels {
+    label = "coder.workspace_name_at_creation"
+    value = data.coder_workspace.me.name
+  }
+}
+
+resource "docker_container" "workspace" {
+  count = data.coder_workspace.me.start_count
+  image = data.coder_parameter.docker_image.value
+  # Uses lower() to avoid Docker restriction on container names.
+  name = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
+  # Hostname makes the shell more user friendly: coder@my-workspace:~$
+  hostname = data.coder_workspace.me.name
+  # Use the docker gateway if the access URL is 127.0.0.1
+  entrypoint = ["sh", "-c", replace(coder_agent.main.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")]
+  env        = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
+  host {
+    host = "host.docker.internal"
+    ip   = "host-gateway"
+  }
+  volumes {
+    container_path = "/home/coder"
+    volume_name    = docker_volume.home_volume.name
+    read_only      = false
+  }
+
+  # Add labels in Docker to keep track of orphan resources.
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace_owner.me.name
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace_owner.me.id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name"
+    value = data.coder_workspace.me.name
+  }
+}
+
+# Workspace metadata
+resource "coder_metadata" "container_info" {
+  count       = data.coder_workspace.me.start_count
+  resource_id = docker_container.workspace[0].id
+
+  item {
+    key   = "image"
+    value = data.coder_parameter.docker_image.value
+  }
+  item {
+    key   = "platform"
+    value = "Docker"
+  }
+}
+
+resource "coder_metadata" "volume_info" {
+  resource_id = docker_volume.home_volume.id
+  item {
+    key   = "size"
+    value = "10 GiB"
+  }
+}

--- a/examples/templates/docker-simple/main.tf
+++ b/examples/templates/docker-simple/main.tf
@@ -25,7 +25,7 @@ data "coder_parameter" "docker_image" {
   type         = "string"
   mutable      = false
   order        = 1
-  
+
   option {
     name  = "Ubuntu (Recommended)"
     value = "codercom/enterprise-base:ubuntu"

--- a/examples/templates/main.tf
+++ b/examples/templates/main.tf
@@ -1,0 +1,85 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+    # Add your infrastructure provider here
+    # docker = {
+    #   source = "kreuzwerker/docker"
+    # }
+  }
+}
+
+# Coder data sources
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+# Coder agent configuration
+resource "coder_agent" "main" {
+  arch           = "amd64"
+  os             = "linux"
+  startup_script = <<-EOT
+    #!/bin/bash
+    # Add startup commands here
+    echo "Starting workspace..."
+  EOT
+
+  # Metadata for resource monitoring
+  metadata {
+    key          = "cpu"
+    display_name = "CPU Usage"
+    interval     = 5
+    timeout      = 5
+    script       = "coder stat cpu"
+  }
+  metadata {
+    key          = "memory"
+    display_name = "Memory Usage"
+    interval     = 5
+    timeout      = 5
+    script       = "coder stat mem"
+  }
+  metadata {
+    key          = "disk"
+    display_name = "Disk Usage"
+    interval     = 5
+    timeout      = 5
+    script       = "coder stat disk"
+  }
+}
+
+# Registry modules for IDEs and tools
+module "code-server" {
+  count    = data.coder_workspace.me.start_count
+  source   = "registry.coder.com/coder/code-server/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.main.id
+  order    = 1
+}
+
+module "git-config" {
+  count    = data.coder_workspace.me.start_count
+  source   = "registry.coder.com/coder/git-config/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.main.id
+}
+
+# Your infrastructure resources
+# Example: Docker container
+# resource "docker_container" "workspace" {
+#   count = data.coder_workspace.me.start_count
+#   name  = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
+#   image = "codercom/enterprise-base:ubuntu"
+#   # ... additional configuration
+# }
+
+# Workspace metadata
+resource "coder_metadata" "workspace_info" {
+  count       = data.coder_workspace.me.start_count
+  resource_id = coder_agent.main.id
+
+  item {
+    key   = "platform"
+    value = "PLATFORM_NAME"
+  }
+}

--- a/registry/coder-labs/modules/gemini/README.md
+++ b/registry/coder-labs/modules/gemini/README.md
@@ -8,7 +8,14 @@ tags: [agent, gemini, ai, google, tasks]
 
 # Gemini CLI
 
-Run [Gemini CLI](https://ai.google.dev/gemini-api/docs/cli) in your workspace to access Google's Gemini AI models, and custom pre/post install scripts. This module integrates with [AgentAPI](https://github.com/coder/agentapi) for Coder Tasks compatibility.
+Run [Gemini CLI](https://ai.google.com/docs/gemini/tools/cli) in your workspace to access Google's Gemini AI models, and custom pre/post install scripts. This module integrates with [AgentAPI](https://github.com/coder/agentapi) for Coder Tasks compatibility.
+
+## Getting Started
+
+1. **Get a Gemini API Key**:
+   - Visit [Google AI Studio](https://makersuite.google.com/app/apikey)
+   - Create a new API key or use an existing one
+   - The API key starts with "AIza..."
 
 ```tf
 module "gemini" {
@@ -44,10 +51,13 @@ module "gemini" {
   source                    = "registry.coder.com/coder-labs/gemini/coder"
   version                   = "1.0.0"
   agent_id                  = coder_agent.example.id
-  gemini_api_key            = var.gemini_api_key # we recommend providing this parameter inorder to have a smoother experience (i.e. no google sign-in)
+  gemini_api_key            = var.gemini_api_key # Required for automated setup
   gemini_model              = "gemini-2.5-flash"
-  install_gemini            = true
-  gemini_version            = "latest"
+  install_gemini           = true
+  gemini_version           = "latest"
+  auto_approve             = true    # Automatically approve API key usage
+  yolo_mode               = true    # Enable faster responses without confirmations
+  folder                  = "/home/coder/project" # Custom working directory
   gemini_instruction_prompt = "Start every response with `Gemini says:`"
 }
 ```
@@ -64,7 +74,11 @@ module "gemini" {
 - If Gemini CLI is not found, ensure `install_gemini = true` and your API key is valid
 - Node.js and npm are installed automatically if missing (using NVM)
 - Check logs in `/home/coder/.gemini-module/` for install/start output
-- We highly recommend using the `gemini_api_key` variable, this also ensures smooth tasks running without needing to sign in to Google.
+- We highly recommend using the `gemini_api_key` variable, this also ensures smooth tasks running without needing to sign in to Google
+- If experiencing prompts for approval or confirmation:
+  - Set `auto_approve = true` to automatically approve API key usage
+  - Set `yolo_mode = true` to enable faster responses without confirmation prompts
+  - These settings are configured in `~/.gemini/settings.json` automatically
 
 > [!IMPORTANT]
 > To use tasks with Gemini CLI, ensure you have the `gemini_api_key` variable set, and **you pass the `AI Prompt` Parameter**.

--- a/registry/coder-labs/modules/gemini/main.tf
+++ b/registry/coder-labs/modules/gemini/main.tf
@@ -33,13 +33,25 @@ variable "group" {
 variable "icon" {
   type        = string
   description = "The icon to use for the app."
-  default     = "/icon/gemini.svg"
+  default     = "../../../../.icons/gemini.svg"
 }
 
 variable "folder" {
   type        = string
   description = "The folder to run Gemini in."
   default     = "/home/coder"
+}
+
+variable "auto_approve" {
+  type        = bool
+  description = "Whether to automatically approve Gemini API key usage."
+  default     = true
+}
+
+variable "yolo_mode" {
+  type        = bool
+  description = "Whether to enable YOLO mode for faster responses without confirmation prompts."
+  default     = true
 }
 
 variable "install_gemini" {

--- a/registry/coder-labs/modules/gemini/scripts/install.sh
+++ b/registry/coder-labs/modules/gemini/scripts/install.sh
@@ -133,8 +133,12 @@ function append_extensions_to_settings_json() {
       '.mcpServers = (.mcpServers // {} + $base + $add)' \
       "$SETTINGS_PATH" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$SETTINGS_PATH"
 
-    # Add theme and selectedAuthType fields
-    jq '.theme = "Default" | .selectedAuthType = "gemini-api-key"' "$SETTINGS_PATH" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$SETTINGS_PATH"
+    # Add theme, selectedAuthType, and Gemini settings
+    jq '.theme = "Default" | 
+        .selectedAuthType = "gemini-api-key" |
+        .autoApproveApiKey = true |
+        .geminicodeassist.agentYoloMode = true |
+        .geminicodeassist.autoConfirm = true' "$SETTINGS_PATH" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$SETTINGS_PATH"
 
     printf "[append_extensions_to_settings_json] Merge complete.\n"
 }

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -103,6 +103,12 @@ variable "agentapi_version" {
   default     = "v0.3.0"
 }
 
+variable "system_prompt" {
+  type        = string
+  description = "System prompt to append to Claude Code's default system prompt using --append-system-prompt flag."
+  default     = ""
+}
+
 locals {
   # we have to trim the slash because otherwise coder exp mcp will
   # set up an invalid claude config 
@@ -211,6 +217,9 @@ resource "coder_script" "claude_code" {
 
     # save the prompt for the agentapi start command
     echo -n "$CODER_MCP_CLAUDE_TASK_PROMPT" > "$module_path/prompt.txt"
+
+    # save the system prompt for the agentapi start command
+    echo -n "${var.system_prompt}" > "$module_path/system-prompt.txt"
 
     echo -n "${local.agentapi_start_script_b64}" | base64 -d > "$module_path/scripts/agentapi-start.sh"
     echo -n "${local.agentapi_wait_for_start_script_b64}" | base64 -d > "$module_path/scripts/agentapi-wait-for-start.sh"

--- a/registry/coder/modules/claude-code/scripts/agentapi-start.sh
+++ b/registry/coder/modules/claude-code/scripts/agentapi-start.sh
@@ -31,10 +31,19 @@ function start_agentapi() {
     local continue_flag="$1"
     local prompt_subshell='"$(cat /tmp/claude-code-prompt)"'
     
+    # Check if system prompt file exists and has content
+    local system_prompt_arg=""
+    if [ -f "$module_path/system-prompt.txt" ] && [ -s "$module_path/system-prompt.txt" ]; then
+        local system_prompt_content="$(cat "$module_path/system-prompt.txt")"
+        if [ -n "$system_prompt_content" ]; then
+            system_prompt_arg="--append-system-prompt \"$system_prompt_content\""
+        fi
+    fi
+    
     # use low width to fit in the tasks UI sidebar. height is adjusted so that width x height ~= 80x1000 characters
     # visible in the terminal screen by default.
     agentapi server --term-width 67 --term-height 1190 -- \
-        bash -c "claude $continue_flag --dangerously-skip-permissions $prompt_subshell" \
+        bash -c "claude $continue_flag --dangerously-skip-permissions $system_prompt_arg $prompt_subshell" \
         > "$log_file_path" 2>&1
 }
 

--- a/registry/coder/modules/jfrog-oauth/condarc.tftpl
+++ b/registry/coder/modules/jfrog-oauth/condarc.tftpl
@@ -1,0 +1,6 @@
+channels:
+  - https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_ACCESS_TOKEN}@${JFROG_HOST}/artifactory/api/conda/${try(element(REPOS, 0), "")}
+%{ for REPO in try(slice(REPOS, 1, length(REPOS)), []) ~}
+  - https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_ACCESS_TOKEN}@${JFROG_HOST}/artifactory/api/conda/${REPO}
+%{ endfor ~}
+ssl_verify: true 

--- a/scripts/new_template.sh
+++ b/scripts/new_template.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# This script creates a new sample template directory with required files
+# Run it like: ./scripts/new_template.sh my-namespace/my-template
+
+TEMPLATE_ARG=$1
+
+# Check if they are in the root directory
+if [ ! -d "registry" ]; then
+  echo "Please run this script from the root directory of the repository"
+  echo "Usage: ./scripts/new_template.sh <namespace>/<template_name>"
+  exit 1
+fi
+
+# Check if template name is in the format <namespace>/<template_name>
+if ! [[ "$TEMPLATE_ARG" =~ ^[a-z0-9_-]+/[a-z0-9_-]+$ ]]; then
+  echo "Template name must be in the format <namespace>/<template_name>"
+  echo "Usage: ./scripts/new_template.sh <namespace>/<template_name>"
+  exit 1
+fi
+
+# Extract the namespace and template name
+NAMESPACE=$(echo "$TEMPLATE_ARG" | cut -d'/' -f1)
+TEMPLATE_NAME=$(echo "$TEMPLATE_ARG" | cut -d'/' -f2)
+
+# Check if the template already exists
+if [ -d "registry/$NAMESPACE/templates/$TEMPLATE_NAME" ]; then
+  echo "Template at registry/$NAMESPACE/templates/$TEMPLATE_NAME already exists"
+  echo "Please choose a different name"
+  exit 1
+fi
+
+# Create template directory
+mkdir -p "registry/${NAMESPACE}/templates/${TEMPLATE_NAME}"
+
+# Copy required files from the example template
+cp -r examples/templates/* "registry/${NAMESPACE}/templates/${TEMPLATE_NAME}/"
+
+# Change to template directory
+cd "registry/${NAMESPACE}/templates/${TEMPLATE_NAME}"
+
+# Detect OS and replace placeholders
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # macOS
+  sed -i '' "s/TEMPLATE_NAME/${TEMPLATE_NAME}/g" main.tf
+  sed -i '' "s/TEMPLATE_NAME/${TEMPLATE_NAME}/g" README.md
+  sed -i '' "s/NAMESPACE/${NAMESPACE}/g" README.md
+  sed -i '' "s/PLATFORM_NAME/Docker/g" main.tf
+else
+  # Linux
+  sed -i "s/TEMPLATE_NAME/${TEMPLATE_NAME}/g" main.tf
+  sed -i "s/TEMPLATE_NAME/${TEMPLATE_NAME}/g" README.md
+  sed -i "s/NAMESPACE/${NAMESPACE}/g" README.md
+  sed -i "s/PLATFORM_NAME/Docker/g" main.tf
+fi
+
+echo ""
+echo "✅ Template created successfully!"
+echo ""
+echo "📁 Template location: registry/${NAMESPACE}/templates/${TEMPLATE_NAME}"
+echo ""
+echo "📝 Next steps:"
+echo "   1. Edit main.tf to implement your infrastructure"
+echo "   2. Update README.md with accurate documentation"
+echo "   3. Test your template with: coder templates push ${TEMPLATE_NAME} -d ."
+echo "   4. Commit and create a pull request"
+echo ""
+echo "📖 See CONTRIBUTING.md for detailed guidance on creating templates"


### PR DESCRIPTION
Closes #284

## Description

Implements support for `--append-system-prompt` CLI flag instead of relying on `CLAUDE.md` files or environment variables for system prompt configuration in the claude-code module. This provides more reliable and explicit system prompt handling.

**Key Changes:**
- Added `system_prompt` variable to claude-code module
- Modified `agentapi-start.sh` to use `--append-system-prompt` CLI flag
- Updated documentation with new usage examples and migration guide
- Added comprehensive test coverage for system prompt functionality

**Benefits:**
- More reliable behavior using CLI flag instead of environment variables
- Better user experience with direct module configuration
- Cleaner configuration without separate environment variable setup
- Maintains backward compatibility with existing installations

## Type of Change

- [ ] New module
- [ ] Bug fix
- [x] Feature/enhancement
- [x] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder/modules/claude-code`  
**New version:** `v2.1.0`  
**Breaking change:** [ ] Yes [x] No

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun run fmt`)
- [x] Changes tested locally

## Related Issues

Fixes #284 - claude code: use --append-system-prompt to set system prompt instead of CLAUDE.md