### PR TITLE
fix(claude-code): revert workaround

### DIFF
--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Run the [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "2.0.5"
+  version             = "2.0.6"
   agent_id            = coder_agent.example.id
   folder              = "/home/coder"
   install_claude_code = true
@@ -84,7 +84,7 @@ resource "coder_agent" "main" {
 module "claude-code" {
   count               = data.coder_workspace.me.start_count
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "2.0.5"
+  version             = "2.0.6"
   agent_id            = coder_agent.example.id
   folder              = "/home/coder"
   install_claude_code = true
@@ -102,7 +102,7 @@ Run Claude Code as a standalone app in your workspace. This will install Claude 
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "2.0.5"
+  version             = "2.0.6"
   agent_id            = coder_agent.example.id
   folder              = "/home/coder"
   install_claude_code = true

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -289,11 +289,3 @@ resource "coder_ai_task" "claude_code" {
     id = coder_app.claude_code_web.id
   }
 }
-
-# As of https://github.com/coder/coder/commit/6ba4b5bbc95e2e528d7f5b1e31fffa200ae1a6db,
-# there's a bug in Coder's Terraform statefile parsing which prevents it from seeing coder_apps
-# in certain scenarios. This is a workaround to bypass this bug until we have a proper fix.
-# For more details see https://github.com/coder/coder/issues/18776
-resource "terraform_data" "claude_code_app_id" {
-  input = coder_app.claude_code_web.id
-}


### PR DESCRIPTION
The workaround introduced in https://github.com/coder/registry/pull/283 sometimes causes Coder to associate the Coder agent with the `terraform_data` resource instead of a compute resource. Additionally, it creates a new agent once a workspace is stopped.

See https://codercom.slack.com/archives/C08PHACTZRB/p1754391012982629 for more details.

<img width="2480" height="1312" alt="image (6)" src="https://github.com/user-attachments/assets/6ccf2b40-92e7-4c67-b61f-b26888753e72" />

Related to https://github.com/coder/coder/issues/18776.