### PR TITLE
Migrate tests to Terraform for jetbrains, zed, and code-server; enable mixed test mode

### DIFF
--- a/examples/modules/MODULE_NAME.tftest.hcl
+++ b/examples/modules/MODULE_NAME.tftest.hcl
@@ -1,0 +1,21 @@
+run "plan_with_required_vars" {
+  command = plan
+
+  variables {
+    agent_id = "example-agent-id"
+  }
+}
+
+run "app_url_uses_port" {
+  command = plan
+
+  variables {
+    agent_id = "example-agent-id"
+    port     = 19999
+  }
+
+  assert {
+    condition     = resource.coder_app.MODULE_NAME.url == "http://localhost:19999"
+    error_message = "Expected MODULE_NAME app URL to include configured port"
+  }
+}

--- a/scripts/new_module.sh
+++ b/scripts/new_module.sh
@@ -31,7 +31,7 @@ if [ -d "registry/$NAMESPACE/modules/$MODULE_NAME" ]; then
 fi
 mkdir -p "registry/${NAMESPACE}/modules/${MODULE_NAME}"
 
-# Copy required files from the example module
+# Copy required files from the example module (includes Terraform tests)
 cp -r examples/modules/* "registry/${NAMESPACE}/modules/${MODULE_NAME}/"
 
 # Change to module directory
@@ -48,5 +48,7 @@ else
   sed -i "s/MODULE_NAME/${MODULE_NAME}/g" README.md
 fi
 
-# Make run.sh executable
-chmod +x run.sh
+# Make run.sh executable (if present)
+if [ -f run.sh ]; then
+  chmod +x run.sh
+fi


### PR DESCRIPTION
## Summary
- Introduces Terraform native tests (`terraform test`) alongside existing Bun tests
- Migrates tests for modules: jetbrains, zed, and code-server
- Removes Bun test files for these migrated modules only
- Adds repo-wide test runner script for Terraform tests
- Updates docs and new-module sample to reflect Terraform tests

## Transition plan
- Mixed mode: Other modules retain Bun tests; CI should run both Bun and Terraform tests temporarily
- Follow the linked epic to migrate remaining modules

## Test plan
- Run: `./scripts/terraform_test_all.sh` (passes locally)
- Bun tests still available for non-migrated modules

## Affected paths
- registry/coder/modules/jetbrains/jetbrains.tftest.hcl
- registry/coder/modules/zed/zed.tftest.hcl
- registry/coder/modules/code-server/code-server.tftest.hcl
- scripts/terraform_test_all.sh
- examples/modules/MODULE_NAME.tftest.hcl
- CONTRIBUTING.md