### PR TITLE
feat(cursor-cli): add Cursor Agent CLI module (no AgentAPI, interactive by default)

### DIFF
--- a/registry/coder-labs/modules/cursor-cli/README.md
+++ b/registry/coder-labs/modules/cursor-cli/README.md
@@ -1,0 +1,57 @@
+---
+display_name: Cursor CLI
+icon: ../../../../.icons/cursor.svg
+description: Run Cursor CLI agent in your workspace (no AgentAPI)
+verified: true
+tags: [agent, cursor, ai, cli]
+---
+
+# Cursor CLI
+
+Run the Cursor Coding Agent in your workspace using the Cursor CLI directly. This module does not use AgentAPI and executes the Cursor agent process itself.
+
+- Defaults to interactive mode, with an option for non-interactive mode
+- Supports `--force` runs
+- Allows configuring MCP servers (settings merge)
+- Lets you choose a model and pass extra CLI arguments
+
+```tf
+module "cursor_cli" {
+  source   = "registry.coder.com/coder-labs/cursor-cli/coder"
+  version  = "0.1.0"
+  agent_id = coder_agent.example.id
+
+  # Optional
+  folder              = "/home/coder/project"
+  install_cursor_cli  = true
+  cursor_cli_version  = "latest"
+  interactive         = true
+  non_interactive_cmd = "run --once"
+  force               = false
+  model               = "gpt-4o"
+  additional_settings = jsonencode({
+    mcpServers = {
+      coder = {
+        command = "coder"
+        args    = ["exp", "mcp", "server"]
+        type    = "stdio"
+        name    = "Coder"
+        env     = {}
+        enabled = true
+      }
+    }
+  })
+  extra_args = ["--verbose"]
+}
+```
+
+## Notes
+
+- See Cursor CLI docs: `https://docs.cursor.com/en/cli/overview`
+- The module writes merged settings to `~/.cursor/settings.json`
+- Interactive by default; set `interactive = false` to run non-interactively via `non_interactive_cmd`
+
+## Troubleshooting
+
+- Ensure the CLI is installed (enable `install_cursor_cli = true` or preinstall it in your image)
+- Logs are written to `~/.cursor-cli-module/`

--- a/registry/coder-labs/modules/cursor-cli/cursor-cli.tftest.hcl
+++ b/registry/coder-labs/modules/cursor-cli/cursor-cli.tftest.hcl
@@ -1,0 +1,91 @@
+// Terraform tests for the cursor-cli module
+// Validates that we render expected script content given inputs
+
+run "defaults_interactive" {
+  command = plan
+
+  variables {
+    agent_id = "test-agent"
+  }
+
+  assert {
+    condition     = can(regex("INTERACTIVE='true'", resource.coder_script.cursor_cli.script))
+    error_message = "Expected INTERACTIVE default to be true"
+  }
+
+  assert {
+    condition     = can(regex("BINARY_NAME='cursor-agent'", resource.coder_script.cursor_cli.script))
+    error_message = "Expected default binary_name to be cursor-agent"
+  }
+}
+
+run "non_interactive_mode" {
+  command = plan
+
+  variables {
+    agent_id            = "test-agent"
+    interactive         = false
+    non_interactive_cmd = "run --once"
+  }
+
+  assert {
+    condition     = can(regex("INTERACTIVE='false'", resource.coder_script.cursor_cli.script))
+    error_message = "Expected INTERACTIVE to be false when interactive=false"
+  }
+
+  assert {
+    condition     = can(regex("NON_INTERACTIVE_CMD='run --once'", resource.coder_script.cursor_cli.script))
+    error_message = "Expected NON_INTERACTIVE_CMD to be propagated"
+  }
+}
+
+run "model_and_force" {
+  command = plan
+
+  variables {
+    agent_id = "test-agent"
+    model    = "test-model"
+    force    = true
+  }
+
+  assert {
+    condition     = can(regex("MODEL='test-model'", resource.coder_script.cursor_cli.script))
+    error_message = "Expected MODEL to be propagated"
+  }
+
+  assert {
+    condition     = can(regex("FORCE='true'", resource.coder_script.cursor_cli.script))
+    error_message = "Expected FORCE true to be propagated"
+  }
+}
+
+run "additional_settings_propagated" {
+  command = plan
+
+  variables {
+    agent_id            = "test-agent"
+    additional_settings = jsonencode({
+      mcpServers = {
+        coder = {
+          command = "coder"
+          args    = ["exp", "mcp", "server"]
+          type    = "stdio"
+        }
+      }
+    })
+  }
+
+  // Ensure the encoded settings are passed into the install invocation
+  assert {
+    condition     = can(regex(base64encode(jsonencode({
+      mcpServers = {
+        coder = {
+          command = "coder"
+          args    = ["exp", "mcp", "server"]
+          type    = "stdio"
+        }
+      }
+    })), resource.coder_script.cursor_cli.script))
+    error_message = "Expected ADDITIONAL_SETTINGS (base64) to be in the install step"
+  }
+}

--- a/registry/coder-labs/modules/cursor-cli/main.test.ts
+++ b/registry/coder-labs/modules/cursor-cli/main.test.ts
@@ -1,0 +1,96 @@
+import { test, afterEach, describe, setDefaultTimeout, beforeAll, expect } from "bun:test";
+import { execContainer, readFileContainer, runTerraformInit, runTerraformApply, writeFileContainer, runContainer, removeContainer, findResourceInstance } from "~test";
+import dedent from "dedent";
+
+let cleanupFunctions: (() => Promise<void>)[] = [];
+const registerCleanup = (cleanup: () => Promise<void>) => {
+  cleanupFunctions.push(cleanup);
+};
+
+afterEach(async () => {
+  const cleanupFnsCopy = cleanupFunctions.slice().reverse();
+  cleanupFunctions = [];
+  for (const cleanup of cleanupFnsCopy) {
+    try {
+      await cleanup();
+    } catch (error) {
+      console.error("Error during cleanup:", error);
+    }
+  }
+});
+
+const writeExecutable = async (containerId: string, filePath: string, content: string) => {
+  await writeFileContainer(containerId, filePath, content, { user: "root" });
+  await execContainer(containerId, ["bash", "-c", `chmod 755 ${filePath}`], ["--user", "root"]);
+};
+
+const loadTestFile = async (...relativePath: string[]) => {
+  return await Bun.file(new URL(`./testdata/${relativePath.join("/")}`, import.meta.url)).text();
+};
+
+const setup = async (vars?: Record<string, string>): Promise<{ id: string }> => {
+  const state = await runTerraformApply(import.meta.dir, {
+    agent_id: "foo",
+    install_cursor_cli: "false",
+    ...vars,
+  });
+  const coderScript = findResourceInstance(state, "coder_script");
+  const id = await runContainer("codercom/enterprise-node:latest");
+  registerCleanup(async () => removeContainer(id));
+  await writeExecutable(id, "/home/coder/script.sh", coderScript.script);
+  await writeExecutable(id, "/usr/bin/cursor", await loadTestFile("cursor-mock.sh"));
+  return { id };
+};
+
+setDefaultTimeout(60 * 1000);
+
+describe("cursor-cli", async () => {
+  beforeAll(async () => {
+    await runTerraformInit(import.meta.dir);
+  });
+
+  test("happy-path-interactive", async () => {
+    const { id } = await setup();
+    const resp = await execContainer(id, ["bash", "-c", "cd /home/coder && ./script.sh"]);
+    if (resp.exitCode !== 0) {
+      console.log(resp.stdout);
+      console.log(resp.stderr);
+    }
+    expect(resp.exitCode).toBe(0);
+    const startLog = await readFileContainer(id, "/home/coder/.cursor-cli-module/start.log");
+    expect(startLog).toContain("agent");
+    expect(startLog).toContain("--interactive");
+  });
+
+  test("non-interactive-with-cmd", async () => {
+    const { id } = await setup({ interactive: "false", non_interactive_cmd: "run --once" });
+    const resp = await execContainer(id, ["bash", "-c", "cd /home/coder && ./script.sh"]);
+    expect(resp.exitCode).toBe(0);
+    const startLog = await readFileContainer(id, "/home/coder/.cursor-cli-module/start.log");
+    expect(startLog).toContain("run");
+    expect(startLog).toContain("--once");
+    expect(startLog).not.toContain("--interactive");
+  });
+
+  test("model-and-force-and-extra-args", async () => {
+    const { id } = await setup({ model: "test-model", force: "true" });
+    const resp = await execContainer(id, ["bash", "-c", "cd /home/coder && ./script.sh"], ["--env", "TF_VAR_extra_args=--foo\nbar"]);
+    expect(resp.exitCode).toBe(0);
+    const startLog = await readFileContainer(id, "/home/coder/.cursor-cli-module/start.log");
+    expect(startLog).toContain("--model");
+    expect(startLog).toContain("test-model");
+    expect(startLog).toContain("--force");
+  });
+
+  test("additional-settings-merge", async () => {
+    const settings = dedent`
+      {"mcpServers": {"coder": {"command": "coder", "args": ["exp","mcp","server"], "type": "stdio"}}}
+    `;
+    const { id } = await setup({ additional_settings: settings });
+    const resp = await execContainer(id, ["bash", "-c", "cd /home/coder && ./script.sh"]);
+    expect(resp.exitCode).toBe(0);
+    const cfg = await readFileContainer(id, "/home/coder/.cursor/settings.json");
+    expect(cfg).toContain("mcpServers");
+    expect(cfg).toContain("coder");
+  });
+});

--- a/registry/coder-labs/modules/cursor-cli/main.tf
+++ b/registry/coder-labs/modules/cursor-cli/main.tf
@@ -1,0 +1,186 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = ">= 2.7"
+    }
+  }
+}
+
+variable "agent_id" {
+  type        = string
+  description = "The ID of a Coder agent."
+}
+
+data "coder_workspace" "me" {}
+
+data "coder_workspace_owner" "me" {}
+
+variable "order" {
+  type        = number
+  description = "The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order)."
+  default     = null
+}
+
+variable "group" {
+  type        = string
+  description = "The name of a group that this app belongs to."
+  default     = null
+}
+
+variable "icon" {
+  type        = string
+  description = "The icon to use for the app."
+  default     = "/icon/cursor.svg"
+}
+
+variable "folder" {
+  type        = string
+  description = "The folder to run Cursor CLI in."
+  default     = "/home/coder"
+}
+
+variable "install_cursor_cli" {
+  type        = bool
+  description = "Whether to install Cursor CLI."
+  default     = true
+}
+
+variable "cursor_cli_version" {
+  type        = string
+  description = "The version of Cursor CLI to install (latest for latest)."
+  default     = "latest"
+}
+
+variable "interactive" {
+  type        = bool
+  description = "Run in interactive chat mode (default)."
+  default     = true
+}
+
+variable "initial_prompt" {
+  type        = string
+  description = "Initial prompt to start the chat with (passed as trailing arg)."
+  default     = ""
+}
+
+variable "non_interactive_cmd" {
+  type        = string
+  description = "Additional arguments appended when interactive=false (advanced usage)."
+  default     = ""
+}
+
+variable "force" {
+  type        = bool
+  description = "Pass -f/--force to allow commands unless explicitly denied."
+  default     = false
+}
+
+variable "model" {
+  type        = string
+  description = "Pass -m/--model to select model (e.g., sonnet-4, gpt-5)."
+  default     = ""
+}
+
+variable "output_format" {
+  type        = string
+  description = "Output format with -p: text, json, or stream-json."
+  default     = ""
+}
+
+variable "api_key" {
+  type        = string
+  description = "API key (sets CURSOR_API_KEY env or pass via -a)."
+  default     = ""
+  sensitive   = true
+}
+
+variable "extra_args" {
+  type        = list(string)
+  description = "Additional args to pass to the Cursor CLI."
+  default     = []
+}
+
+variable "binary_name" {
+  type        = string
+  description = "Cursor Agent binary name (default: cursor-agent)."
+  default     = "cursor-agent"
+}
+
+variable "base_command" {
+  type        = string
+  description = "Base Cursor CLI command to run (default: none for chat)."
+  default     = ""
+}
+
+variable "additional_settings" {
+  type        = string
+  description = "JSON to merge into ~/.cursor/settings.json (e.g., mcpServers)."
+  default     = ""
+}
+
+locals {
+  app_slug        = "cursor-cli"
+  install_script  = file("${path.module}/scripts/install.sh")
+  start_script    = file("${path.module}/scripts/start.sh")
+  module_dir_name = ".cursor-cli-module"
+}
+
+resource "coder_script" "cursor_cli" {
+  agent_id     = var.agent_id
+  display_name = "Cursor CLI"
+  icon         = var.icon
+  script       = <<-EOT
+    #!/bin/bash
+    set -o errexit
+    set -o pipefail
+
+    echo -n '${base64encode(local.install_script)}' | base64 -d > /tmp/install.sh
+    chmod +x /tmp/install.sh
+    ARG_INSTALL='${var.install_cursor_cli}' \
+    ARG_VERSION='${var.cursor_cli_version}' \
+    ADDITIONAL_SETTINGS='${base64encode(replace(var.additional_settings, "'", "'\\''"))}' \
+    MODULE_DIR_NAME='${local.module_dir_name}' \
+    FOLDER='${var.folder}' \
+    /tmp/install.sh | tee "$HOME/${local.module_dir_name}/install.log"
+
+    echo -n '${base64encode(local.start_script)}' | base64 -d > /tmp/start.sh
+    chmod +x /tmp/start.sh
+    INTERACTIVE='${var.interactive}' \
+    INITIAL_PROMPT='${replace(var.initial_prompt, "'", "'\\''")}' \
+    NON_INTERACTIVE_CMD='${replace(var.non_interactive_cmd, "'", "'\\''")}' \
+    BASE_COMMAND='${var.base_command}' \
+    FORCE='${var.force}' \
+    MODEL='${var.model}' \
+    OUTPUT_FORMAT='${var.output_format}' \
+    API_KEY_SECRET='${var.api_key}' \
+    EXTRA_ARGS='${base64encode(join("\n", var.extra_args))}' \
+    MODULE_DIR_NAME='${local.module_dir_name}' \
+    FOLDER='${var.folder}' \
+    BINARY_NAME='${var.binary_name}' \
+    /tmp/start.sh | tee "$HOME/${local.module_dir_name}/start.log"
+  EOT
+  run_on_start = true
+}
+
+resource "coder_app" "cursor_cli" {
+  agent_id     = var.agent_id
+  slug         = local.app_slug
+  display_name = "Cursor CLI"
+  icon         = var.icon
+  order        = var.order
+  group        = var.group
+  command      = <<-EOT
+    #!/bin/bash
+    set -o errexit
+    set -o pipefail
+    if [ -f "$HOME/${local.module_dir_name}/start.log" ]; then
+      tail -n +1 -f "$HOME/${local.module_dir_name}/start.log"
+    else
+      echo "Cursor CLI not started yet. Check install/start logs in $HOME/${local.module_dir_name}/"
+      /bin/bash
+    fi
+  EOT
+}

--- a/registry/coder-labs/modules/cursor-cli/scripts/install.sh
+++ b/registry/coder-labs/modules/cursor-cli/scripts/install.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Inputs
+ARG_INSTALL=${ARG_INSTALL:-true}
+ARG_VERSION=${ARG_VERSION:-latest}
+MODULE_DIR_NAME=${MODULE_DIR_NAME:-.cursor-cli-module}
+FOLDER=${FOLDER:-$HOME}
+
+mkdir -p "$HOME/$MODULE_DIR_NAME"
+
+ADDITIONAL_SETTINGS=$(echo -n "$ADDITIONAL_SETTINGS" | base64 -d)
+
+{
+  echo "--------------------------------"
+  echo "install: $ARG_INSTALL"
+  echo "version: $ARG_VERSION"
+  echo "folder: $FOLDER"
+  echo "--------------------------------"
+} | tee -a "$HOME/$MODULE_DIR_NAME/install.log"
+
+# Install Cursor Agent CLI if requested.
+# The docs show Cursor Agent CLI usage; we will install via npm globally.
+# This requires Node/npm; install Node via NVM if not present (similar to gemini module approach).
+if [ "$ARG_INSTALL" = "true" ]; then
+  echo "Installing Cursor Agent CLI..." | tee -a "$HOME/$MODULE_DIR_NAME/install.log"
+
+  install_node() {
+    if ! command_exists npm; then
+      if ! command_exists node; then
+        export NVM_DIR="$HOME/.nvm"
+        if [ ! -d "$NVM_DIR" ]; then
+          mkdir -p "$NVM_DIR"
+          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+          [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+        else
+          [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+        fi
+        nvm install --lts
+        nvm use --lts
+        nvm alias default node
+      else
+        echo "Node is installed but npm missing; please install npm manually." | tee -a "$HOME/$MODULE_DIR_NAME/install.log"
+      fi
+    fi
+  }
+
+  install_node
+
+  # If nvm not present, create local npm global dir to avoid permissions issues
+  if ! command_exists nvm; then
+    mkdir -p "$HOME/.npm-global"
+    npm config set prefix "$HOME/.npm-global"
+    export PATH="$HOME/.npm-global/bin:$PATH"
+    if ! grep -q "export PATH=$HOME/.npm-global/bin:\$PATH" "$HOME/.bashrc" 2>/dev/null; then
+      echo "export PATH=$HOME/.npm-global/bin:\$PATH" >> "$HOME/.bashrc"
+    fi
+  fi
+
+  if [ -n "$ARG_VERSION" ] && [ "$ARG_VERSION" != "latest" ]; then
+    npm install -g "cursor-agent@$ARG_VERSION" 2>&1 | tee -a "$HOME/$MODULE_DIR_NAME/install.log"
+  else
+    npm install -g cursor-agent 2>&1 | tee -a "$HOME/$MODULE_DIR_NAME/install.log"
+  fi
+
+  echo "Installed cursor-agent: $(command -v cursor-agent || true)" | tee -a "$HOME/$MODULE_DIR_NAME/install.log"
+fi
+
+# Ensure settings path exists and merge additional_settings JSON
+SETTINGS_PATH="$HOME/.cursor/settings.json"
+mkdir -p "$(dirname "$SETTINGS_PATH")"
+
+# If settings file doesn't exist, initialize basic structure
+if [ ! -f "$SETTINGS_PATH" ]; then
+  echo '{}' > "$SETTINGS_PATH"
+fi
+
+if [ -n "$ADDITIONAL_SETTINGS" ]; then
+  echo "Merging additional settings into $SETTINGS_PATH" | tee -a "$HOME/$MODULE_DIR_NAME/install.log"
+  TMP_SETTINGS=$(mktemp)
+  # Merge JSON: deep merge mcpServers and top-level keys
+  jq --argjson add "$ADDITIONAL_SETTINGS" 'def deepmerge(a;b): reduce (b|keys[]) as $key (a; .[$key] = if ( (.[ $key ]|type?) == "object" and (b[$key]|type?) == "object" ) then deepmerge(.[ $key ]; b[$key]) else b[$key] end); deepmerge(.;$add)' "$SETTINGS_PATH" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$SETTINGS_PATH"
+fi
+
+exit 0

--- a/registry/coder-labs/modules/cursor-cli/scripts/start.sh
+++ b/registry/coder-labs/modules/cursor-cli/scripts/start.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+INTERACTIVE=${INTERACTIVE:-true}
+INITIAL_PROMPT=${INITIAL_PROMPT:-}
+NON_INTERACTIVE_CMD=${NON_INTERACTIVE_CMD:-}
+FORCE=${FORCE:-false}
+MODEL=${MODEL:-}
+OUTPUT_FORMAT=${OUTPUT_FORMAT:-}
+API_KEY_SECRET=${API_KEY_SECRET:-}
+EXTRA_ARGS_BASE64=${EXTRA_ARGS:-}
+MODULE_DIR_NAME=${MODULE_DIR_NAME:-.cursor-cli-module}
+FOLDER=${FOLDER:-$HOME}
+BINARY_NAME=${BINARY_NAME:-cursor-agent}
+
+mkdir -p "$HOME/$MODULE_DIR_NAME"
+
+# Decode EXTRA_ARGS lines into an array
+IFS=$'\n' read -r -d '' -a EXTRA_ARR < <(echo -n "$EXTRA_ARGS_BASE64" | base64 -d; printf '\0') || true
+
+# Find cursor agent cli
+if command_exists "$BINARY_NAME"; then
+  CURSOR_CMD="$BINARY_NAME"
+elif [ -x "$HOME/.local/bin/$BINARY_NAME" ]; then
+  CURSOR_CMD="$HOME/.local/bin/$BINARY_NAME"
+else
+  echo "Error: $BINARY_NAME not found. Install it or set install_cursor_cli=true." | tee -a "$HOME/$MODULE_DIR_NAME/start.log"
+  exit 1
+fi
+
+# Ensure working directory exists
+if [ -d "$FOLDER" ]; then
+  cd "$FOLDER"
+else
+  mkdir -p "$FOLDER"
+  cd "$FOLDER"
+fi
+
+ARGS=()
+
+# base command: if provided, append; otherwise chat mode (no command)
+if [ -n "${BASE_COMMAND:-}" ]; then
+  ARGS+=("${BASE_COMMAND}")
+fi
+
+# global flags
+if [ -n "$MODEL" ]; then
+  ARGS+=("-m" "$MODEL")
+fi
+if [ "$FORCE" = "true" ]; then
+  ARGS+=("-f")
+fi
+
+# Non-interactive printing flags
+PRINT_TO_CONSOLE=false
+if [ "$INTERACTIVE" != "true" ]; then
+  PRINT_TO_CONSOLE=true
+  ARGS+=("-p")
+  if [ -n "$OUTPUT_FORMAT" ]; then
+    ARGS+=("--output-format" "$OUTPUT_FORMAT")
+  fi
+  if [ -n "$NON_INTERACTIVE_CMD" ]; then
+    # shellcheck disable=SC2206
+    CMD_PARTS=($NON_INTERACTIVE_CMD)
+    ARGS+=("${CMD_PARTS[@]}")
+  fi
+fi
+
+# Extra args, if any
+if [ ${#EXTRA_ARR[@]} -gt 0 ]; then
+  ARGS+=("${EXTRA_ARR[@]}")
+fi
+
+# If initial prompt specified (chat mode), pass as trailing arg
+if [ -n "$INITIAL_PROMPT" ]; then
+  ARGS+=("$INITIAL_PROMPT")
+fi
+
+# Set API key env if provided
+if [ -n "$API_KEY_SECRET" ]; then
+  export CURSOR_API_KEY="$API_KEY_SECRET"
+fi
+
+# Log and exec
+printf "Running: %q %s\n" "$CURSOR_CMD" "$(printf '%q ' "${ARGS[@]}")" | tee -a "$HOME/$MODULE_DIR_NAME/start.log"
+exec "$CURSOR_CMD" "${ARGS[@]}"

--- a/registry/coder-labs/modules/cursor-cli/testdata/cursor-mock.sh
+++ b/registry/coder-labs/modules/cursor-cli/testdata/cursor-mock.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# minimal mock that prints args and exits
+printf "cursor mock invoked with: %s\n" "$*"
+# Exit successfully regardless
+exit 0


### PR DESCRIPTION
## Summary
- Add new module `registry/coder-labs/modules/cursor-cli` to run Cursor Agent CLI directly (no AgentAPI)
- Interactive chat by default; supports non-interactive mode (-p) with output-format
- Supports model (-m) and force (-f) flags, initial prompt, and CURSOR_API_KEY
- Merges MCP settings into ~/.cursor/settings.json
- Installs via npm, bootstrapping Node via NVM if missing (mirrors gemini approach)
- Adds Terraform-native tests (.tftest.hcl); all pass locally

## Test plan
- From module dir:
  - terraform init -upgrade
  - terraform test -verbose
- Expect 4 tests passing covering defaults, flag plumbing, and MCP settings injection
- Basic smoke run: ensure `cursor-agent` is on PATH or set install_cursor_cli=true