### PR TITLE
Fix contributor avatars: use `avatar` key and correct anomaly image extension

### DIFF
--- a/registry/anomaly/README.md
+++ b/registry/anomaly/README.md
@@ -1,7 +1,7 @@
 ---
 display_name: "Jay Kumar"
 bio: "I'm a Software Engineer :)"
-avatar_url: "./.images/avatar.png"
+avatar: "./.images/avatar.jpeg"
 github: "35C4n0r"
 linkedin: "https://www.linkedin.com/in/jaykum4r"
 support_email: "work.jaykumar@gmail.com"

--- a/registry/ericpaulsen/README.md
+++ b/registry/ericpaulsen/README.md
@@ -1,7 +1,7 @@
 ---
 display_name: "Eric Paulsen"
 bio: "Field CTO, EMEA @ Coder"
-avatar_url: "./.images/avatar.png"
+avatar: "./.images/avatar.png"
 github: "ericpaulsen"
 linkedin: "https://www.linkedin.com/in/ericpaulsen17" # Optional
 website: "https://ericpaulsen.io" # Optional

--- a/registry/sharkymark/README.md
+++ b/registry/sharkymark/README.md
@@ -1,7 +1,7 @@
 ---
 display_name: "Mark Milligan"
 bio: "VP of Revenue  at https://nuon.co. Former VP of Sales at Coder. Love building startup revenue teams and tinkering with technology."
-avatar_url: "./.images/avatar.png"
+avatar: "./.images/avatar.png"
 github: "sharkymark"
 linkedin: "https://www.linkedin.com/in/marktmilligan" # Optional
 website: "https://markmilligan.io" # Optional


### PR DESCRIPTION
Summary
- Switch frontmatter key from `avatar_url` to `avatar` for three contributor profiles
- Fix anomaly profile to reference existing `avatar.jpeg`

Files updated
- registry/anomaly/README.md (avatar_url -> avatar, .png -> .jpeg)
- registry/sharkymark/README.md (avatar_url -> avatar)
- registry/ericpaulsen/README.md (avatar_url -> avatar)

Notes
- Left paths unchanged except correcting anomaly to match the actual file present
- Did not run Bun tests locally due to Terraform/Docker deps; this change only affects frontmatter consumed by registry-server

Test plan
- Build registry-server site; verify avatars render for Jay, Mark, and Eric on contributors listing and profile pages

Co-authored-by: bpmct <22407953+bpmct@users.noreply.github.com>