### PR TITLE
chore: bump agentapi versions in the goose and gemini modules

### DIFF
--- a/registry/coder-labs/modules/gemini/README.md
+++ b/registry/coder-labs/modules/gemini/README.md
@@ -13,7 +13,7 @@ Run [Gemini CLI](https://ai.google.dev/gemini-api/docs/cli) in your workspace to
 ```tf
 module "gemini" {
   source           = "registry.coder.com/coder-labs/gemini/coder"
-  version          = "1.0.0"
+  version          = "1.0.1"
   agent_id         = coder_agent.example.id
   gemini_api_key   = var.gemini_api_key
   gemini_model     = "gemini-2.5-pro"
@@ -42,7 +42,7 @@ variable "gemini_api_key" {
 module "gemini" {
   count                     = data.coder_workspace.me.start_count
   source                    = "registry.coder.com/coder-labs/gemini/coder"
-  version                   = "1.0.0"
+  version                   = "1.0.1"
   agent_id                  = coder_agent.example.id
   gemini_api_key            = var.gemini_api_key # we recommend providing this parameter inorder to have a smoother experience (i.e. no google sign-in)
   gemini_model              = "gemini-2.5-flash"

--- a/registry/coder-labs/modules/gemini/main.tf
+++ b/registry/coder-labs/modules/gemini/main.tf
@@ -166,7 +166,7 @@ EOT
 
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "1.0.0"
+  version = "1.1.1"
 
   agent_id             = var.agent_id
   web_app_slug         = local.app_slug

--- a/registry/coder/modules/goose/README.md
+++ b/registry/coder/modules/goose/README.md
@@ -13,7 +13,7 @@ Run the [Goose](https://block.github.io/goose/) agent in your workspace to gener
 ```tf
 module "goose" {
   source           = "registry.coder.com/coder/goose/coder"
-  version          = "2.1.0"
+  version          = "2.1.1"
   agent_id         = coder_agent.example.id
   folder           = "/home/coder"
   install_goose    = true
@@ -79,7 +79,7 @@ resource "coder_agent" "main" {
 module "goose" {
   count            = data.coder_workspace.me.start_count
   source           = "registry.coder.com/coder/goose/coder"
-  version          = "2.1.0"
+  version          = "2.1.1"
   agent_id         = coder_agent.example.id
   folder           = "/home/coder"
   install_goose    = true

--- a/registry/coder/modules/goose/main.tf
+++ b/registry/coder/modules/goose/main.tf
@@ -139,7 +139,7 @@ EOT
 
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "1.1.0"
+  version = "1.1.1"
 
   agent_id             = var.agent_id
   web_app_slug         = local.app_slug


### PR DESCRIPTION
related to https://github.com/coder/registry/pull/320