### PR TITLE
chore: fix module detection to exclude hidden dirs

### DIFF
--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -308,7 +308,9 @@ detect_modules_needing_tags() {
   fi
 
   local all_modules
-  all_modules=$(find registry -mindepth 3 -maxdepth 3 -type d -path "*/modules/*" | sort -u || echo "")
+  # Find all module directories, excluding hidden directories
+  # This works on both macOS and Linux
+  all_modules=$(find registry -mindepth 3 -maxdepth 3 -type d -path "*/modules/*" ! -name ".*" | sort -u || echo "")
 
   [ -z "$all_modules" ] && {
     log "ERROR" "No modules found to check"


### PR DESCRIPTION
## Before
```console
🚀 Coder Registry Tag Release Script
       Operating on commit: 4238f38353a20c52afc28de8a3878b029a7473c2

       🔍 Scanning all modules for missing release tags...

       ⚠️  anomaly/.coder: No version found in README, skipping
       ✅ anomaly/tmux: v1.0.0 (already tagged)
       ⚠️  coder-labs/.coder: No version found in README, skipping
       ✅ coder-labs/cursor-cli: v0.1.1 (already tagged)
       ✅ coder-labs/gemini: v1.1.0 (already tagged)
       ⚠️  coder-labs/jetbrains-fleet: No version found in README, skipping
       ⚠️  coder/.coder: No version found in README, skipping
       ✅ coder/agentapi: v1.1.1 (already tagged)
       ✅ coder/aider: v1.1.2 (already tagged)
       ✅ coder/amazon-dcv-windows: v1.1.1 (already tagged)
       ✅ coder/amazon-q: v1.1.2 (already tagged)
       ✅ coder/aws-region: v1.0.31 (already tagged)
       ✅ coder/azure-region: v1.0.31 (already tagged)
       ✅ coder/claude-code: v2.1.0 (already tagged)
       ✅ coder/code-server: v1.3.1 (already tagged)
       ✅ coder/coder-login: v1.0.31 (already tagged)
       ✅ coder/cursor: v1.3.1 (already tagged)
       ✅ coder/devcontainers-cli: v1.0.32 (already tagged)
       ✅ coder/dotfiles: v1.2.1 (already tagged)
       ✅ coder/filebrowser: v1.1.2 (already tagged)
       ✅ coder/fly-region: v1.0.31 (already tagged)
       ✅ coder/gcp-region: v1.0.31 (already tagged)
       ✅ coder/git-clone: v1.1.1 (already tagged)
       ✅ coder/git-commit-signing: v1.0.31 (already tagged)
       ✅ coder/git-config: v1.0.31 (already tagged)
       ✅ coder/github-upload-public-key: v1.0.31 (already tagged)
       ✅ coder/goose: v2.1.1 (already tagged)
       ✅ coder/hcp-vault-secrets: v1.0.34 (already tagged)
       ✅ coder/jetbrains: v1.0.3 (already tagged)
       ✅ coder/jetbrains-fleet: v1.0.1 (already tagged)
       ✅ coder/jetbrains-gateway: v1.2.2 (already tagged)
       ✅ coder/jfrog-oauth: v1.0.31 (already tagged)
       ✅ coder/jfrog-token: v1.0.31 (already tagged)
       ✅ coder/jupyter-notebook: v1.2.0 (already tagged)
       ✅ coder/jupyterlab: v1.1.1 (already tagged)
       ✅ coder/kasmvnc: v1.2.1 (already tagged)
       ✅ coder/kiro: v1.0.0 (already tagged)
       ✅ coder/local-windows-rdp: v1.0.2 (already tagged)
       ✅ coder/personalize: v1.0.31 (already tagged)
       ✅ coder/slackme: v1.0.31 (already tagged)
       ✅ coder/vault-github: v1.0.31 (already tagged)
       ✅ coder/vault-jwt: v1.1.1 (already tagged)
       ✅ coder/vault-token: v1.2.1 (already tagged)
       ✅ coder/vscode-desktop: v1.1.1 (already tagged)
       ✅ coder/vscode-desktop-core: v1.0.0 (already tagged)
       ✅ coder/vscode-web: v1.3.1 (already tagged)
       ✅ coder/windows-rdp: v1.2.3 (already tagged)
       ✅ coder/windsurf: v1.1.1 (already tagged)
       ✅ coder/zed: v1.1.0 (already tagged)
       ✅ nataindata/apache-airflow: v1.0.14 (already tagged)
       ✅ thezoker/nodejs: v1.0.11 (already tagged)
       ⚠️  whizus/.coder: No version found in README, skipping
       ✅ whizus/exoscale-instance-type: v1.0.13 (already tagged)
       ✅ whizus/exoscale-zone: v1.0.13 (already tagged)

       📊 Summary: 0 of 54 modules need tagging

       ✅ 🎉 All modules are up to date! No tags needed.
```

## After

```console
🚀 Coder Registry Tag Release Script
Operating on commit: 7f9725209fc143014c98c4d750163c88e93338f4

🔍 Scanning all modules for missing release tags...

✅ anomaly/tmux: v1.0.0 (already tagged)
✅ coder-labs/cursor-cli: v0.1.1 (already tagged)
✅ coder-labs/gemini: v1.1.0 (already tagged)
✅ coder/agentapi: v1.1.1 (already tagged)
✅ coder/aider: v1.1.2 (already tagged)
✅ coder/amazon-dcv-windows: v1.1.1 (already tagged)
✅ coder/amazon-q: v1.1.2 (already tagged)
✅ coder/aws-region: v1.0.31 (already tagged)
✅ coder/azure-region: v1.0.31 (already tagged)
✅ coder/claude-code: v2.1.0 (already tagged)
✅ coder/code-server: v1.3.1 (already tagged)
✅ coder/coder-login: v1.0.31 (already tagged)
✅ coder/cursor: v1.3.1 (already tagged)
✅ coder/devcontainers-cli: v1.0.32 (already tagged)
✅ coder/dotfiles: v1.2.1 (already tagged)
✅ coder/filebrowser: v1.1.2 (already tagged)
✅ coder/fly-region: v1.0.31 (already tagged)
✅ coder/gcp-region: v1.0.31 (already tagged)
✅ coder/git-clone: v1.1.1 (already tagged)
✅ coder/git-commit-signing: v1.0.31 (already tagged)
✅ coder/git-config: v1.0.31 (already tagged)
✅ coder/github-upload-public-key: v1.0.31 (already tagged)
✅ coder/goose: v2.1.1 (already tagged)
✅ coder/hcp-vault-secrets: v1.0.34 (already tagged)
✅ coder/jetbrains: v1.0.3 (already tagged)
✅ coder/jetbrains-fleet: v1.0.1 (already tagged)
✅ coder/jetbrains-gateway: v1.2.2 (already tagged)
✅ coder/jfrog-oauth: v1.0.31 (already tagged)
✅ coder/jfrog-token: v1.0.31 (already tagged)
✅ coder/jupyter-notebook: v1.2.0 (already tagged)
✅ coder/jupyterlab: v1.1.1 (already tagged)
✅ coder/kasmvnc: v1.2.1 (already tagged)
✅ coder/kiro: v1.0.0 (already tagged)
✅ coder/local-windows-rdp: v1.0.2 (already tagged)
✅ coder/personalize: v1.0.31 (already tagged)
✅ coder/slackme: v1.0.31 (already tagged)
✅ coder/vault-github: v1.0.31 (already tagged)
✅ coder/vault-jwt: v1.1.1 (already tagged)
✅ coder/vault-token: v1.2.1 (already tagged)
✅ coder/vscode-desktop: v1.1.1 (already tagged)
✅ coder/vscode-desktop-core: v1.0.0 (already tagged)
✅ coder/vscode-web: v1.3.1 (already tagged)
✅ coder/windows-rdp: v1.2.3 (already tagged)
✅ coder/windsurf: v1.1.1 (already tagged)
✅ coder/zed: v1.1.0 (already tagged)
✅ nataindata/apache-airflow: v1.0.14 (already tagged)
✅ thezoker/nodejs: v1.0.11 (already tagged)
✅ whizus/exoscale-instance-type: v1.0.13 (already tagged)
✅ whizus/exoscale-zone: v1.0.13 (already tagged)

📊 Summary: 0 of 49 modules need tagging

✅ 🎉 All modules are up to date! No tags needed.
```