### PR TITLE
fix: use correct app slug for status reporting

### DIFF
--- a/registry/coder-labs/templates/tasks-docker/main.tf
+++ b/registry/coder-labs/templates/tasks-docker/main.tf
@@ -181,7 +181,7 @@ resource "coder_env" "claude_task_prompt" {
 resource "coder_env" "app_status_slug" {
   agent_id = coder_agent.main.id
   name     = "CODER_MCP_APP_STATUS_SLUG"
-  value    = "claude-code"
+  value    = "ccw"
 }
 resource "coder_env" "claude_system_prompt" {
   agent_id = coder_agent.main.id


### PR DESCRIPTION
## Description

I don't know how long this was broken for, but we had a [customer run into this](https://codercom.slack.com/archives/C04EHNF3A0Y/p1755635729486939). I also noticed that the MCP seemed to still report "ok" when this was reported with the wrong slug. Ultimately, I'm not sure if this should even be in our example template or if it should be in the module itself, or if its needed at all. Perhaps @35C4n0r, @matifali, or @DevelopmentCats has thoughts on how we can improve this UX overall.

## Type of Change

- [ ] New module
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other