### PR TITLE
feat: add conda support to JFrog modules

### DIFF
--- a/registry/coder/modules/jfrog-oauth/README.md
+++ b/registry/coder/modules/jfrog-oauth/README.md
@@ -26,6 +26,7 @@ module "jfrog" {
     go     = ["go", "another-go-repo"]
     pypi   = ["pypi", "extra-index-pypi"]
     docker = ["example-docker-staging.jfrog.io", "example-docker-production.jfrog.io"]
+    conda  = ["conda", "conda-local"]
   }
 }
 ```

--- a/registry/coder/modules/jfrog-oauth/conda.conf.tftpl
+++ b/registry/coder/modules/jfrog-oauth/conda.conf.tftpl
@@ -1,0 +1,6 @@
+channels:
+%{ for REPO in REPOS ~}
+  - https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_ACCESS_TOKEN}@${JFROG_HOST}/artifactory/api/conda/${REPO}
+%{ endfor ~}
+  - defaults
+ssl_verify: true

--- a/registry/coder/modules/jfrog-oauth/main.test.ts
+++ b/registry/coder/modules/jfrog-oauth/main.test.ts
@@ -126,4 +126,28 @@ EOF`;
       'if [ -z "YES" ]; then\n  not_configured go',
     );
   });
+
+  it("generates a conda config with multiple repos", async () => {
+    const state = await runTerraformApply<TestVariables>(import.meta.dir, {
+      agent_id: "some-agent-id",
+      jfrog_url: fakeFrogUrl,
+      package_managers: JSON.stringify({
+        conda: ["conda-main", "conda-secondary", "conda-local"],
+      }),
+    });
+    const coderScript = findResourceInstance(state, "coder_script");
+    const condaStanza = `cat << EOF > ~/.condarc
+channels:
+  - https://${user}:@${fakeFrogApi}/conda/conda-main
+  - https://${user}:@${fakeFrogApi}/conda/conda-secondary
+  - https://${user}:@${fakeFrogApi}/conda/conda-local
+  - defaults
+ssl_verify: true
+
+EOF`;
+    expect(coderScript.script).toContain(condaStanza);
+    expect(coderScript.script).toContain(
+      'if [ -z "YES" ]; then\n  not_configured conda',
+    );
+  });
 });

--- a/registry/coder/modules/jfrog-oauth/run.sh
+++ b/registry/coder/modules/jfrog-oauth/run.sh
@@ -81,6 +81,19 @@ else
   fi
 fi
 
+# Configure conda to use the Artifactory "conda" repository.
+if [ -z "${HAS_CONDA}" ]; then
+  not_configured conda
+else
+  echo "🐍 Configuring conda..."
+  # Create conda config directory if it doesn't exist
+  mkdir -p ~/.conda
+  cat << EOF > ~/.condarc
+${CONDA_CONF}
+EOF
+  config_complete
+fi
+
 # Install the JFrog vscode extension for code-server.
 if [ "${CONFIGURE_CODE_SERVER}" == "true" ]; then
   while ! [ -x /tmp/code-server/bin/code-server ]; do

--- a/registry/coder/modules/jfrog-token/README.md
+++ b/registry/coder/modules/jfrog-token/README.md
@@ -22,6 +22,7 @@ module "jfrog" {
     go     = ["go", "another-go-repo"]
     pypi   = ["pypi", "extra-index-pypi"]
     docker = ["example-docker-staging.jfrog.io", "example-docker-production.jfrog.io"]
+    conda  = ["conda", "conda-local"]
   }
 }
 ```
@@ -45,25 +46,28 @@ module "jfrog" {
   jfrog_url                = "https://YYYY.jfrog.io"
   artifactory_access_token = var.artifactory_access_token # An admin access token
   package_managers = {
-    npm  = ["npm-local"]
-    go   = ["go-local"]
-    pypi = ["pypi-local"]
+    npm   = ["npm-local"]
+    go    = ["go-local"]
+    pypi  = ["pypi-local"]
+    conda = ["conda-local"]
   }
 }
 ```
 
-You should now be able to install packages from Artifactory using both the `jf npm`, `jf go`, `jf pip` and `npm`, `go`, `pip` commands.
+You should now be able to install packages from Artifactory using both the `jf npm`, `jf go`, `jf pip` and `npm`, `go`, `pip`, `conda` commands.
 
 ```shell
 jf npm install prettier
 jf go get github.com/golang/example/hello
 jf pip install requests
+conda install numpy
 ```
 
 ```shell
 npm install prettier
 go get github.com/golang/example/hello
 pip install requests
+conda install numpy
 ```
 
 ### Configure code-server with JFrog extension

--- a/registry/coder/modules/jfrog-token/conda.conf.tftpl
+++ b/registry/coder/modules/jfrog-token/conda.conf.tftpl
@@ -1,0 +1,6 @@
+channels:
+%{ for REPO in REPOS ~}
+  - https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_ACCESS_TOKEN}@${JFROG_HOST}/artifactory/api/conda/${REPO}
+%{ endfor ~}
+  - defaults
+ssl_verify: true

--- a/registry/coder/modules/jfrog-token/main.tf
+++ b/registry/coder/modules/jfrog-token/main.tf
@@ -91,6 +91,7 @@ variable "package_managers" {
     go     = optional(list(string), [])
     pypi   = optional(list(string), [])
     docker = optional(list(string), [])
+    conda  = optional(list(string), [])
   })
   description = <<-EOF
     A map of package manager names to their respective artifactory repositories. Unused package managers can be omitted.
@@ -100,6 +101,7 @@ variable "package_managers" {
         go     = ["YOUR_GO_REPO_KEY", "ANOTHER_GO_REPO_KEY"]
         pypi   = ["YOUR_PYPI_REPO_KEY", "ANOTHER_PYPI_REPO_KEY"]
         docker = ["YOUR_DOCKER_REPO_KEY", "ANOTHER_DOCKER_REPO_KEY"]
+        conda  = ["YOUR_CONDA_REPO_KEY", "ANOTHER_CONDA_REPO_KEY"]
       }
   EOF
 }
@@ -130,6 +132,9 @@ locals {
   )
   pip_conf = templatefile(
     "${path.module}/pip.conf.tftpl", merge(local.common_values, { REPOS = var.package_managers.pypi })
+  )
+  conda_conf = templatefile(
+    "${path.module}/conda.conf.tftpl", merge(local.common_values, { REPOS = var.package_managers.conda })
   )
 }
 
@@ -171,6 +176,9 @@ resource "coder_script" "jfrog" {
       REPOSITORY_PYPI       = try(element(var.package_managers.pypi, 0), "")
       HAS_DOCKER            = length(var.package_managers.docker) == 0 ? "" : "YES"
       REGISTER_DOCKER       = join("\n", formatlist("register_docker \"%s\"", var.package_managers.docker))
+      HAS_CONDA             = length(var.package_managers.conda) == 0 ? "" : "YES"
+      CONDA_CONF            = local.conda_conf
+      REPOSITORY_CONDA      = try(element(var.package_managers.conda, 0), "")
     }
   ))
   run_on_start = true

--- a/registry/coder/modules/jfrog-token/run.sh
+++ b/registry/coder/modules/jfrog-token/run.sh
@@ -80,6 +80,19 @@ else
   fi
 fi
 
+# Configure conda to use the Artifactory "conda" repository.
+if [ -z "${HAS_CONDA}" ]; then
+  not_configured conda
+else
+  echo "🐍 Configuring conda..."
+  # Create conda config directory if it doesn't exist
+  mkdir -p ~/.conda
+  cat << EOF > ~/.condarc
+${CONDA_CONF}
+EOF
+  config_complete
+fi
+
 # Install the JFrog vscode extension for code-server.
 if [ "${CONFIGURE_CODE_SERVER}" == "true" ]; then
   while ! [ -x /tmp/code-server/bin/code-server ]; do


### PR DESCRIPTION
Closes #34 

## Description
Jfrog Modules doesn't support conda package manager, This PR adds support of that

## Type of Change

- [x] Feature/enhancement
- [x] Documentation

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun run fmt`)
- [x] Changes tested locally

## Related Issues
#34 
/claim #34 
