### PR TITLE
fix(ci): add fallback for GitHub API failures in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,13 +73,15 @@ jobs:
             exit 0
           fi
           
-          FULL_CHANGELOG=$(gh api repos/:owner/:repo/releases/generate-notes \
-            --field tag_name="$CURRENT_TAG" \
-            --field previous_tag_name="$PREV_TAG" \
-            --jq '.body' 2>/dev/null) || {
-            echo "GitHub API failed (likely new module), proceeding with git-based changelog"
+          if [[ "$PREV_TAG" == release/* ]]; then
+            FULL_CHANGELOG=$(gh api repos/:owner/:repo/releases/generate-notes \
+              --field tag_name="$CURRENT_TAG" \
+              --field previous_tag_name="$PREV_TAG" \
+              --jq '.body')
+          else
+            echo "New module detected, skipping GitHub API"
             FULL_CHANGELOG=""
-          }
+          fi
           
           MODULE_COMMIT_SHAS=$(git log --format="%H" --no-merges "$PREV_TAG..$CURRENT_TAG" -- "$MODULE_PATH")
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,10 @@ jobs:
           FULL_CHANGELOG=$(gh api repos/:owner/:repo/releases/generate-notes \
             --field tag_name="$CURRENT_TAG" \
             --field previous_tag_name="$PREV_TAG" \
-            --jq '.body')
+            --jq '.body' 2>/dev/null) || {
+            echo "GitHub API failed (likely new module), proceeding with git-based changelog"
+            FULL_CHANGELOG=$(git log --pretty=format:"* %s by %an" --no-merges "$PREV_TAG..$CURRENT_TAG" -- "$MODULE_PATH")
+          }
           
           MODULE_COMMIT_SHAS=$(git log --format="%H" --no-merges "$PREV_TAG..$CURRENT_TAG" -- "$MODULE_PATH")
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
             --field previous_tag_name="$PREV_TAG" \
             --jq '.body' 2>/dev/null) || {
             echo "GitHub API failed (likely new module), proceeding with git-based changelog"
-            FULL_CHANGELOG=$(git log --pretty=format:"* %s by %an" --no-merges "$PREV_TAG..$CURRENT_TAG" -- "$MODULE_PATH")
+            FULL_CHANGELOG=""
           }
           
           MODULE_COMMIT_SHAS=$(git log --format="%H" --no-merges "$PREV_TAG..$CURRENT_TAG" -- "$MODULE_PATH")


### PR DESCRIPTION
## Description

CI was failing on new module releases because there was no fallback to gh api failures when there was no previous tag for the module was found.

https://github.com/coder/registry/actions/runs/17225186737/job/48868318539

<!-- Briefly describe what this PR does and why -->

## Type of Change

- [ ] New module
- [ ] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [X] Other
