### PR TITLE
Add maven package manager support to JFrog modules

### DIFF
--- a/registry/coder/modules/jfrog-oauth/README.md
+++ b/registry/coder/modules/jfrog-oauth/README.md
@@ -26,12 +26,13 @@ module "jfrog" {
     go     = ["go", "another-go-repo"]
     pypi   = ["pypi", "extra-index-pypi"]
     docker = ["example-docker-staging.jfrog.io", "example-docker-production.jfrog.io"]
+    maven  = ["maven-local", "maven-virtual"]
   }
 }
 ```
 
 > Note
-> This module does not install `npm`, `go`, `pip`, etc but only configure them. You need to handle the installation of these tools yourself.
+> This module does not install `npm`, `go`, `pip`, `maven`, etc but only configure them. You need to handle the installation of these tools yourself.
 
 ## Prerequisites
 
@@ -80,9 +81,10 @@ module "jfrog" {
   username_field        = "username" # If you are using GitHub to login to both Coder and Artifactory, use username_field = "username"
   configure_code_server = true       # Add JFrog extension configuration for code-server
   package_managers = {
-    npm  = ["npm"]
-    go   = ["go"]
-    pypi = ["pypi"]
+    npm   = ["npm"]
+    go    = ["go"]
+    pypi  = ["pypi"]
+    maven = ["maven"]
   }
 }
 ```

--- a/registry/coder/modules/jfrog-oauth/main.test.ts
+++ b/registry/coder/modules/jfrog-oauth/main.test.ts
@@ -126,4 +126,24 @@ EOF`;
       'if [ -z "YES" ]; then\n  not_configured go',
     );
   });
+
+  it("generates Maven settings.xml with OAuth authentication", async () => {
+    const state = await runTerraformApply<TestVariables>(import.meta.dir, {
+      agent_id: "some-agent-id",
+      jfrog_url: fakeFrogUrl,
+      package_managers: JSON.stringify({
+        maven: ["maven-local", "maven-remote"],
+      }),
+    });
+    const coderScript = findResourceInstance(state, "coder_script");
+
+    // Check that Maven settings.xml is created
+    expect(coderScript.script).toContain("~/.m2/settings.xml");
+    expect(coderScript.script).toContain(
+      'jf mvnc --global --repo-resolve "maven-local"',
+    );
+    expect(coderScript.script).toContain(
+      'if [ -z "YES" ]; then\n  not_configured maven',
+    );
+  });
 });

--- a/registry/coder/modules/jfrog-oauth/main.tf
+++ b/registry/coder/modules/jfrog-oauth/main.tf
@@ -58,6 +58,7 @@ variable "package_managers" {
     go     = optional(list(string), [])
     pypi   = optional(list(string), [])
     docker = optional(list(string), [])
+    maven  = optional(list(string), [])
   })
   description = <<-EOF
     A map of package manager names to their respective artifactory repositories. Unused package managers can be omitted.
@@ -67,6 +68,7 @@ variable "package_managers" {
         go     = ["YOUR_GO_REPO_KEY", "ANOTHER_GO_REPO_KEY"]
         pypi   = ["YOUR_PYPI_REPO_KEY", "ANOTHER_PYPI_REPO_KEY"]
         docker = ["YOUR_DOCKER_REPO_KEY", "ANOTHER_DOCKER_REPO_KEY"]
+        maven  = ["YOUR_MAVEN_REPO_KEY", "ANOTHER_MAVEN_REPO_KEY"]
       }
   EOF
 }
@@ -98,6 +100,9 @@ locals {
   pip_conf = templatefile(
     "${path.module}/pip.conf.tftpl", merge(local.common_values, { REPOS = var.package_managers.pypi })
   )
+  settings_xml = templatefile(
+    "${path.module}/settings.xml.tftpl", merge(local.common_values, { REPOS = var.package_managers.maven })
+  )
 }
 
 data "coder_workspace" "me" {}
@@ -125,6 +130,9 @@ resource "coder_script" "jfrog" {
       REPOSITORY_PYPI       = try(element(var.package_managers.pypi, 0), "")
       HAS_DOCKER            = length(var.package_managers.docker) == 0 ? "" : "YES"
       REGISTER_DOCKER       = join("\n", formatlist("register_docker \"%s\"", var.package_managers.docker))
+      HAS_MAVEN             = length(var.package_managers.maven) == 0 ? "" : "YES"
+      SETTINGS_XML          = local.settings_xml
+      REPOSITORY_MAVEN      = try(element(var.package_managers.maven, 0), "")
     }
   ))
   run_on_start = true

--- a/registry/coder/modules/jfrog-oauth/run.sh
+++ b/registry/coder/modules/jfrog-oauth/run.sh
@@ -81,6 +81,19 @@ else
   fi
 fi
 
+# Configure Maven to use the Artifactory "maven" repository.
+if [ -z "${HAS_MAVEN}" ]; then
+  not_configured maven
+else
+  echo "☕ Configuring Maven..."
+  jf mvnc --global --repo-resolve "${REPOSITORY_MAVEN}"
+  mkdir -p ~/.m2
+  cat << EOF > ~/.m2/settings.xml
+${SETTINGS_XML}
+EOF
+  config_complete
+fi
+
 # Install the JFrog vscode extension for code-server.
 if [ "${CONFIGURE_CODE_SERVER}" == "true" ]; then
   while ! [ -x /tmp/code-server/bin/code-server ]; do
@@ -111,7 +124,7 @@ begin_stanza="# BEGIN: jf CLI shell completion (added by coder module jfrog-oaut
 if [ "$SHELLNAME" == "bash" ] && [ -f ~/.bashrc ]; then
   if ! grep -q "$begin_stanza" ~/.bashrc; then
     printf "%s\n" "$begin_stanza" >> ~/.bashrc
-    echo 'source "$HOME/.jfrog/jfrog_bash_completion"' >> ~/.bashrc
+    echo '[ -f "$HOME/.jfrog/jfrog_bash_completion" ] && source "$HOME/.jfrog/jfrog_bash_completion"' >> ~/.bashrc
     echo "# END: jf CLI shell completion" >> ~/.bashrc
   else
     echo "🥳 ~/.bashrc already contains jf CLI shell completion configuration, skipping."
@@ -121,7 +134,7 @@ elif [ "$SHELLNAME" == "zsh" ] && [ -f ~/.zshrc ]; then
     printf "\n%s\n" "$begin_stanza" >> ~/.zshrc
     echo "autoload -Uz compinit" >> ~/.zshrc
     echo "compinit" >> ~/.zshrc
-    echo 'source "$HOME/.jfrog/jfrog_zsh_completion"' >> ~/.zshrc
+    echo '[ -f "$HOME/.jfrog/jfrog_zsh_completion" ] && source "$HOME/.jfrog/jfrog_zsh_completion"' >> ~/.zshrc
     echo "# END: jf CLI shell completion" >> ~/.zshrc
   else
     echo "🥳 ~/.zshrc already contains jf CLI shell completion configuration, skipping."

--- a/registry/coder/modules/jfrog-oauth/settings.xml.tftpl
+++ b/registry/coder/modules/jfrog-oauth/settings.xml.tftpl
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+%{ for REPO in REPOS ~}
+    <server>
+      <id>${REPO}</id>
+      <username>${ARTIFACTORY_USERNAME}</username>
+      <password>${ARTIFACTORY_ACCESS_TOKEN}</password>
+    </server>
+%{ endfor ~}
+  </servers>
+  <profiles>
+    <profile>
+      <id>artifactory</id>
+      <repositories>
+%{ for REPO in REPOS ~}
+        <repository>
+          <id>${REPO}</id>
+          <url>${JFROG_URL}/artifactory/${REPO}</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+%{ endfor ~}
+      </repositories>
+      <pluginRepositories>
+%{ for REPO in REPOS ~}
+        <pluginRepository>
+          <id>${REPO}</id>
+          <url>${JFROG_URL}/artifactory/${REPO}</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+%{ endfor ~}
+      </pluginRepositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>artifactory</activeProfile>
+  </activeProfiles>
+</settings>

--- a/registry/coder/modules/jfrog-token/README.md
+++ b/registry/coder/modules/jfrog-token/README.md
@@ -22,6 +22,7 @@ module "jfrog" {
     go     = ["go", "another-go-repo"]
     pypi   = ["pypi", "extra-index-pypi"]
     docker = ["example-docker-staging.jfrog.io", "example-docker-production.jfrog.io"]
+    maven  = ["maven-local", "maven-virtual"]
   }
 }
 ```
@@ -29,13 +30,13 @@ module "jfrog" {
 For detailed instructions, please see this [guide](https://coder.com/docs/v2/latest/guides/artifactory-integration#jfrog-token) on the Coder documentation.
 
 > Note
-> This module does not install `npm`, `go`, `pip`, etc but only configure them. You need to handle the installation of these tools yourself.
+> This module does not install `npm`, `go`, `pip`, `maven`, etc but only configure them. You need to handle the installation of these tools yourself.
 
 ![JFrog](../../.images/jfrog.png)
 
 ## Examples
 
-### Configure npm, go, and pypi to use Artifactory local repositories
+### Configure npm, go, pypi, and maven to use Artifactory local repositories
 
 ```tf
 module "jfrog" {
@@ -45,25 +46,28 @@ module "jfrog" {
   jfrog_url                = "https://YYYY.jfrog.io"
   artifactory_access_token = var.artifactory_access_token # An admin access token
   package_managers = {
-    npm  = ["npm-local"]
-    go   = ["go-local"]
-    pypi = ["pypi-local"]
+    npm   = ["npm-local"]
+    go    = ["go-local"]
+    pypi  = ["pypi-local"]
+    maven = ["maven-local"]
   }
 }
 ```
 
-You should now be able to install packages from Artifactory using both the `jf npm`, `jf go`, `jf pip` and `npm`, `go`, `pip` commands.
+You should now be able to install packages from Artifactory using both the `jf npm`, `jf go`, `jf pip`, `jf mvn` and `npm`, `go`, `pip`, `mvn` commands.
 
 ```shell
 jf npm install prettier
 jf go get github.com/golang/example/hello
 jf pip install requests
+jf mvn compile
 ```
 
 ```shell
 npm install prettier
 go get github.com/golang/example/hello
 pip install requests
+mvn compile
 ```
 
 ### Configure code-server with JFrog extension
@@ -79,9 +83,10 @@ module "jfrog" {
   artifactory_access_token = var.artifactory_access_token
   configure_code_server    = true # Add JFrog extension configuration for code-server
   package_managers = {
-    npm  = ["npm"]
-    go   = ["go"]
-    pypi = ["pypi"]
+    npm   = ["npm"]
+    go    = ["go"]
+    pypi  = ["pypi"]
+    maven = ["maven"]
   }
 }
 ```

--- a/registry/coder/modules/jfrog-token/main.test.ts
+++ b/registry/coder/modules/jfrog-token/main.test.ts
@@ -162,4 +162,25 @@ EOF`;
       'if [ -z "YES" ]; then\n  not_configured go',
     );
   });
+
+  it("generates Maven settings.xml with multiple repositories", async () => {
+    const state = await runTerraformApply<TestVariables>(import.meta.dir, {
+      agent_id: "some-agent-id",
+      jfrog_url: fakeFrogUrl,
+      artifactory_access_token: "XXXX",
+      package_managers: JSON.stringify({
+        maven: ["maven-local", "maven-remote"],
+      }),
+    });
+    const coderScript = findResourceInstance(state, "coder_script");
+
+    // Check that Maven settings.xml is created
+    expect(coderScript.script).toContain("~/.m2/settings.xml");
+    expect(coderScript.script).toContain(
+      'jf mvnc --global --repo-resolve "maven-local"',
+    );
+    expect(coderScript.script).toContain(
+      'if [ -z "YES" ]; then\n  not_configured maven',
+    );
+  });
 });

--- a/registry/coder/modules/jfrog-token/main.tf
+++ b/registry/coder/modules/jfrog-token/main.tf
@@ -91,6 +91,7 @@ variable "package_managers" {
     go     = optional(list(string), [])
     pypi   = optional(list(string), [])
     docker = optional(list(string), [])
+    maven  = optional(list(string), [])
   })
   description = <<-EOF
     A map of package manager names to their respective artifactory repositories. Unused package managers can be omitted.
@@ -100,6 +101,7 @@ variable "package_managers" {
         go     = ["YOUR_GO_REPO_KEY", "ANOTHER_GO_REPO_KEY"]
         pypi   = ["YOUR_PYPI_REPO_KEY", "ANOTHER_PYPI_REPO_KEY"]
         docker = ["YOUR_DOCKER_REPO_KEY", "ANOTHER_DOCKER_REPO_KEY"]
+        maven  = ["YOUR_MAVEN_REPO_KEY", "ANOTHER_MAVEN_REPO_KEY"]
       }
   EOF
 }
@@ -130,6 +132,9 @@ locals {
   )
   pip_conf = templatefile(
     "${path.module}/pip.conf.tftpl", merge(local.common_values, { REPOS = var.package_managers.pypi })
+  )
+  settings_xml = templatefile(
+    "${path.module}/settings.xml.tftpl", merge(local.common_values, { REPOS = var.package_managers.maven })
   )
 }
 
@@ -171,6 +176,9 @@ resource "coder_script" "jfrog" {
       REPOSITORY_PYPI       = try(element(var.package_managers.pypi, 0), "")
       HAS_DOCKER            = length(var.package_managers.docker) == 0 ? "" : "YES"
       REGISTER_DOCKER       = join("\n", formatlist("register_docker \"%s\"", var.package_managers.docker))
+      HAS_MAVEN             = length(var.package_managers.maven) == 0 ? "" : "YES"
+      SETTINGS_XML          = local.settings_xml
+      REPOSITORY_MAVEN      = try(element(var.package_managers.maven, 0), "")
     }
   ))
   run_on_start = true

--- a/registry/coder/modules/jfrog-token/run.sh
+++ b/registry/coder/modules/jfrog-token/run.sh
@@ -80,6 +80,19 @@ else
   fi
 fi
 
+# Configure Maven to use the Artifactory "maven" repository.
+if [ -z "${HAS_MAVEN}" ]; then
+  not_configured maven
+else
+  echo "☕ Configuring Maven..."
+  jf mvnc --global --repo-resolve "${REPOSITORY_MAVEN}"
+  mkdir -p ~/.m2
+  cat << EOF > ~/.m2/settings.xml
+${SETTINGS_XML}
+EOF
+  config_complete
+fi
+
 # Install the JFrog vscode extension for code-server.
 if [ "${CONFIGURE_CODE_SERVER}" == "true" ]; then
   while ! [ -x /tmp/code-server/bin/code-server ]; do
@@ -110,7 +123,7 @@ begin_stanza="# BEGIN: jf CLI shell completion (added by coder module jfrog-toke
 if [ "$SHELLNAME" == "bash" ] && [ -f ~/.bashrc ]; then
   if ! grep -q "$begin_stanza" ~/.bashrc; then
     printf "%s\n" "$begin_stanza" >> ~/.bashrc
-    echo 'source "$HOME/.jfrog/jfrog_bash_completion"' >> ~/.bashrc
+    echo '[ -f "$HOME/.jfrog/jfrog_bash_completion" ] && source "$HOME/.jfrog/jfrog_bash_completion"' >> ~/.bashrc
     echo "# END: jf CLI shell completion" >> ~/.bashrc
   else
     echo "🥳 ~/.bashrc already contains jf CLI shell completion configuration, skipping."
@@ -120,7 +133,7 @@ elif [ "$SHELLNAME" == "zsh" ] && [ -f ~/.zshrc ]; then
     printf "\n%s\n" "$begin_stanza" >> ~/.zshrc
     echo "autoload -Uz compinit" >> ~/.zshrc
     echo "compinit" >> ~/.zshrc
-    echo 'source "$HOME/.jfrog/jfrog_zsh_completion"' >> ~/.zshrc
+    echo '[ -f "$HOME/.jfrog/jfrog_zsh_completion" ] && source "$HOME/.jfrog/jfrog_zsh_completion"' >> ~/.zshrc
     echo "# END: jf CLI shell completion" >> ~/.zshrc
   else
     echo "🥳 ~/.zshrc already contains jf CLI shell completion configuration, skipping."

--- a/registry/coder/modules/jfrog-token/settings.xml.tftpl
+++ b/registry/coder/modules/jfrog-token/settings.xml.tftpl
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+%{ for REPO in REPOS ~}
+    <server>
+      <id>${REPO}</id>
+      <username>${ARTIFACTORY_USERNAME}</username>
+      <password>${ARTIFACTORY_ACCESS_TOKEN}</password>
+    </server>
+%{ endfor ~}
+  </servers>
+  <profiles>
+    <profile>
+      <id>artifactory</id>
+      <repositories>
+%{ for REPO in REPOS ~}
+        <repository>
+          <id>${REPO}</id>
+          <url>${JFROG_URL}/artifactory/${REPO}</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+%{ endfor ~}
+      </repositories>
+      <pluginRepositories>
+%{ for REPO in REPOS ~}
+        <pluginRepository>
+          <id>${REPO}</id>
+          <url>${JFROG_URL}/artifactory/${REPO}</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+%{ endfor ~}
+      </pluginRepositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>artifactory</activeProfile>
+  </activeProfiles>
+</settings>


### PR DESCRIPTION
Closes #33 

## Description

Jfrog Modules doesn't support conda package manager, This PR adds support of that

## Type of Change

- [ ] New module
- [ ] Bug fix
- [x] Feature/enhancement
- [x] Documentation
- [ ] Other
## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun run fmt`)
- [x] Changes tested locally

## Related Issues
#33 
