### PR TITLE
goose module: pass folder along to agentapi

### DIFF
--- a/registry/coder/modules/goose/README.md
+++ b/registry/coder/modules/goose/README.md
@@ -13,7 +13,7 @@ Run the [Goose](https://block.github.io/goose/) agent in your workspace to gener
 ```tf
 module "goose" {
   source           = "registry.coder.com/coder/goose/coder"
-  version          = "2.2.0"
+  version          = "2.2.1"
   agent_id         = coder_agent.example.id
   folder           = "/home/coder"
   install_goose    = true
@@ -79,7 +79,7 @@ resource "coder_agent" "main" {
 module "goose" {
   count            = data.coder_workspace.me.start_count
   source           = "registry.coder.com/coder/goose/coder"
-  version          = "2.2.0"
+  version          = "2.2.1"
   agent_id         = coder_agent.example.id
   folder           = "/home/coder"
   install_goose    = true

--- a/registry/coder/modules/goose/main.tf
+++ b/registry/coder/modules/goose/main.tf
@@ -135,6 +135,7 @@ EOT
   install_script        = file("${path.module}/scripts/install.sh")
   start_script          = file("${path.module}/scripts/start.sh")
   module_dir_name       = ".goose-module"
+  folder                = trimsuffix(var.folder, "/")
 }
 
 module "agentapi" {
@@ -156,7 +157,7 @@ module "agentapi" {
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script
   start_script         = local.start_script
-  folder               = var.folder
+  folder               = local.folder
   install_script       = <<-EOT
     #!/bin/bash
     set -o errexit


### PR DESCRIPTION
Closes #

## Description

While playing with the new tasks feature I tried to setup Goose with a non-standard home directory.
Goose installs correctly but when trying to start agent-api it tries to start in a non-existant directory `/home/coder`
This PR passes the goose modules `folder` var to the agentapi module.

## Type of Change

- [ ] New module
- [X] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

<!-- Delete this section if not applicable -->

**Path:** `registry/coder/modules/goose`  
**New version:** `v1.0.0`  
**Breaking change:** [ ] Yes [X] No

## Testing & Validation

- [X] Tests pass (`bun test`)
- [X] Code formatted (`bun run fmt`)
- [X] Changes tested locally

## Related Issues

<!-- Link related issues or write "None" if not applicable -->
