### PR TITLE
chore: fix for jetbrains gateway agent_id issue

### DIFF
--- a/registry/coder/modules/jetbrains-gateway/README.md
+++ b/registry/coder/modules/jetbrains-gateway/README.md
@@ -19,7 +19,7 @@ Consult the [JetBrains documentation](https://www.jetbrains.com/help/idea/prereq
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.3"
+  version        = "1.2.4"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["CL", "GO", "IU", "PY", "WS"]
@@ -37,7 +37,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.3"
+  version        = "1.2.4"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["GO", "WS"]
@@ -51,7 +51,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.3"
+  version        = "1.2.4"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["IU", "PY"]
@@ -66,7 +66,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.3"
+  version        = "1.2.4"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["IU", "PY"]
@@ -91,7 +91,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.3"
+  version        = "1.2.4"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["GO", "WS"]
@@ -109,7 +109,7 @@ Due to the highest priority of the `ide_download_link` parameter in the `(jetbra
 module "jetbrains_gateway" {
   count              = data.coder_workspace.me.start_count
   source             = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version            = "1.2.3"
+  version            = "1.2.4"
   agent_id           = coder_agent.example.id
   folder             = "/home/coder/example"
   jetbrains_ides     = ["GO", "WS"]

--- a/registry/coder/modules/jetbrains-gateway/README.md
+++ b/registry/coder/modules/jetbrains-gateway/README.md
@@ -43,6 +43,43 @@ module "jetbrains_gateway" {
 }
 ```
 
+### Embed the agent name in the Gateway URL
+
+This can be used when support for connecting to multiple agents within one workspace is required.
+
+To utilise this both `embed_agent_id` and `agent_name` must be populated on each instance of the module.
+In addition each instance must have a unique `slug` and `ide_parameter_name` variable defined.
+
+```tf
+module "jetbrains_gateway" {
+  count              = data.coder_workspace.me.start_count
+  source             = "registry.coder.com/coder/jetbrains-gateway/coder"
+  version            = "1.2.3"
+  agent_id           = coder_agent.example.id
+  folder             = "/home/coder/example"
+  jetbrains_ides     = ["CL", "GO"]
+  default            = "GO"
+  embed_agent_id     = true
+  agent_name         = "main"
+  ide_parameter_name = "jetbrains_ide" # default variable value
+  slug               = "gateway"       # default variable value
+}
+
+module "jetbrains_gateway_agent2" {
+  count              = data.coder_workspace.me.start_count
+  source             = "registry.coder.com/coder/jetbrains-gateway/coder"
+  version            = "1.2.3"
+  agent_id           = coder_agent.jetbrainsagent2.id
+  folder             = "/home/coder/example"
+  jetbrains_ides     = ["CL", "GO", "IU", "PY", "WS"]
+  default            = "GO"
+  embed_agent_id     = true
+  agent_name         = "jetbrainsagent2"
+  ide_parameter_name = "jetbrains_ide_agent2"
+  slug               = "gateway-agent2"
+}
+```
+
 ### Use the latest version of each IDE
 
 ```tf

--- a/registry/coder/modules/jetbrains-gateway/README.md
+++ b/registry/coder/modules/jetbrains-gateway/README.md
@@ -43,43 +43,6 @@ module "jetbrains_gateway" {
 }
 ```
 
-### Embed the agent name in the Gateway URL
-
-This can be used when support for connecting to multiple agents within one workspace is required.
-
-To utilise this both `embed_agent_name` and `agent_name` must be populated on each instance of the module.
-In addition each instance must have a unique `slug` and `ide_parameter_name` variable defined.
-
-```tf
-module "jetbrains_gateway" {
-  count              = data.coder_workspace.me.start_count
-  source             = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version            = "1.2.3"
-  agent_id           = coder_agent.example.id
-  folder             = "/home/coder/example"
-  jetbrains_ides     = ["CL", "GO"]
-  default            = "GO"
-  embed_agent_name   = true
-  agent_name         = "main"
-  ide_parameter_name = "jetbrains_ide" # default variable value
-  slug               = "gateway"       # default variable value
-}
-
-module "jetbrains_gateway_agent2" {
-  count              = data.coder_workspace.me.start_count
-  source             = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version            = "1.2.3"
-  agent_id           = coder_agent.jetbrainsagent2.id
-  folder             = "/home/coder/example"
-  jetbrains_ides     = ["CL", "GO", "IU", "PY", "WS"]
-  default            = "GO"
-  embed_agent_name   = true
-  agent_name         = "jetbrainsagent2"
-  ide_parameter_name = "jetbrains_ide_agent2"
-  slug               = "gateway-agent2"
-}
-```
-
 ### Use the latest version of each IDE
 
 ```tf

--- a/registry/coder/modules/jetbrains-gateway/README.md
+++ b/registry/coder/modules/jetbrains-gateway/README.md
@@ -19,7 +19,7 @@ Consult the [JetBrains documentation](https://www.jetbrains.com/help/idea/prereq
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version = "1.2.3"
+  version        = "1.2.3"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["CL", "GO", "IU", "PY", "WS"]
@@ -37,7 +37,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version = "1.2.3"
+  version        = "1.2.3"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["GO", "WS"]
@@ -51,7 +51,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version = "1.2.3"
+  version        = "1.2.3"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["IU", "PY"]
@@ -66,7 +66,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version = "1.2.3"
+  version        = "1.2.3"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["IU", "PY"]
@@ -91,7 +91,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version = "1.2.3"
+  version        = "1.2.3"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["GO", "WS"]
@@ -109,7 +109,7 @@ Due to the highest priority of the `ide_download_link` parameter in the `(jetbra
 module "jetbrains_gateway" {
   count              = data.coder_workspace.me.start_count
   source             = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version = "1.2.3"
+  version        = "1.2.3"
   agent_id           = coder_agent.example.id
   folder             = "/home/coder/example"
   jetbrains_ides     = ["GO", "WS"]

--- a/registry/coder/modules/jetbrains-gateway/README.md
+++ b/registry/coder/modules/jetbrains-gateway/README.md
@@ -17,7 +17,7 @@ Consult the [JetBrains documentation](https://www.jetbrains.com/help/idea/prereq
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.2"
+  version        = "1.2.3"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["CL", "GO", "IU", "PY", "WS"]
@@ -35,7 +35,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.2"
+  version        = "1.2.3"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["GO", "WS"]
@@ -49,7 +49,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.2"
+  version        = "1.2.3"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["IU", "PY"]
@@ -64,7 +64,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.2"
+  version        = "1.2.3"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["IU", "PY"]
@@ -89,7 +89,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.2"
+  version        = "1.2.3"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["GO", "WS"]
@@ -107,7 +107,7 @@ Due to the highest priority of the `ide_download_link` parameter in the `(jetbra
 module "jetbrains_gateway" {
   count              = data.coder_workspace.me.start_count
   source             = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version            = "1.2.2"
+  version            = "1.2.3"
   agent_id           = coder_agent.example.id
   folder             = "/home/coder/example"
   jetbrains_ides     = ["GO", "WS"]

--- a/registry/coder/modules/jetbrains-gateway/README.md
+++ b/registry/coder/modules/jetbrains-gateway/README.md
@@ -109,7 +109,7 @@ Due to the highest priority of the `ide_download_link` parameter in the `(jetbra
 module "jetbrains_gateway" {
   count              = data.coder_workspace.me.start_count
   source             = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.3"
+  version            = "1.2.3"
   agent_id           = coder_agent.example.id
   folder             = "/home/coder/example"
   jetbrains_ides     = ["GO", "WS"]

--- a/registry/coder/modules/jetbrains-gateway/README.md
+++ b/registry/coder/modules/jetbrains-gateway/README.md
@@ -47,7 +47,7 @@ module "jetbrains_gateway" {
 
 This can be used when support for connecting to multiple agents within one workspace is required.
 
-To utilise this both `embed_agent_id` and `agent_name` must be populated on each instance of the module.
+To utilise this both `embed_agent_name` and `agent_name` must be populated on each instance of the module.
 In addition each instance must have a unique `slug` and `ide_parameter_name` variable defined.
 
 ```tf
@@ -59,7 +59,7 @@ module "jetbrains_gateway" {
   folder             = "/home/coder/example"
   jetbrains_ides     = ["CL", "GO"]
   default            = "GO"
-  embed_agent_id     = true
+  embed_agent_name   = true
   agent_name         = "main"
   ide_parameter_name = "jetbrains_ide" # default variable value
   slug               = "gateway"       # default variable value
@@ -73,7 +73,7 @@ module "jetbrains_gateway_agent2" {
   folder             = "/home/coder/example"
   jetbrains_ides     = ["CL", "GO", "IU", "PY", "WS"]
   default            = "GO"
-  embed_agent_id     = true
+  embed_agent_name   = true
   agent_name         = "jetbrainsagent2"
   ide_parameter_name = "jetbrains_ide_agent2"
   slug               = "gateway-agent2"

--- a/registry/coder/modules/jetbrains-gateway/README.md
+++ b/registry/coder/modules/jetbrains-gateway/README.md
@@ -19,7 +19,7 @@ Consult the [JetBrains documentation](https://www.jetbrains.com/help/idea/prereq
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.3"
+  version = "1.2.3"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["CL", "GO", "IU", "PY", "WS"]
@@ -37,7 +37,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.3"
+  version = "1.2.3"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["GO", "WS"]
@@ -51,7 +51,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.3"
+  version = "1.2.3"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["IU", "PY"]
@@ -66,7 +66,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.3"
+  version = "1.2.3"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["IU", "PY"]
@@ -91,7 +91,7 @@ module "jetbrains_gateway" {
 module "jetbrains_gateway" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version        = "1.2.3"
+  version = "1.2.3"
   agent_id       = coder_agent.example.id
   folder         = "/home/coder/example"
   jetbrains_ides = ["GO", "WS"]
@@ -109,7 +109,7 @@ Due to the highest priority of the `ide_download_link` parameter in the `(jetbra
 module "jetbrains_gateway" {
   count              = data.coder_workspace.me.start_count
   source             = "registry.coder.com/coder/jetbrains-gateway/coder"
-  version            = "1.2.3"
+  version = "1.2.3"
   agent_id           = coder_agent.example.id
   folder             = "/home/coder/example"
   jetbrains_ides     = ["GO", "WS"]

--- a/registry/coder/modules/jetbrains-gateway/main.test.ts
+++ b/registry/coder/modules/jetbrains-gateway/main.test.ts
@@ -20,7 +20,7 @@ describe("jetbrains-gateway", async () => {
       folder: "/home/coder",
     });
     expect(state.outputs.url.value).toBe(
-      "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz&agent_id=foo",
+      "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz",
     );
 
     const coder_app = state.resources.find(
@@ -40,4 +40,15 @@ describe("jetbrains-gateway", async () => {
     });
     expect(state.outputs.identifier.value).toBe("IU");
   });
+});
+it("optionally includes agent_id when embed_agent_id is true", async () => {
+  const state = await runTerraformApply(import.meta.dir, {
+    agent_id: "foo",
+    folder: "/home/coder",
+    embed_agent_id: true,
+  });
+
+  expect(state.outputs.url.value).toBe(
+    "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz&agent_id=foo",
+  );
 });

--- a/registry/coder/modules/jetbrains-gateway/main.test.ts
+++ b/registry/coder/modules/jetbrains-gateway/main.test.ts
@@ -20,7 +20,7 @@ describe("jetbrains-gateway", async () => {
       folder: "/home/coder",
     });
     expect(state.outputs.url.value).toBe(
-      "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz",
+      "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz&agent=",
     );
 
     const coder_app = state.resources.find(
@@ -50,6 +50,18 @@ describe("jetbrains-gateway", async () => {
 
     expect(state.outputs.url.value).toBe(
       "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz&agent=main",
+    );
+  });
+
+  it("includes the agent parameter even when the provided value is blank", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      agent_name: "  ",
+      folder: "/home/coder",
+    });
+
+    expect(state.outputs.url.value).toBe(
+      "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz&agent=",
     );
   });
 });

--- a/registry/coder/modules/jetbrains-gateway/main.test.ts
+++ b/registry/coder/modules/jetbrains-gateway/main.test.ts
@@ -41,12 +41,12 @@ describe("jetbrains-gateway", async () => {
     expect(state.outputs.identifier.value).toBe("IU");
   });
 
-  it("optionally includes agent when embed_agent_id is true", async () => {
+  it("optionally includes agent when embed_agent_name is true", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
       agent_name: "main",
       folder: "/home/coder",
-      embed_agent_id: true,
+      embed_agent_name: true,
     });
 
     expect(state.outputs.url.value).toBe(

--- a/registry/coder/modules/jetbrains-gateway/main.test.ts
+++ b/registry/coder/modules/jetbrains-gateway/main.test.ts
@@ -40,15 +40,17 @@ describe("jetbrains-gateway", async () => {
     });
     expect(state.outputs.identifier.value).toBe("IU");
   });
-});
-it("optionally includes agent_id when embed_agent_id is true", async () => {
-  const state = await runTerraformApply(import.meta.dir, {
-    agent_id: "foo",
-    folder: "/home/coder",
-    embed_agent_id: true,
-  });
 
-  expect(state.outputs.url.value).toBe(
-    "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz&agent_id=foo",
-  );
+  it("optionally includes agent when embed_agent_id is true", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      agent_name: "main",
+      folder: "/home/coder",
+      embed_agent_id: true,
+    });
+
+    expect(state.outputs.url.value).toBe(
+      "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz&agent=main",
+    );
+  });
 });

--- a/registry/coder/modules/jetbrains-gateway/main.test.ts
+++ b/registry/coder/modules/jetbrains-gateway/main.test.ts
@@ -20,7 +20,7 @@ describe("jetbrains-gateway", async () => {
       folder: "/home/coder",
     });
     expect(state.outputs.url.value).toBe(
-      "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz",
+      "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz&agent_id=foo",
     );
 
     const coder_app = state.resources.find(
@@ -41,12 +41,11 @@ describe("jetbrains-gateway", async () => {
     expect(state.outputs.identifier.value).toBe("IU");
   });
 
-  it("optionally includes agent when embed_agent_name is true", async () => {
+  it("optionally includes agent when an agent name is provided", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
       agent_name: "main",
       folder: "/home/coder",
-      embed_agent_name: true,
     });
 
     expect(state.outputs.url.value).toBe(

--- a/registry/coder/modules/jetbrains-gateway/main.test.ts
+++ b/registry/coder/modules/jetbrains-gateway/main.test.ts
@@ -20,7 +20,7 @@ describe("jetbrains-gateway", async () => {
       folder: "/home/coder",
     });
     expect(state.outputs.url.value).toBe(
-      "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz&agent_id=foo",
+      "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz",
     );
 
     const coder_app = state.resources.find(

--- a/registry/coder/modules/jetbrains-gateway/main.test.ts
+++ b/registry/coder/modules/jetbrains-gateway/main.test.ts
@@ -61,7 +61,7 @@ describe("jetbrains-gateway", async () => {
     });
 
     expect(state.outputs.url.value).toBe(
-      "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz&agent=",
+      "jetbrains-gateway://connect#type=coder&workspace=default&owner=default&folder=/home/coder&url=https://mydeployment.coder.com&token=$SESSION_TOKEN&ide_product_code=IU&ide_build_number=243.21565.193&ide_download_link=https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz&agent=  ",
     );
   });
 });

--- a/registry/coder/modules/jetbrains-gateway/main.tf
+++ b/registry/coder/modules/jetbrains-gateway/main.tf
@@ -347,9 +347,9 @@ resource "coder_app" "gateway" {
     local.build_number,
     "&ide_download_link=",
     local.download_link,
-  ], trimspace(var.agent_name) != ""
+    ], trimspace(var.agent_name) != ""
     ? ["&agent=", var.agent_name]
-    : []))
+  : []))
 }
 
 output "identifier" {

--- a/registry/coder/modules/jetbrains-gateway/main.tf
+++ b/registry/coder/modules/jetbrains-gateway/main.tf
@@ -67,18 +67,6 @@ variable "group" {
   default     = null
 }
 
-variable "embed_agent_name" {
-  type        = bool
-  description = "Embed the agent name in the JetBrains Gateway URL when support for multiple agents is required."
-  default     = false
-}
-
-variable "ide_parameter_name" {
-  type        = string
-  description = "Terraform parameter name for the JetBrains IDE selector. Must be unique per module instance."
-  default     = "jetbrains_ide"
-}
-
 variable "coder_parameter_order" {
   type        = number
   description = "The order determines the position of a template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order)."
@@ -314,7 +302,7 @@ locals {
 
 data "coder_parameter" "jetbrains_ide" {
   type         = "string"
-  name         = var.ide_parameter_name
+  name         = "jetbrains_ide"
   display_name = "JetBrains IDE"
   icon         = "/icon/gateway.svg"
   mutable      = true
@@ -359,7 +347,9 @@ resource "coder_app" "gateway" {
     local.build_number,
     "&ide_download_link=",
     local.download_link,
-  ], var.embed_agent_name && trimspace(var.agent_name) != "" ? ["&agent=", var.agent_name] : []))
+    ], trimspace(var.agent_name) != ""
+    ? ["&agent=", var.agent_name]
+  : (trimspace(var.agent_id) != "" ? ["&agent_id=", var.agent_id] : [])))
 }
 
 output "identifier" {

--- a/registry/coder/modules/jetbrains-gateway/main.tf
+++ b/registry/coder/modules/jetbrains-gateway/main.tf
@@ -347,9 +347,9 @@ resource "coder_app" "gateway" {
     local.build_number,
     "&ide_download_link=",
     local.download_link,
-    ], trimspace(var.agent_name) != ""
+  ], trimspace(var.agent_name) != ""
     ? ["&agent=", var.agent_name]
-  : (trimspace(var.agent_id) != "" ? ["&agent_id=", var.agent_id] : [])))
+    : []))
 }
 
 output "identifier" {

--- a/registry/coder/modules/jetbrains-gateway/main.tf
+++ b/registry/coder/modules/jetbrains-gateway/main.tf
@@ -37,7 +37,7 @@ variable "slug" {
 variable "agent_name" {
   type        = string
   description = "Agent name."
-  default = ""
+  default     = ""
 }
 
 variable "folder" {

--- a/registry/coder/modules/jetbrains-gateway/main.tf
+++ b/registry/coder/modules/jetbrains-gateway/main.tf
@@ -36,8 +36,7 @@ variable "slug" {
 
 variable "agent_name" {
   type        = string
-  description = "Agent name. (unused). Will be removed in a future version"
-
+  description = "Agent name."
   default = ""
 }
 
@@ -68,7 +67,7 @@ variable "group" {
   default     = null
 }
 
-variable "embed_agent_id" {
+variable "embed_agent_name" {
   type        = bool
   description = "Embed the agent name in the JetBrains Gateway URL when support for multiple agents is required."
   default     = false
@@ -360,7 +359,7 @@ resource "coder_app" "gateway" {
     local.build_number,
     "&ide_download_link=",
     local.download_link,
-  ], var.embed_agent_id && trimspace(var.agent_name) != "" ? ["&agent=", var.agent_name] : []))
+  ], var.embed_agent_name && trimspace(var.agent_name) != "" ? ["&agent=", var.agent_name] : []))
 }
 
 output "identifier" {

--- a/registry/coder/modules/jetbrains-gateway/main.tf
+++ b/registry/coder/modules/jetbrains-gateway/main.tf
@@ -330,7 +330,7 @@ resource "coder_app" "gateway" {
   external     = true
   order        = var.order
   group        = var.group
-  url = join("", concat([
+  url = join("", [
     "jetbrains-gateway://connect#type=coder&workspace=",
     data.coder_workspace.me.name,
     "&owner=",
@@ -347,9 +347,9 @@ resource "coder_app" "gateway" {
     local.build_number,
     "&ide_download_link=",
     local.download_link,
-    ], trimspace(var.agent_name) != ""
-    ? ["&agent=", var.agent_name]
-  : []))
+    "&agent=",
+    var.agent_name,
+  ])
 }
 
 output "identifier" {

--- a/registry/coder/modules/jetbrains-gateway/main.tf
+++ b/registry/coder/modules/jetbrains-gateway/main.tf
@@ -70,8 +70,14 @@ variable "group" {
 
 variable "embed_agent_id" {
   type        = bool
-  description = "Append the agent_id to the JetBrains Gateway URL for when support for multiple agents is required."
+  description = "Embed the agent name in the JetBrains Gateway URL when support for multiple agents is required."
   default     = false
+}
+
+variable "ide_parameter_name" {
+  type        = string
+  description = "Terraform parameter name for the JetBrains IDE selector. Must be unique per module instance."
+  default     = "jetbrains_ide"
 }
 
 variable "coder_parameter_order" {
@@ -309,7 +315,7 @@ locals {
 
 data "coder_parameter" "jetbrains_ide" {
   type         = "string"
-  name         = "jetbrains_ide"
+  name         = var.ide_parameter_name
   display_name = "JetBrains IDE"
   icon         = "/icon/gateway.svg"
   mutable      = true
@@ -354,7 +360,7 @@ resource "coder_app" "gateway" {
     local.build_number,
     "&ide_download_link=",
     local.download_link,
-  ], var.embed_agent_id && trimspace(var.agent_id) != "" ? ["&agent_id=", var.agent_id] : []))
+  ], var.embed_agent_id && trimspace(var.agent_name) != "" ? ["&agent=", var.agent_name] : []))
 }
 
 output "identifier" {

--- a/registry/coder/modules/jetbrains-gateway/main.tf
+++ b/registry/coder/modules/jetbrains-gateway/main.tf
@@ -68,6 +68,12 @@ variable "group" {
   default     = null
 }
 
+variable "embed_agent_id" {
+  type        = bool
+  description = "Append the agent_id to the JetBrains Gateway URL for when support for multiple agents is required."
+  default     = false
+}
+
 variable "coder_parameter_order" {
   type        = number
   description = "The order determines the position of a template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order)."
@@ -331,7 +337,7 @@ resource "coder_app" "gateway" {
   external     = true
   order        = var.order
   group        = var.group
-  url = join("", [
+  url = join("", concat([
     "jetbrains-gateway://connect#type=coder&workspace=",
     data.coder_workspace.me.name,
     "&owner=",
@@ -348,9 +354,7 @@ resource "coder_app" "gateway" {
     local.build_number,
     "&ide_download_link=",
     local.download_link,
-    "&agent_id=",
-    var.agent_id,
-  ])
+  ], var.embed_agent_id && trimspace(var.agent_id) != "" ? ["&agent_id=", var.agent_id] : []))
 }
 
 output "identifier" {


### PR DESCRIPTION
## Description

Fixes a regression added in #167 which implemented support for multiple agents by appending the agent id to the URI, however in a single agent environment it results in the agent id from the template apply (on upload to Coder from client) being injected, and when a workspace is later built using the template the agent id is no longer correct.

Resolves the error `The workspace “<name>” does not have an agent with ID “<id>”` being thrown by Jetbrains Gateway app upon attempting to open a Jetbrains app from within a Coder workspace.

When wishing to target a specific Coder Agent with the Jetbrains Gateway module one should use the `agent_name` variable in the module configuration to specify the desired agent name. This will append the agent name to the URI.

## Type of Change

- [ ] New module
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder/modules/jetbrains-gateway`  
**New version:** `v1.2.4`  
**Breaking change:** [ ] Yes [x] No

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun run fmt`)
- [x] Changes tested locally

## Related Issues

Reported by customer on Zendesk ticket 4391