### PR TITLE
Fix claude-code module not passing workdir to agentapi

### DIFF
--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Run the [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
 ```tf
 module "claude-code" {
   source         = "registry.coder.com/coder/claude-code/coder"
-  version        = "3.0.0"
+  version        = "3.0.1"
   agent_id       = coder_agent.example.id
   workdir        = "/home/coder/project"
   claude_api_key = "xxxx-xxxxx-xxxx"
@@ -49,7 +49,7 @@ data "coder_parameter" "ai_prompt" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "3.0.0"
+  version  = "3.0.1"
   agent_id = coder_agent.example.id
   workdir  = "/home/coder/project"
 
@@ -85,7 +85,7 @@ Run and configure Claude Code as a standalone CLI in your workspace.
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "3.0.0"
+  version             = "3.0.1"
   agent_id            = coder_agent.example.id
   workdir             = "/home/coder"
   install_claude_code = true
@@ -108,7 +108,7 @@ variable "claude_code_oauth_token" {
 
 module "claude-code" {
   source                  = "registry.coder.com/coder/claude-code/coder"
-  version                 = "3.0.0"
+  version                 = "3.0.1"
   agent_id                = coder_agent.example.id
   workdir                 = "/home/coder/project"
   claude_code_oauth_token = var.claude_code_oauth_token

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -244,6 +244,7 @@ module "agentapi" {
   web_app_group        = var.group
   web_app_icon         = var.icon
   web_app_display_name = var.web_app_display_name
+  folder               = local.workdir
   cli_app              = var.cli_app
   cli_app_slug         = var.cli_app ? "${local.app_slug}-cli" : null
   cli_app_display_name = var.cli_app ? var.cli_app_display_name : null


### PR DESCRIPTION
## Summary

Fixes #436 - The claude-code 3.0.0 module was not passing the custom `workdir` variable to the agentapi module, causing it to default to `/home/coder` instead of using the specified working directory.

## Changes

- Added missing `folder = local.workdir` parameter to the agentapi module call in `main.tf:247`
- This ensures that custom working directories are properly propagated to the agentapi module

## Test Plan

- [x] Terraform validation passes
- [x] Code formatting applied with `bun run fmt`
- [x] Basic terraform test passes (one pre-existing test failure unrelated to this change)

## Verification

The fix adds the missing parameter that was identified in the issue:
```terraform
module "agentapi" {
  # ... other parameters
  folder = local.workdir  # <- Added this line
  # ... rest of configuration
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)