### PR TITLE
docs: add MAINTAINER.md link to CONTRIBUTING.md and README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -495,4 +495,8 @@ When reporting bugs, include:
 4. **Breaking changes** without defaults
 5. **Not running** formatting (`bun run fmt`) and tests (`terraform test`) before submitting
 
+## For Maintainers
+
+Guidelines for reviewing PRs, managing releases, and maintaining the registry. [See the maintainer guide for detailed information.](./MAINTAINER.md)
+
 Happy contributing! 🚀

--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ Simply include that snippet inside your Coder template, defining any data depend
 ## Contributing
 
 We are always accepting new contributions. [Please see our contributing guide for more information.](./CONTRIBUTING.md)
+
+## For Maintainers
+
+Guidelines for maintainers reviewing PRs and managing releases. [See the maintainer guide for more information.](./MAINTAINER.md)


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why -->
Add links to `MAINTAINER.md` in `README.md` and `CONTRIBUTING.md` to help guide internal contributors.

## Type of Change

- [ ] New module
- [ ] Bug fix
- [ ] Feature/enhancement
- [X] Documentation
- [ ] Other

## Testing & Validation

- [ ] Tests pass (`bun test`)
- [X] Code formatted (`bun run fmt`)
- [ ] Changes tested locally

## Related Issues

<!-- Link related issues or write "None" if not applicable -->
