### PR TITLE
fix: Add COPILOT_MODEL to install script args

### DIFF
--- a/registry/coder-labs/modules/copilot/README.md
+++ b/registry/coder-labs/modules/copilot/README.md
@@ -13,7 +13,7 @@ Run [GitHub Copilot CLI](https://docs.github.com/copilot/concepts/agents/about-c
 ```tf
 module "copilot" {
   source   = "registry.coder.com/coder-labs/copilot/coder"
-  version  = "0.1.0"
+  version  = "0.1.1"
   agent_id = coder_agent.example.id
   workdir  = "/home/coder/projects"
 }
@@ -51,7 +51,7 @@ data "coder_parameter" "ai_prompt" {
 
 module "copilot" {
   source   = "registry.coder.com/coder-labs/copilot/coder"
-  version  = "0.1.0"
+  version  = "0.1.1"
   agent_id = coder_agent.example.id
   workdir  = "/home/coder/projects"
 
@@ -71,7 +71,7 @@ Customize tool permissions, MCP servers, and Copilot settings:
 ```tf
 module "copilot" {
   source   = "registry.coder.com/coder-labs/copilot/coder"
-  version  = "0.1.0"
+  version  = "0.1.1"
   agent_id = coder_agent.example.id
   workdir  = "/home/coder/projects"
 
@@ -142,7 +142,7 @@ variable "github_token" {
 
 module "copilot" {
   source       = "registry.coder.com/coder-labs/copilot/coder"
-  version      = "0.1.0"
+  version      = "0.1.1"
   agent_id     = coder_agent.example.id
   workdir      = "/home/coder/projects"
   github_token = var.github_token
@@ -156,7 +156,7 @@ Run Copilot as a command-line tool without task reporting or web interface. This
 ```tf
 module "copilot" {
   source       = "registry.coder.com/coder-labs/copilot/coder"
-  version      = "0.1.0"
+  version      = "0.1.1"
   agent_id     = coder_agent.example.id
   workdir      = "/home/coder"
   report_tasks = false

--- a/registry/coder-labs/modules/copilot/main.tf
+++ b/registry/coder-labs/modules/copilot/main.tf
@@ -295,6 +295,7 @@ module "agentapi" {
     ARG_COPILOT_CONFIG='${base64encode(local.final_copilot_config)}' \
     ARG_EXTERNAL_AUTH_ID='${var.external_auth_id}' \
     ARG_COPILOT_VERSION='${var.copilot_version}' \
+    ARG_COPILOT_MODEL='${var.copilot_model}' \
     /tmp/install.sh
   EOT
 }

--- a/registry/coder-labs/modules/copilot/scripts/install.sh
+++ b/registry/coder-labs/modules/copilot/scripts/install.sh
@@ -85,7 +85,6 @@ setup_copilot_configurations() {
 
   local module_path="$HOME/.copilot-module"
   mkdir -p "$module_path"
-  mkdir -p "$HOME/.config"
 
   setup_copilot_config
 

--- a/registry/coder-labs/modules/copilot/scripts/install.sh
+++ b/registry/coder-labs/modules/copilot/scripts/install.sh
@@ -92,7 +92,8 @@ setup_copilot_configurations() {
 }
 
 setup_copilot_config() {
-  local copilot_config_dir="$HOME/.copilot"
+  export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+  local copilot_config_dir="$XDG_CONFIG_HOME/.copilot"
   local copilot_config_file="$copilot_config_dir/config.json"
   local mcp_config_file="$copilot_config_dir/mcp-config.json"
 

--- a/registry/coder-labs/modules/copilot/scripts/install.sh
+++ b/registry/coder-labs/modules/copilot/scripts/install.sh
@@ -14,6 +14,7 @@ ARG_MCP_CONFIG=$(echo -n "${ARG_MCP_CONFIG:-}" | base64 -d 2> /dev/null || echo 
 ARG_COPILOT_CONFIG=$(echo -n "${ARG_COPILOT_CONFIG:-}" | base64 -d 2> /dev/null || echo "")
 ARG_EXTERNAL_AUTH_ID=${ARG_EXTERNAL_AUTH_ID:-github}
 ARG_COPILOT_VERSION=${ARG_COPILOT_VERSION:-0.0.334}
+ARG_COPILOT_MODEL=${ARG_COPILOT_MODEL:-claude-sonnet-4.5}
 
 validate_prerequisites() {
   if ! command_exists node; then

--- a/registry/coder-labs/modules/copilot/scripts/start.sh
+++ b/registry/coder-labs/modules/copilot/scripts/start.sh
@@ -71,7 +71,7 @@ build_copilot_args() {
 check_existing_session() {
   if [ "$ARG_RESUME_SESSION" = "true" ]; then
     if copilot --help > /dev/null 2>&1; then
-      local session_dir="$HOME/.copilot/history-session-state"
+      local session_dir="$XDG_CONFIG_HOME/.copilot/history-session-state"
       if [ -d "$session_dir" ] && [ -n "$(ls "$session_dir"/session_*_*.json 2> /dev/null)" ]; then
         echo "Found existing Copilot session. Will continue latest session." >&2
         return 0
@@ -82,6 +82,7 @@ check_existing_session() {
 }
 
 setup_github_authentication() {
+  export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
   echo "Setting up GitHub authentication..."
 
   if [ -n "${GITHUB_TOKEN:-}" ]; then

--- a/registry/coder-labs/modules/copilot/scripts/start.sh
+++ b/registry/coder-labs/modules/copilot/scripts/start.sh
@@ -71,7 +71,7 @@ build_copilot_args() {
 check_existing_session() {
   if [ "$ARG_RESUME_SESSION" = "true" ]; then
     if copilot --help > /dev/null 2>&1; then
-      local session_dir="$XDG_CONFIG_HOME/.copilot/history-session-state"
+      local session_dir="$HOME/.copilot/history-session-state"
       if [ -d "$session_dir" ] && [ -n "$(ls "$session_dir"/session_*_*.json 2> /dev/null)" ]; then
         echo "Found existing Copilot session. Will continue latest session." >&2
         return 0


### PR DESCRIPTION
Closes #462

## Description

<!-- Briefly describe what this PR does and why -->
Fixes missing COPILOT_MODEL arg from install script

## Type of Change

- [ ] New module
- [X] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

<!-- Delete this section if not applicable -->

**Path:** `registry/coder-labs/modules/copilot`  
**New version:** `v0.1.1`  
**Breaking change:** [ ] Yes [X] No

## Testing & Validation

- [X] Tests pass (`bun test`)
- [X] Code formatted (`bun run fmt`)
- [X] Changes tested locally
