### PR TITLE
fix: update CLI icon for copilot module to same icon as web app

### DIFF
--- a/registry/coder-labs/modules/copilot/README.md
+++ b/registry/coder-labs/modules/copilot/README.md
@@ -13,7 +13,7 @@ Run [GitHub Copilot CLI](https://docs.github.com/copilot/concepts/agents/about-c
 ```tf
 module "copilot" {
   source   = "registry.coder.com/coder-labs/copilot/coder"
-  version  = "0.2.0"
+  version  = "0.2.1"
   agent_id = coder_agent.example.id
   workdir  = "/home/coder/projects"
 }
@@ -51,7 +51,7 @@ data "coder_parameter" "ai_prompt" {
 
 module "copilot" {
   source   = "registry.coder.com/coder-labs/copilot/coder"
-  version  = "0.2.0"
+  version  = "0.2.1"
   agent_id = coder_agent.example.id
   workdir  = "/home/coder/projects"
 
@@ -71,7 +71,7 @@ Customize tool permissions, MCP servers, and Copilot settings:
 ```tf
 module "copilot" {
   source   = "registry.coder.com/coder-labs/copilot/coder"
-  version  = "0.2.0"
+  version  = "0.2.1"
   agent_id = coder_agent.example.id
   workdir  = "/home/coder/projects"
 
@@ -142,7 +142,7 @@ variable "github_token" {
 
 module "copilot" {
   source       = "registry.coder.com/coder-labs/copilot/coder"
-  version      = "0.2.0"
+  version      = "0.2.1"
   agent_id     = coder_agent.example.id
   workdir      = "/home/coder/projects"
   github_token = var.github_token
@@ -156,7 +156,7 @@ Run Copilot as a command-line tool without task reporting or web interface. This
 ```tf
 module "copilot" {
   source       = "registry.coder.com/coder-labs/copilot/coder"
-  version      = "0.2.0"
+  version      = "0.2.1"
   agent_id     = coder_agent.example.id
   workdir      = "/home/coder"
   report_tasks = false

--- a/registry/coder-labs/modules/copilot/main.tf
+++ b/registry/coder-labs/modules/copilot/main.tf
@@ -253,6 +253,7 @@ module "agentapi" {
   web_app_display_name = var.web_app_display_name
   cli_app              = var.cli_app
   cli_app_slug         = var.cli_app ? "${local.app_slug}-cli" : null
+  cli_app_icon         = var.cli_app ? var.icon : null
   cli_app_display_name = var.cli_app ? var.cli_app_display_name : null
   agentapi_subdomain   = var.subdomain
   module_dir_name      = local.module_dir_name


### PR DESCRIPTION
## Description

Sets `cli_app_icon` in agentapi to the same icon used for `web_app_icon`.  Its currently using the default of Claude.

## Type of Change

- [ ] New module
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

<!-- Delete this section if not applicable -->

**Path:** `registry/coder-labs/modules/copilot`  
**New version:** `v0.2.1`  
**Breaking change:** [ ] Yes [x] No

## Testing & Validation

- [ ] Tests pass (`bun test`)
- [ ] Code formatted (`bun run fmt`)
- [x] Changes tested locally

## Related Issues

<!-- Link related issues or write "None" if not applicable -->
