### PR TITLE
refactor(coder/agentapi): support terraform-provider-coder v2.12.0

### DIFF
--- a/registry/coder/modules/agentapi/README.md
+++ b/registry/coder/modules/agentapi/README.md
@@ -16,7 +16,7 @@ The AgentAPI module is a building block for modules that need to run an AgentAPI
 ```tf
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "1.2.0"
+  version = "2.0.0"
 
   agent_id             = var.agent_id
   web_app_slug         = local.app_slug

--- a/registry/coder/modules/agentapi/main.tf
+++ b/registry/coder/modules/agentapi/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 2.7"
+      version = ">= 2.12"
     }
   }
 }
@@ -239,8 +239,6 @@ resource "coder_app" "agentapi_cli" {
   group        = var.cli_app_group
 }
 
-resource "coder_ai_task" "agentapi" {
-  sidebar_app {
-    id = coder_app.agentapi_web.id
-  }
+output "task_app_id" {
+  value = coder_app.agentapi_web.id
 }


### PR DESCRIPTION
## Description

In https://github.com/coder/terraform-provider-coder v2.12.0 and the up-coming https://github.com/coder/coder v2.28 we have removed the requirement for the "AI Prompt" parameter, and are intending on slightly re-designing the API of the AI task modules.

Instead of `agentapi` defining the `coder_ai_task` resource, it will output the `task_app_id`. Consumers of the module will then be expected to create the `coder_ai_task` resource themselves with this `task_app_id`.

## Type of Change

- [ ] New module
- [ ] New template
- [ ] Bug fix
- [x] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

<!-- Delete this section if not applicable -->

**Path:** `registry/coder/modules/agent-api`  
**New version:** `v2.0.0`  
**Breaking change:** [x] Yes [ ] No

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun fmt`)
- [x] Changes tested locally

## Related Issues

- https://github.com/coder/internal/issues/1065

## Related PRs

- https://github.com/coder/registry/pull/488
  - https://github.com/coder/registry/pull/497
- https://github.com/coder/registry/pull/489
- https://github.com/coder/registry/pull/490
- https://github.com/coder/registry/pull/491
- https://github.com/coder/registry/pull/492
- https://github.com/coder/registry/pull/493
- https://github.com/coder/registry/pull/494
- https://github.com/coder/registry/pull/495
