### PR TITLE
fix(vscode-web): apply settings on every workspace start

### DIFF
--- a/registry/coder/modules/vscode-web/README.md
+++ b/registry/coder/modules/vscode-web/README.md
@@ -53,7 +53,7 @@ module "vscode-web" {
 
 ### Pre-configure Settings
 
-Configure VS Code's [settings.json](https://code.visualstudio.com/docs/getstarted/settings#_settings-json-file) file:
+Configure VS Code's [Machine settings.json](https://code.visualstudio.com/docs/getstarted/settings#_settings-json-file) file. These settings are applied on every workspace start, ensuring template-defined settings are always enforced:
 
 ```tf
 module "vscode-web" {

--- a/registry/coder/modules/vscode-web/run.sh
+++ b/registry/coder/modules/vscode-web/run.sh
@@ -28,12 +28,12 @@ run_vscode_web() {
   "$VSCODE_WEB" serve-local "$EXTENSION_ARG" "$SERVER_BASE_PATH_ARG" "$DISABLE_TRUST_ARG" --port "${PORT}" --host 127.0.0.1 --accept-server-license-terms --without-connection-token --telemetry-level "${TELEMETRY_LEVEL}" > "${LOG_PATH}" 2>&1 &
 }
 
-# Check if the settings file exists...
-if [ ! -f ~/.vscode-server/data/Machine/settings.json ]; then
-  echo "⚙️ Creating settings file..."
-  mkdir -p ~/.vscode-server/data/Machine
-  echo "${SETTINGS}" > ~/.vscode-server/data/Machine/settings.json
-fi
+# Apply/overwrite template-based settings on every start
+# Machine settings are always overwritten to apply template changes.
+# See: https://github.com/coder/registry/issues/42
+echo "⚙️ Applying VS Code settings..."
+mkdir -p ~/.vscode-server/data/Machine
+echo "${SETTINGS}" > ~/.vscode-server/data/Machine/settings.json
 
 # Check if vscode-server is already installed for offline or cached mode
 if [ -f "$VSCODE_WEB" ]; then


### PR DESCRIPTION
## Summary

Fixes #42 - `vscode-web` module doesn't apply settings.json

### The Problem

Previously, settings were only written to `~/.vscode-server/data/Machine/settings.json` if the file didn't already exist:

```bash
if [ ! -f ~/.vscode-server/data/Machine/settings.json ]; then
  echo "${SETTINGS}" > ~/.vscode-server/data/Machine/settings.json
fi
```

This meant that template changes to the `settings` variable would **never be applied** to existing workspaces, since the settings file already existed from the first workspace build.

### The Fix

Now, Machine settings are always applied on every workspace start:

```bash
# Apply/overwrite template-based settings on every start
mkdir -p ~/.vscode-server/data/Machine
echo "${SETTINGS}" > ~/.vscode-server/data/Machine/settings.json
```

This is the expected behavior for template-controlled (Machine) settings. It matches the behavior of the `code-server` module which always overwrites `machine-settings` for template-level configuration.

### Changes

- **run.sh**: Remove conditional check and always write Machine settings
- **README.md**: Updated documentation to clarify that settings are applied on every workspace start

### Testing

- All existing tests pass
- The fix has been validated against the template behavior of the similar `code-server` module