### PR TITLE
feat(claude-code): add pre_start_script variable for startup dependency control

### DIFF
--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -77,6 +77,12 @@ variable "post_install_script" {
   default     = null
 }
 
+variable "pre_start_script" {
+  type        = string
+  description = "Custom script to run before starting Claude Code."
+  default     = null
+}
+
 variable "install_agentapi" {
   type        = bool
   description = "Whether to install AgentAPI."
@@ -361,6 +367,9 @@ module "agentapi" {
      #!/bin/bash
      set -o errexit
      set -o pipefail
+
+     ${var.pre_start_script != null ? var.pre_start_script : ""}
+
      echo -n '${base64encode(local.start_script)}' | base64 -d > /tmp/start.sh
      chmod +x /tmp/start.sh
 


### PR DESCRIPTION
## Summary

Adds a `pre_start_script` variable to the claude-code module that allows running custom shell commands before the Claude Code startup script executes.

## Problem

When using multiple startup modules in a workspace template (e.g., git-clone and claude-code), there's a race condition where startup scripts execute in parallel. The claude-code module may fail if it tries to access a workdir before git-clone completes cloning the repository.

See #609 for detailed analysis of the issue.

## Solution

The `pre_start_script` enables dependency management between modules by allowing users to wait for preconditions before proceeding:

```hcl
module "claude-code" {
  source = "registry.coder.com/coder/claude-code/coder"
  
  workdir = "/path/to/repo"
  
  # Wait for git-clone to complete before starting
  pre_start_script = <<-EOT
    #!/bin/bash
    set -e
    while [ ! -f /tmp/.git-clone-complete ]; do
      sleep 1
    done
  EOT
}
```

## Changes

- Add `pre_start_script` variable (optional, defaults to null)
- Inject pre_start_script content before the main start script execution
- Consistent with existing `pre_install_script` and `post_install_script` pattern

## Testing

This has been validated in the altana-ai/monorepo Coder template where it successfully coordinates between git-clone and claude-code modules.