### PR TITLE
feat: add RDP Keep Alive to windows-rdp module

### DIFF
--- a/registry/coder/modules/windows-rdp/README.md
+++ b/registry/coder/modules/windows-rdp/README.md
@@ -59,3 +59,17 @@ module "windows_rdp" {
   devolutions_gateway_version = "2025.2.2" # Specify a specific version
 }
 ```
+### Session Keep Alive
+
+Extend workspace sessions during active RDP connections. This is enabled by default and reports activity every 60 seconds if an active RDP connection is detected on port 3389.
+
+```tf
+module "windows_rdp" {
+  count              = data.coder_workspace.me.start_count
+  source             = "registry.coder.com/coder/windows-rdp/coder"
+  version            = "1.3.0"
+  agent_id           = coder_agent.main.id
+  keepalive          = true
+  keepalive_interval = 30 # Check every 30 seconds
+}
+```


### PR DESCRIPTION
This PR implements the Windows RDP Keep Alive feature as requested in #200.

### Changes
- Added `keepalive` (bool) and `keepalive_interval` (number) variables to the `windows-rdp` module.
- Added a background PowerShell `coder_script` that monitors TCP port 3389 for established connections.
- When an active RDP connection is detected, the script reports activity using `coder stat` to extend the workspace session.
- Updated `README.md` with documentation and configuration examples.
- Added regression tests in `main.test.ts` to verify script creation and logic.

/claim #200
