### PR TITLE
Add JetBrains plugin pre-install support

### DIFF
--- a/registry/coder/modules/jetbrains/README.md
+++ b/registry/coder/modules/jetbrains/README.md
@@ -136,6 +136,29 @@ module "jetbrains" {
 }
 ```
 
+### Pre-install Plugins
+
+Provide a list of JetBrains Marketplace plugin IDs to install automatically after
+the RemoteDev server is available on the workspace.
+
+```tf
+module "jetbrains" {
+  count    = data.coder_workspace.me.start_count
+  source   = "registry.coder.com/coder/jetbrains/coder"
+  version  = "1.3.0"
+  agent_id = coder_agent.main.id
+  folder   = "/home/coder/project"
+
+  plugins = [
+    "org.intellij.plugins.markdown",
+    "com.jetbrains.python",
+  ]
+}
+```
+
+> Note: Plugins are installed once the JetBrains RemoteDev server is present on
+> the workspace (triggered after the first Toolbox/Gateway connection).
+
 ### Accessing the IDE Metadata
 
 You can now reference the output `ide_metadata` as a map.


### PR DESCRIPTION
## Summary
- add a `plugins` parameter to the JetBrains module to pre-install Marketplace plugins
- add a startup script that installs plugins via the RemoteDev server once it exists
- document usage and behavior in the module README

## Testing
- Not run locally (requires JetBrains Toolbox RemoteDev server)

## Demo Video
- Pending (can record once RemoteDev server is available)

## Issue
- https://github.com/coder/registry/issues/208

/claim #208