### PR TITLE
feat(windows-rdp): add RDP keep-alive to extend workspace deadline

### DIFF
--- a/registry/coder/modules/windows-rdp/README.md
+++ b/registry/coder/modules/windows-rdp/README.md
@@ -15,7 +15,7 @@ Enable Remote Desktop + a web based client on Windows workspaces, powered by [de
 module "windows_rdp" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/windows-rdp/coder"
-  version  = "1.3.0"
+  version  = "1.4.0"
   agent_id = coder_agent.main.id
 }
 ```
@@ -32,7 +32,7 @@ module "windows_rdp" {
 module "windows_rdp" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/windows-rdp/coder"
-  version  = "1.3.0"
+  version  = "1.4.0"
   agent_id = coder_agent.main.id
 }
 ```
@@ -43,7 +43,7 @@ module "windows_rdp" {
 module "windows_rdp" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/windows-rdp/coder"
-  version  = "1.3.0"
+  version  = "1.4.0"
   agent_id = coder_agent.main.id
 }
 ```
@@ -54,8 +54,25 @@ module "windows_rdp" {
 module "windows_rdp" {
   count                       = data.coder_workspace.me.start_count
   source                      = "registry.coder.com/coder/windows-rdp/coder"
-  version                     = "1.3.0"
+  version                     = "1.4.0"
   agent_id                    = coder_agent.main.id
   devolutions_gateway_version = "2025.2.2" # Specify a specific version
 }
 ```
+
+### With RDP Keep-Alive
+
+Automatically extend the workspace deadline while an RDP connection is active. This prevents workspace autostop during active remote desktop sessions:
+
+```tf
+module "windows_rdp" {
+  count              = data.coder_workspace.me.start_count
+  source             = "registry.coder.com/coder/windows-rdp/coder"
+  version            = "1.4.0"
+  agent_id           = coder_agent.main.id
+  keepalive          = true
+  keepalive_interval = 30 # Check every 30 seconds (default)
+}
+```
+
+When `keepalive` is enabled, a background script monitors port 3389 for established RDP connections. On detection, it calls the [Coder workspace extend API](https://coder.com/docs/reference/api/workspaces#extend-workspace-deadline-by-id) to bump the workspace deadline. When the RDP session disconnects, the normal autostop countdown resumes.

--- a/registry/coder/modules/windows-rdp/main.test.ts
+++ b/registry/coder/modules/windows-rdp/main.test.ts
@@ -11,6 +11,8 @@ type TestVariables = Readonly<{
   share?: string;
   admin_username?: string;
   admin_password?: string;
+  keepalive?: boolean;
+  keepalive_interval?: number;
 }>;
 
 function findWindowsRdpScript(state: TerraformState): string | null {
@@ -25,6 +27,29 @@ function findWindowsRdpScript(state: TerraformState): string | null {
     for (const instance of resource.instances) {
       if (
         instance.attributes.display_name === "windows-rdp" &&
+        typeof instance.attributes.script === "string"
+      ) {
+        return instance.attributes.script;
+      }
+    }
+  }
+
+  return null;
+}
+
+function findKeepaliveScript(state: TerraformState): string | null {
+  for (const resource of state.resources) {
+    const isKeepaliveScriptResource =
+      resource.type === "coder_script" &&
+      resource.name === "windows-rdp-keepalive";
+
+    if (!isKeepaliveScriptResource) {
+      continue;
+    }
+
+    for (const instance of resource.instances) {
+      if (
+        instance.attributes.display_name === "windows-rdp-keepalive" &&
         typeof instance.attributes.script === "string"
       ) {
         return instance.attributes.script;
@@ -127,5 +152,42 @@ describe("Web RDP", async () => {
 
     expect(customResultsGroup.username).toBe(customAdminUsername);
     expect(customResultsGroup.password).toBe(customAdminPassword);
+  });
+
+  it("Does not create keepalive script when keepalive is disabled (default)", async () => {
+    const state = await runTerraformApply<TestVariables>(import.meta.dir, {
+      agent_id: "foo",
+    });
+
+    const keepaliveScript = findKeepaliveScript(state);
+    expect(keepaliveScript).toBeNull();
+  });
+
+  it("Creates keepalive script when keepalive is enabled", async () => {
+    const state = await runTerraformApply<TestVariables>(import.meta.dir, {
+      agent_id: "foo",
+      keepalive: true,
+    });
+
+    const keepaliveScript = findKeepaliveScript(state);
+    expect(keepaliveScript).toBeString();
+    expect(keepaliveScript).toContain("Get-NetTCPConnection");
+    expect(keepaliveScript).toContain("-LocalPort 3389");
+    expect(keepaliveScript).toContain("/api/v2/workspaces/");
+    expect(keepaliveScript).toContain("/extend");
+    expect(keepaliveScript).toContain("CODER_AGENT_TOKEN");
+  });
+
+  it("Uses custom keepalive interval", async () => {
+    const customInterval = 120;
+    const state = await runTerraformApply<TestVariables>(import.meta.dir, {
+      agent_id: "foo",
+      keepalive: true,
+      keepalive_interval: customInterval,
+    });
+
+    const keepaliveScript = findKeepaliveScript(state);
+    expect(keepaliveScript).toBeString();
+    expect(keepaliveScript).toContain(`$CheckInterval = ${customInterval}`);
   });
 });

--- a/registry/coder/modules/windows-rdp/main.tftest.hcl
+++ b/registry/coder/modules/windows-rdp/main.tftest.hcl
@@ -1,0 +1,107 @@
+run "basic_defaults" {
+  command = plan
+
+  variables {
+    agent_id = "test-agent-id"
+  }
+
+  assert {
+    condition     = coder_script.windows-rdp.agent_id == "test-agent-id"
+    error_message = "Windows RDP script should use the provided agent_id"
+  }
+
+  assert {
+    condition     = coder_app.windows-rdp.agent_id == "test-agent-id"
+    error_message = "Windows RDP app should use the provided agent_id"
+  }
+
+  assert {
+    condition     = length(coder_script.windows-rdp-keepalive) == 0
+    error_message = "Keepalive script should not be created when keepalive is disabled (default)"
+  }
+}
+
+run "keepalive_disabled_by_default" {
+  command = plan
+
+  variables {
+    agent_id = "test-agent-id"
+  }
+
+  assert {
+    condition     = var.keepalive == false
+    error_message = "keepalive should default to false"
+  }
+}
+
+run "keepalive_enabled" {
+  command = plan
+
+  variables {
+    agent_id  = "test-agent-id"
+    keepalive = true
+  }
+
+  assert {
+    condition     = length(coder_script.windows-rdp-keepalive) == 1
+    error_message = "Keepalive script should be created when keepalive is enabled"
+  }
+
+  assert {
+    condition     = coder_script.windows-rdp-keepalive[0].display_name == "windows-rdp-keepalive"
+    error_message = "Keepalive script should have correct display name"
+  }
+
+  assert {
+    condition     = coder_script.windows-rdp-keepalive[0].run_on_start == true
+    error_message = "Keepalive script should run on start"
+  }
+
+  assert {
+    condition     = coder_script.windows-rdp-keepalive[0].start_blocks_login == false
+    error_message = "Keepalive script should not block login"
+  }
+}
+
+run "keepalive_default_interval" {
+  command = plan
+
+  variables {
+    agent_id  = "test-agent-id"
+    keepalive = true
+  }
+
+  assert {
+    condition     = var.keepalive_interval == 30
+    error_message = "Default keepalive interval should be 30 seconds"
+  }
+}
+
+run "keepalive_custom_interval" {
+  command = plan
+
+  variables {
+    agent_id           = "test-agent-id"
+    keepalive          = true
+    keepalive_interval = 120
+  }
+
+  assert {
+    condition     = var.keepalive_interval == 120
+    error_message = "Custom keepalive interval should be accepted"
+  }
+}
+
+run "custom_devolutions_version" {
+  command = plan
+
+  variables {
+    agent_id                    = "test-agent-id"
+    devolutions_gateway_version = "2025.2.2"
+  }
+
+  assert {
+    condition     = var.devolutions_gateway_version == "2025.2.2"
+    error_message = "Custom Devolutions Gateway version should be accepted"
+  }
+}

--- a/registry/coder/modules/windows-rdp/rdp-keepalive.ps1.tftpl
+++ b/registry/coder/modules/windows-rdp/rdp-keepalive.ps1.tftpl
@@ -1,0 +1,78 @@
+# RDP Keep-Alive Monitor for Coder Workspaces
+# Detects active RDP connections on port 3389 and extends the workspace
+# deadline via the Coder API to prevent autostop during active sessions.
+
+$CheckInterval = ${keepalive_interval}
+$CoderURL = "${coder_url}"
+$WorkspaceID = "${workspace_id}"
+
+# The Coder agent sets CODER_AGENT_TOKEN in the environment automatically.
+$AgentToken = $env:CODER_AGENT_TOKEN
+
+if (-not $AgentToken) {
+    Write-Host "[RDP Keep-Alive] WARNING: CODER_AGENT_TOKEN not found. Activity reporting will not work."
+}
+
+function Test-RDPConnection {
+    try {
+        $connections = Get-NetTCPConnection -LocalPort 3389 -State Established -ErrorAction SilentlyContinue
+        if ($connections) {
+            return ($connections | Measure-Object).Count
+        }
+        return 0
+    }
+    catch {
+        return 0
+    }
+}
+
+function Send-ActivityBump {
+    # Extend the workspace deadline by the template's activity bump duration.
+    # We set the deadline far enough into the future that the server will clamp
+    # it to the template-configured activity bump value.
+    $newDeadline = (Get-Date).AddHours(12).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    $body = @{ deadline = $newDeadline } | ConvertTo-Json
+    $url = "$CoderURL/api/v2/workspaces/$WorkspaceID/extend"
+
+    try {
+        $headers = @{
+            "Content-Type"        = "application/json"
+            "Coder-Session-Token" = $AgentToken
+        }
+        $response = Invoke-WebRequest -Uri $url -Method PUT -Headers $headers -Body $body -UseBasicParsing -ErrorAction Stop
+        return $true
+    }
+    catch {
+        Write-Host "[RDP Keep-Alive] Failed to extend deadline: $_"
+        return $false
+    }
+}
+
+Write-Host "[RDP Keep-Alive] Started monitoring RDP connections (interval: $($CheckInterval)s)"
+$wasActive = $false
+
+while ($true) {
+    $connectionCount = Test-RDPConnection
+
+    if ($connectionCount -gt 0) {
+        if (-not $wasActive) {
+            Write-Host "[RDP Keep-Alive] RDP connection(s) detected ($connectionCount active)"
+        }
+        $wasActive = $true
+
+        if ($AgentToken) {
+            $success = Send-ActivityBump
+            if ($success) {
+                Write-Host "[RDP Keep-Alive] Workspace deadline extended ($connectionCount active connection(s))"
+            }
+        }
+    }
+    else {
+        if ($wasActive) {
+            Write-Host "[RDP Keep-Alive] RDP connection(s) ended"
+        }
+        $wasActive = $false
+    }
+
+    Start-Sleep -Seconds $CheckInterval
+}


### PR DESCRIPTION
/claim #200

## Summary

Adds an opt-in `keepalive` feature to the existing `windows-rdp` module that prevents workspace autostop during active RDP sessions.

### How it works

When `keepalive = true`, a background PowerShell script (`coder_script`) runs on workspace start that:

1. Polls port 3389 every `keepalive_interval` seconds (default: 30) using `Get-NetTCPConnection -LocalPort 3389 -State Established`
2. When an established RDP connection is detected, calls `PUT /api/v2/workspaces/{workspace_id}/extend` using the `CODER_AGENT_TOKEN` that the Coder agent sets automatically
3. When the RDP session disconnects, stops sending activity bumps and the normal autostop countdown resumes

This uses the [manual activity bump API](https://coder.com/docs/reference/api/workspaces#extend-workspace-deadline-by-id) recommended by @matifali in https://github.com/coder/registry/issues/200#issuecomment-3461026332.

### Why this approach

- **Uses the correct API**: Calls the documented workspace extend endpoint with `CODER_AGENT_TOKEN` rather than relying on stdout/stderr, `coder stat`, or registry keys (which only keep the TCP connection alive but don't tell Coder the workspace is active)
- **Integrated into the existing module**: No separate module needed; just set `keepalive = true`
- **Backward compatible**: Defaults to `false`, no behavior change for existing users
- **Minimal and focused**: ~80 lines of PowerShell, one new `coder_script` resource, two new variables

### Usage

```tf
module "windows_rdp" {
  count              = data.coder_workspace.me.start_count
  source             = "registry.coder.com/coder/windows-rdp/coder"
  version            = "1.4.0"
  agent_id           = coder_agent.main.id
  keepalive          = true
  keepalive_interval = 30
}
```

### Changes

- `main.tf`: Added `keepalive` (bool) and `keepalive_interval` (number) variables, conditional `data.coder_workspace` data source, and `coder_script.windows-rdp-keepalive` resource
- `rdp-keepalive.ps1.tftpl`: PowerShell script that monitors port 3389 and calls the extend API
- `main.tftest.hcl`: Terraform plan tests for the new feature (and base module)
- `main.test.ts`: TypeScript tests verifying keepalive script creation and content
- `README.md`: Version bump to 1.4.0, added keep-alive usage example

## Test plan

- [ ] `terraform test -verbose` passes in the module directory
- [ ] `bun test main.test.ts` passes (keepalive script creation, content validation, interval customization)
- [ ] Existing tests continue to pass (backward compatibility)
- [ ] Deploy with `keepalive = true` on a Windows workspace, connect via RDP, verify workspace deadline extends in Coder dashboard
- [ ] Disconnect RDP, verify autostop countdown resumes normally