### PR TITLE
feat(agentapi,claude-code): expose hidden parameter for web app

### DIFF
--- a/registry/coder/modules/agentapi/README.md
+++ b/registry/coder/modules/agentapi/README.md
@@ -16,7 +16,7 @@ The AgentAPI module is a building block for modules that need to run an AgentAPI
 ```tf
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "2.2.0"
+  version = "2.3.0"
 
   agent_id             = var.agent_id
   web_app_slug         = local.app_slug

--- a/registry/coder/modules/agentapi/main.tf
+++ b/registry/coder/modules/agentapi/main.tf
@@ -47,6 +47,12 @@ variable "web_app_slug" {
   description = "The slug of the web app."
 }
 
+variable "web_app_hidden" {
+  type        = bool
+  description = "Whether to hide the web app from the dashboard UI. The app still exists and functions (healthchecks, task status), but is not visible in the workspace app list. Requires Coder v2.16+."
+  default     = false
+}
+
 variable "folder" {
   type        = string
   description = "The folder to run AgentAPI in."
@@ -268,6 +274,7 @@ resource "coder_app" "agentapi_web" {
   order        = var.web_app_order
   group        = var.web_app_group
   subdomain    = var.agentapi_subdomain
+  hidden       = var.web_app_hidden
   healthcheck {
     url       = "http://localhost:${var.agentapi_port}/status"
     interval  = 3

--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Run the [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
 ```tf
 module "claude-code" {
   source         = "registry.coder.com/coder/claude-code/coder"
-  version        = "4.8.0"
+  version        = "4.9.0"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   claude_api_key = "xxxx-xxxxx-xxxx"
@@ -60,7 +60,7 @@ By default, when `enable_boundary = true`, the module uses `coder boundary` subc
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.8.0"
+  version         = "4.9.0"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_boundary = true
@@ -81,7 +81,7 @@ For tasks integration with AI Bridge, add `enable_aibridge = true` to the [Usage
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.8.0"
+  version         = "4.9.0"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_aibridge = true
@@ -110,7 +110,7 @@ data "coder_task" "me" {}
 
 module "claude-code" {
   source    = "registry.coder.com/coder/claude-code/coder"
-  version   = "4.8.0"
+  version   = "4.9.0"
   agent_id  = coder_agent.main.id
   workdir   = "/home/coder/project"
   ai_prompt = data.coder_task.me.prompt
@@ -133,7 +133,7 @@ This example shows additional configuration options for version pinning, custom 
 ```tf
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.8.0"
+  version  = "4.9.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -189,7 +189,7 @@ Run and configure Claude Code as a standalone CLI in your workspace.
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "4.8.0"
+  version             = "4.9.0"
   agent_id            = coder_agent.main.id
   workdir             = "/home/coder/project"
   install_claude_code = true
@@ -211,7 +211,7 @@ variable "claude_code_oauth_token" {
 
 module "claude-code" {
   source                  = "registry.coder.com/coder/claude-code/coder"
-  version                 = "4.8.0"
+  version                 = "4.9.0"
   agent_id                = coder_agent.main.id
   workdir                 = "/home/coder/project"
   claude_code_oauth_token = var.claude_code_oauth_token
@@ -284,7 +284,7 @@ resource "coder_env" "bedrock_api_key" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.8.0"
+  version  = "4.9.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -341,7 +341,7 @@ resource "coder_env" "google_application_credentials" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.8.0"
+  version  = "4.9.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "claude-sonnet-4@20250514"

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -59,6 +59,12 @@ variable "web_app_display_name" {
   default     = "Claude Code"
 }
 
+variable "web_app_hidden" {
+  type        = bool
+  description = "Whether to hide the web app from the dashboard UI. The app still exists and functions (healthchecks, task status reporting), but is not visible in the workspace app list. Requires Coder v2.16+."
+  default     = false
+}
+
 variable "cli_app_display_name" {
   type        = string
   description = "Display name for the CLI app"
@@ -370,6 +376,7 @@ module "agentapi" {
   web_app_group            = var.group
   web_app_icon             = var.icon
   web_app_display_name     = var.web_app_display_name
+  web_app_hidden           = var.web_app_hidden
   folder                   = local.workdir
   cli_app                  = var.cli_app
   cli_app_slug             = var.cli_app ? "${local.app_slug}-cli" : null

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -368,7 +368,7 @@ locals {
 
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "2.2.0"
+  version = "2.3.0"
 
   agent_id                 = var.agent_id
   web_app_slug             = local.app_slug


### PR DESCRIPTION
## Summary

- Add `web_app_hidden` variable to the `agentapi` module, passing it through to `coder_app.agentapi_web.hidden`
- Add `web_app_hidden` variable to the `claude-code` module, forwarding it to the `agentapi` sub-module

This allows users to hide the AgentAPI web chat UI from the Coder dashboard while keeping the app fully functional for healthchecks and task status reporting (required by `coder_ai_task`).

## Use Case

Users who prefer Claude Code via terminal (SSH / code-server) can set `web_app_hidden = true` to declutter their dashboard without losing the Tasks feature.

```hcl
module "claude-code" {
  source         = "registry.coder.com/coder/claude-code/coder"
  version        = "~> 4.0"
  agent_id       = coder_agent.main.id
  web_app_hidden = true
  # ... other params
}
```

## Changes

| File | Change |
|------|--------|
| `registry/coder/modules/agentapi/main.tf` | Add `web_app_hidden` variable + pass to `coder_app.agentapi_web.hidden` |
| `registry/coder/modules/claude-code/main.tf` | Add `web_app_hidden` variable + forward to agentapi module |

Closes #729