### PR TITLE
feat(coder/modules/git-config): set user name and email via git config

### DIFF
--- a/registry/coder/modules/git-config/README.md
+++ b/registry/coder/modules/git-config/README.md
@@ -14,7 +14,7 @@ Runs a script that updates git credentials in the workspace to match the user's 
 module "git-config" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-config/coder"
-  version  = "1.0.33"
+  version  = "1.0.34"
   agent_id = coder_agent.main.id
 }
 ```
@@ -29,7 +29,7 @@ TODO: Add screenshot
 module "git-config" {
   count              = data.coder_workspace.me.start_count
   source             = "registry.coder.com/coder/git-config/coder"
-  version            = "1.0.33"
+  version            = "1.0.34"
   agent_id           = coder_agent.main.id
   allow_email_change = true
 }
@@ -43,7 +43,7 @@ TODO: Add screenshot
 module "git-config" {
   count                 = data.coder_workspace.me.start_count
   source                = "registry.coder.com/coder/git-config/coder"
-  version               = "1.0.33"
+  version               = "1.0.34"
   agent_id              = coder_agent.main.id
   allow_username_change = false
   allow_email_change    = false

--- a/registry/coder/modules/git-config/main.test.ts
+++ b/registry/coder/modules/git-config/main.test.ts
@@ -20,7 +20,7 @@ describe("git-config", async () => {
     });
 
     const resources = state.resources;
-    expect(resources).toHaveLength(6);
+    expect(resources).toHaveLength(8);
     expect(resources).toMatchObject([
       { type: "coder_workspace", name: "me" },
       { type: "coder_workspace_owner", name: "me" },
@@ -28,6 +28,8 @@ describe("git-config", async () => {
       { type: "coder_env", name: "git_author_name" },
       { type: "coder_env", name: "git_commmiter_email" },
       { type: "coder_env", name: "git_commmiter_name" },
+      { type: "coder_script", name: "git_config_user_email" },
+      { type: "coder_script", name: "git_config_user_name" },
     ]);
   });
 
@@ -38,7 +40,7 @@ describe("git-config", async () => {
     });
 
     const resources = state.resources;
-    expect(resources).toHaveLength(8);
+    expect(resources).toHaveLength(10);
     expect(resources).toMatchObject([
       { type: "coder_parameter", name: "user_email" },
       { type: "coder_parameter", name: "username" },
@@ -48,6 +50,8 @@ describe("git-config", async () => {
       { type: "coder_env", name: "git_author_name" },
       { type: "coder_env", name: "git_commmiter_email" },
       { type: "coder_env", name: "git_commmiter_name" },
+      { type: "coder_script", name: "git_config_user_email" },
+      { type: "coder_script", name: "git_config_user_name" },
     ]);
   });
 
@@ -63,7 +67,7 @@ describe("git-config", async () => {
     );
 
     const resources = state.resources;
-    expect(resources).toHaveLength(6);
+    expect(resources).toHaveLength(8);
     expect(resources).toMatchObject([
       { type: "coder_workspace", name: "me" },
       { type: "coder_workspace_owner", name: "me" },
@@ -71,6 +75,8 @@ describe("git-config", async () => {
       { type: "coder_env", name: "git_author_name" },
       { type: "coder_env", name: "git_commmiter_email" },
       { type: "coder_env", name: "git_commmiter_name" },
+      { type: "coder_script", name: "git_config_user_email" },
+      { type: "coder_script", name: "git_config_user_name" },
     ]);
   });
 
@@ -83,7 +89,7 @@ describe("git-config", async () => {
       coder_parameter_order: order.toString(),
     });
     const resources = state.resources;
-    expect(resources).toHaveLength(8);
+    expect(resources).toHaveLength(10);
     expect(resources).toMatchObject([
       { type: "coder_parameter", name: "user_email" },
       { type: "coder_parameter", name: "username" },
@@ -93,6 +99,8 @@ describe("git-config", async () => {
       { type: "coder_env", name: "git_author_name" },
       { type: "coder_env", name: "git_commmiter_email" },
       { type: "coder_env", name: "git_commmiter_name" },
+      { type: "coder_script", name: "git_config_user_email" },
+      { type: "coder_script", name: "git_config_user_name" },
     ]);
     // user_email order is the same as the order
     expect(resources[0].instances[0].attributes.order).toBe(order);
@@ -110,7 +118,7 @@ describe("git-config", async () => {
       coder_parameter_order: order.toString(),
     });
     const resources = state.resources;
-    expect(resources).toHaveLength(7);
+    expect(resources).toHaveLength(9);
     expect(resources).toMatchObject([
       { type: "coder_parameter", name: "username" },
       { type: "coder_workspace", name: "me" },
@@ -119,6 +127,8 @@ describe("git-config", async () => {
       { type: "coder_env", name: "git_author_name" },
       { type: "coder_env", name: "git_commmiter_email" },
       { type: "coder_env", name: "git_commmiter_name" },
+      { type: "coder_script", name: "git_config_user_email" },
+      { type: "coder_script", name: "git_config_user_name" },
     ]);
     // user_email was not created
     // username order is incremented by 1

--- a/registry/coder/modules/git-config/main.test.ts
+++ b/registry/coder/modules/git-config/main.test.ts
@@ -20,7 +20,7 @@ describe("git-config", async () => {
     });
 
     const resources = state.resources;
-    expect(resources).toHaveLength(8);
+    expect(resources).toHaveLength(7);
     expect(resources).toMatchObject([
       { type: "coder_workspace", name: "me" },
       { type: "coder_workspace_owner", name: "me" },
@@ -28,8 +28,7 @@ describe("git-config", async () => {
       { type: "coder_env", name: "git_author_name" },
       { type: "coder_env", name: "git_commmiter_email" },
       { type: "coder_env", name: "git_commmiter_name" },
-      { type: "coder_script", name: "git_config_user_email" },
-      { type: "coder_script", name: "git_config_user_name" },
+      { type: "coder_script", name: "git_user_config" },
     ]);
   });
 
@@ -40,7 +39,7 @@ describe("git-config", async () => {
     });
 
     const resources = state.resources;
-    expect(resources).toHaveLength(10);
+    expect(resources).toHaveLength(9);
     expect(resources).toMatchObject([
       { type: "coder_parameter", name: "user_email" },
       { type: "coder_parameter", name: "username" },
@@ -50,8 +49,7 @@ describe("git-config", async () => {
       { type: "coder_env", name: "git_author_name" },
       { type: "coder_env", name: "git_commmiter_email" },
       { type: "coder_env", name: "git_commmiter_name" },
-      { type: "coder_script", name: "git_config_user_email" },
-      { type: "coder_script", name: "git_config_user_name" },
+      { type: "coder_script", name: "git_user_config" },
     ]);
   });
 
@@ -67,7 +65,7 @@ describe("git-config", async () => {
     );
 
     const resources = state.resources;
-    expect(resources).toHaveLength(8);
+    expect(resources).toHaveLength(7);
     expect(resources).toMatchObject([
       { type: "coder_workspace", name: "me" },
       { type: "coder_workspace_owner", name: "me" },
@@ -75,8 +73,7 @@ describe("git-config", async () => {
       { type: "coder_env", name: "git_author_name" },
       { type: "coder_env", name: "git_commmiter_email" },
       { type: "coder_env", name: "git_commmiter_name" },
-      { type: "coder_script", name: "git_config_user_email" },
-      { type: "coder_script", name: "git_config_user_name" },
+      { type: "coder_script", name: "git_user_config" },
     ]);
   });
 
@@ -89,7 +86,7 @@ describe("git-config", async () => {
       coder_parameter_order: order.toString(),
     });
     const resources = state.resources;
-    expect(resources).toHaveLength(10);
+    expect(resources).toHaveLength(9);
     expect(resources).toMatchObject([
       { type: "coder_parameter", name: "user_email" },
       { type: "coder_parameter", name: "username" },
@@ -99,8 +96,7 @@ describe("git-config", async () => {
       { type: "coder_env", name: "git_author_name" },
       { type: "coder_env", name: "git_commmiter_email" },
       { type: "coder_env", name: "git_commmiter_name" },
-      { type: "coder_script", name: "git_config_user_email" },
-      { type: "coder_script", name: "git_config_user_name" },
+      { type: "coder_script", name: "git_user_config" },
     ]);
     // user_email order is the same as the order
     expect(resources[0].instances[0].attributes.order).toBe(order);
@@ -118,7 +114,7 @@ describe("git-config", async () => {
       coder_parameter_order: order.toString(),
     });
     const resources = state.resources;
-    expect(resources).toHaveLength(9);
+    expect(resources).toHaveLength(8);
     expect(resources).toMatchObject([
       { type: "coder_parameter", name: "username" },
       { type: "coder_workspace", name: "me" },
@@ -127,8 +123,7 @@ describe("git-config", async () => {
       { type: "coder_env", name: "git_author_name" },
       { type: "coder_env", name: "git_commmiter_email" },
       { type: "coder_env", name: "git_commmiter_name" },
-      { type: "coder_script", name: "git_config_user_email" },
-      { type: "coder_script", name: "git_config_user_name" },
+      { type: "coder_script", name: "git_user_config" },
     ]);
     // user_email was not created
     // username order is incremented by 1

--- a/registry/coder/modules/git-config/main.tf
+++ b/registry/coder/modules/git-config/main.tf
@@ -63,28 +63,59 @@ data "coder_parameter" "username" {
   })
 }
 
+locals {
+  git_user_name  = coalesce(try(data.coder_parameter.username[0].value, ""), data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+  git_user_email = coalesce(try(data.coder_parameter.user_email[0].value, ""), data.coder_workspace_owner.me.email)
+}
+
 resource "coder_env" "git_author_name" {
   agent_id = var.agent_id
   name     = "GIT_AUTHOR_NAME"
-  value    = coalesce(try(data.coder_parameter.username[0].value, ""), data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+  value    = local.git_user_name
 }
 
 resource "coder_env" "git_commmiter_name" {
   agent_id = var.agent_id
   name     = "GIT_COMMITTER_NAME"
-  value    = coalesce(try(data.coder_parameter.username[0].value, ""), data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+  value    = local.git_user_name
 }
 
 resource "coder_env" "git_author_email" {
   agent_id = var.agent_id
   name     = "GIT_AUTHOR_EMAIL"
-  value    = coalesce(try(data.coder_parameter.user_email[0].value, ""), data.coder_workspace_owner.me.email)
+  value    = local.git_user_email
   count    = data.coder_workspace_owner.me.email != "" ? 1 : 0
 }
 
 resource "coder_env" "git_commmiter_email" {
   agent_id = var.agent_id
   name     = "GIT_COMMITTER_EMAIL"
-  value    = coalesce(try(data.coder_parameter.user_email[0].value, ""), data.coder_workspace_owner.me.email)
+  value    = local.git_user_email
   count    = data.coder_workspace_owner.me.email != "" ? 1 : 0
+}
+
+resource "coder_script" "git_config_user_name" {
+  agent_id     = var.agent_id
+  run_on_start = true
+  display_name = "Configure git user name globally"
+  script       = <<EOT
+    #!/bin/bash
+    set -o errexit
+    set -o pipefail
+
+    git config --global user.name "${local.git_user_name}"
+  EOT
+}
+
+resource "coder_script" "git_config_user_email" {
+  agent_id     = var.agent_id
+  run_on_start = true
+  display_name = "Configure git user email globally"
+  script       = <<EOT
+    #!/bin/bash
+    set -o errexit
+    set -o pipefail
+
+    git config --global user.email "${local.git_user_email}"
+  EOT
 }

--- a/registry/coder/modules/git-config/main.tf
+++ b/registry/coder/modules/git-config/main.tf
@@ -118,4 +118,5 @@ resource "coder_script" "git_config_user_email" {
 
     git config --global user.email "${local.git_user_email}"
   EOT
+  count        = data.coder_workspace_owner.me.email != "" ? 1 : 0
 }

--- a/registry/coder/modules/git-config/main.tf
+++ b/registry/coder/modules/git-config/main.tf
@@ -64,8 +64,11 @@ data "coder_parameter" "username" {
 }
 
 locals {
-  git_user_name  = coalesce(try(data.coder_parameter.username[0].value, ""), data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
-  git_user_email = coalesce(try(data.coder_parameter.user_email[0].value, ""), data.coder_workspace_owner.me.email)
+  git_user_name = coalesce(try(data.coder_parameter.username[0].value, ""), data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+  # Wrap in try() so it safely returns "" when both the user_email parameter
+  # and the workspace owner email are empty. The combined coder_script below
+  # always references this local, even when no email line is rendered.
+  git_user_email = try(coalesce(try(data.coder_parameter.user_email[0].value, ""), data.coder_workspace_owner.me.email), "")
 }
 
 resource "coder_env" "git_author_name" {
@@ -94,29 +97,18 @@ resource "coder_env" "git_commmiter_email" {
   count    = data.coder_workspace_owner.me.email != "" ? 1 : 0
 }
 
-resource "coder_script" "git_config_user_name" {
+resource "coder_script" "git_user_config" {
   agent_id     = var.agent_id
   run_on_start = true
-  display_name = "Configure git user name globally"
-  script       = <<EOT
+  display_name = "Configure git user globally"
+  script       = <<-EOT
     #!/bin/bash
     set -o errexit
     set -o pipefail
 
     git config --global user.name "${local.git_user_name}"
-  EOT
-}
-
-resource "coder_script" "git_config_user_email" {
-  agent_id     = var.agent_id
-  run_on_start = true
-  display_name = "Configure git user email globally"
-  script       = <<EOT
-    #!/bin/bash
-    set -o errexit
-    set -o pipefail
-
+%{if data.coder_workspace_owner.me.email != ""~}
     git config --global user.email "${local.git_user_email}"
+%{endif~}
   EOT
-  count        = data.coder_workspace_owner.me.email != "" ? 1 : 0
 }


### PR DESCRIPTION
## Description

The likes of JetBrains IDEs rely on git config rather than env variables and prompt users upon first commit/push attempts.

## Type of Change

- [ ] New module
- [ ] New template
- [ ] Bug fix
- [x] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

<!-- Delete this section if not applicable -->

**Path:** `registry/coder/modules/git-config`  
**New version:** `v1.0.34`  
**Breaking change:** [ ] Yes [x] No

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun fmt`)
- [x] Changes tested locally

## Related Issues

<!-- Link related issues or write "None" if not applicable -->
None