### PR TITLE
chore(registry/coder/modules): rename vscode-desktop-core input params

### DIFF
--- a/registry/coder/modules/vscode-desktop-core/README.md
+++ b/registry/coder/modules/vscode-desktop-core/README.md
@@ -16,15 +16,15 @@ The VSCode Desktop Core module is a building block for modules that need to expo
 ```tf
 module "vscode-desktop-core" {
   source  = "registry.coder.com/coder/vscode-desktop-core/coder"
-  version = "1.0.1"
+  version = "1.0.2"
 
   agent_id = var.agent_id
 
-  web_app_icon         = "/icon/code.svg"
-  web_app_slug         = "vscode"
-  web_app_display_name = "VS Code Desktop"
-  web_app_order        = var.order
-  web_app_group        = var.group
+  coder_app_icon         = "/icon/code.svg"
+  coder_app_slug         = "vscode"
+  coder_app_display_name = "VS Code Desktop"
+  coder_app_order        = var.order
+  coder_app_group        = var.group
 
   folder      = var.folder
   open_recent = var.open_recent

--- a/registry/coder/modules/vscode-desktop-core/main.test.ts
+++ b/registry/coder/modules/vscode-desktop-core/main.test.ts
@@ -11,9 +11,9 @@ const appName = "vscode-desktop";
 const defaultVariables = {
   agent_id: "foo",
 
-  web_app_icon: "/icon/code.svg",
-  web_app_slug: "vscode",
-  web_app_display_name: "VS Code Desktop",
+  coder_app_icon: "/icon/code.svg",
+  coder_app_slug: "vscode",
+  coder_app_display_name: "VS Code Desktop",
 
   protocol: "vscode",
 };
@@ -99,16 +99,16 @@ describe("vscode-desktop-core", async () => {
       );
 
       expect(coder_app?.instances[0].attributes.slug).toBe(
-        defaultVariables.web_app_slug,
+        defaultVariables.coder_app_slug,
       );
       expect(coder_app?.instances[0].attributes.display_name).toBe(
-        defaultVariables.web_app_display_name,
+        defaultVariables.coder_app_display_name,
       );
     });
 
     it("sets order", async () => {
       const state = await runTerraformApply(import.meta.dir, {
-        web_app_order: "5",
+        coder_app_order: "5",
 
         ...defaultVariables,
       });
@@ -122,7 +122,7 @@ describe("vscode-desktop-core", async () => {
 
     it("sets group", async () => {
       const state = await runTerraformApply(import.meta.dir, {
-        web_app_group: "web-app-group",
+        coder_app_group: "web-app-group",
 
         ...defaultVariables,
       });

--- a/registry/coder/modules/vscode-desktop-core/main.tf
+++ b/registry/coder/modules/vscode-desktop-core/main.tf
@@ -31,28 +31,28 @@ variable "protocol" {
   description = "The URI protocol the IDE."
 }
 
-variable "web_app_icon" {
+variable "coder_app_icon" {
   type        = string
   description = "The icon of the coder_app."
 }
 
-variable "web_app_slug" {
+variable "coder_app_slug" {
   type        = string
   description = "The slug of the coder_app."
 }
 
-variable "web_app_display_name" {
+variable "coder_app_display_name" {
   type        = string
   description = "The display name of the coder_app."
 }
 
-variable "web_app_order" {
+variable "coder_app_order" {
   type        = number
   description = "The order of the coder_app."
   default     = null
 }
 
-variable "web_app_group" {
+variable "coder_app_group" {
   type        = string
   description = "The group of the coder_app."
   default     = null
@@ -65,12 +65,12 @@ resource "coder_app" "vscode-desktop" {
   agent_id = var.agent_id
   external = true
 
-  icon         = var.web_app_icon
-  slug         = var.web_app_slug
-  display_name = var.web_app_display_name
+  icon         = var.coder_app_icon
+  slug         = var.coder_app_slug
+  display_name = var.coder_app_display_name
 
-  order = var.web_app_order
-  group = var.web_app_group
+  order = var.coder_app_order
+  group = var.coder_app_group
 
   url = join("", [
     var.protocol,


### PR DESCRIPTION
## Description

Rename `web_app_*` suffix to `coder_app_*`

## Type of Change

- [ ] New module
- [ ] New template
- [ ] Bug fix
- [x] Feature/enhancement
- [ ] Documentation
- [ ] Other