### PR TITLE
fix: fix positron module slug and display name

### DIFF
--- a/registry/cytoshahar/modules/positron/main.tf
+++ b/registry/cytoshahar/modules/positron/main.tf
@@ -41,13 +41,13 @@ variable "group" {
 variable "slug" {
   type        = string
   description = "The slug of the app."
-  default     = "cursor"
+  default     = "positron"
 }
 
 variable "display_name" {
   type        = string
   description = "The display name of the app."
-  default     = "Cursor Desktop"
+  default     = "Positron Desktop"
 }
 
 data "coder_workspace" "me" {}


### PR DESCRIPTION
## Description

In https://github.com/coder/registry/pull/279, I had accidentally made the slug of the Positron Desktop app "cursor", and display name to be "Cursor Desktop". This PR fixes that.

## Type of Change

- [ ] New module
- [ ] New template
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other
