### PR TITLE
feat: add configurable npm registry support to mux module

### DIFF
--- a/registry/coder/modules/mux/README.md
+++ b/registry/coder/modules/mux/README.md
@@ -8,13 +8,13 @@ tags: [ai, agents, development, multiplexer]
 
 # Mux
 
-Automatically install and run [Mux](https://github.com/coder/mux) in a Coder workspace. By default, the module installs `mux@next` from npm (with a fallback to downloading the npm tarball if npm is unavailable). Mux is a desktop application for parallel agentic development that enables developers to run multiple AI agents simultaneously across isolated workspaces.
+Automatically install and run [Mux](https://github.com/coder/mux) in a Coder workspace. By default, the module installs `mux@next` from npm (with a fallback to downloading the npm tarball if npm is unavailable), and you can override the npm registry with `custom_npm_registry`. Mux is a desktop application for parallel agentic development that enables developers to run multiple AI agents simultaneously across isolated workspaces.
 
 ```tf
 module "mux" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/mux/coder"
-  version  = "1.2.0"
+  version  = "1.3.0"
   agent_id = coder_agent.main.id
 }
 ```
@@ -37,7 +37,7 @@ module "mux" {
 module "mux" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/mux/coder"
-  version  = "1.2.0"
+  version  = "1.3.0"
   agent_id = coder_agent.main.id
 }
 ```
@@ -48,10 +48,24 @@ module "mux" {
 module "mux" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/mux/coder"
-  version  = "1.2.0"
+  version  = "1.3.0"
   agent_id = coder_agent.main.id
-  # Default is "latest"; set to a specific version to pin
-  install_version = "0.4.0"
+  # Default is "next"; set to a specific version to pin
+  install_version = "0.18.0"
+}
+```
+
+### Custom npm Registry
+
+Point mux installation to a custom npm-compatible registry (for example, Artifactory or Verdaccio):
+
+```tf
+module "mux" {
+  count               = data.coder_workspace.me.start_count
+  source              = "registry.coder.com/coder/mux/coder"
+  version             = "1.3.0"
+  agent_id            = coder_agent.main.id
+  custom_npm_registry = "https://my-artifactory.example.com/npm"
 }
 ```
 
@@ -63,7 +77,7 @@ Start Mux with `mux server --add-project /path/to/project`:
 module "mux" {
   count       = data.coder_workspace.me.start_count
   source      = "registry.coder.com/coder/mux/coder"
-  version     = "1.2.0"
+  version     = "1.3.0"
   agent_id    = coder_agent.main.id
   add-project = "/path/to/project"
 }
@@ -78,7 +92,7 @@ The module parses quoted values, so grouped arguments remain intact.
 module "mux" {
   count                = data.coder_workspace.me.start_count
   source               = "registry.coder.com/coder/mux/coder"
-  version              = "1.2.0"
+  version              = "1.3.0"
   agent_id             = coder_agent.main.id
   additional_arguments = "--open-mode pinned --add-project '/workspaces/my repo'"
 }
@@ -90,7 +104,7 @@ module "mux" {
 module "mux" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/mux/coder"
-  version  = "1.2.0"
+  version  = "1.3.0"
   agent_id = coder_agent.main.id
   port     = 8080
 }
@@ -104,7 +118,7 @@ Run an existing copy of Mux if found, otherwise install from npm:
 module "mux" {
   count      = data.coder_workspace.me.start_count
   source     = "registry.coder.com/coder/mux/coder"
-  version    = "1.2.0"
+  version    = "1.3.0"
   agent_id   = coder_agent.main.id
   use_cached = true
 }
@@ -118,7 +132,7 @@ Run without installing from the network (requires Mux to be pre-installed):
 module "mux" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/mux/coder"
-  version  = "1.2.0"
+  version  = "1.3.0"
   agent_id = coder_agent.main.id
   install  = false
 }

--- a/registry/coder/modules/mux/main.tf
+++ b/registry/coder/modules/mux/main.tf
@@ -67,6 +67,16 @@ variable "install_version" {
   default     = "next"
 }
 
+variable "custom_npm_registry" {
+  type        = string
+  description = "The base URL of the npm registry to install Mux from (e.g. https://registry.npmjs.org, https://my-artifactory.example.com/npm)."
+  default     = "https://registry.npmjs.org"
+  validation {
+    condition     = can(regex("^https?://", var.custom_npm_registry))
+    error_message = "custom_npm_registry must be a valid URL starting with 'https://' or 'http://'."
+  }
+}
+
 variable "share" {
   type    = string
   default = "owner"
@@ -153,6 +163,7 @@ resource "coder_script" "mux" {
     OFFLINE : !var.install,
     USE_CACHED : var.use_cached,
     AUTH_TOKEN : local.mux_auth_token,
+    NPM_REGISTRY : var.custom_npm_registry,
   })
   run_on_start = true
 

--- a/registry/coder/modules/mux/mux.tftest.hcl
+++ b/registry/coder/modules/mux/mux.tftest.hcl
@@ -121,3 +121,35 @@ run "use_cached_only_success" {
     use_cached = true
   }
 }
+
+run "custom_npm_registry" {
+  command = plan
+
+  variables {
+    agent_id            = "foo"
+    custom_npm_registry = "https://my-artifactory.example.com/npm"
+  }
+
+  assert {
+    condition     = strcontains(resource.coder_script.mux.script, "https://my-artifactory.example.com/npm")
+    error_message = "mux launch script must use the configured custom npm registry URL"
+  }
+
+  assert {
+    condition     = !strcontains(resource.coder_script.mux.script, "registry.npmjs.org")
+    error_message = "mux launch script must not contain hardcoded registry.npmjs.org when custom registry is set"
+  }
+}
+
+run "custom_npm_registry_validation" {
+  command = plan
+
+  variables {
+    agent_id            = "foo"
+    custom_npm_registry = "not-a-url"
+  }
+
+  expect_failures = [
+    var.custom_npm_registry
+  ]
+}

--- a/registry/coder/modules/mux/run.sh
+++ b/registry/coder/modules/mux/run.sh
@@ -78,7 +78,7 @@ if [ ! -f "$MUX_BINARY" ] || [ "${USE_CACHED}" != true ]; then
     else
       PKG_SPEC="$PKG@${VERSION}"
     fi
-    if ! npm install --no-audit --no-fund --omit=dev --ignore-scripts "$PKG_SPEC"; then
+    if ! npm install --no-audit --no-fund --omit=dev --ignore-scripts --registry "${NPM_REGISTRY}" "$PKG_SPEC"; then
       echo "❌ Failed to install mux via npm"
       exit 1
     fi
@@ -97,7 +97,7 @@ if [ ! -f "$MUX_BINARY" ] || [ "${USE_CACHED}" != true ]; then
     if [ -z "$VERSION_TO_USE" ]; then
       VERSION_TO_USE="next"
     fi
-    META_URL="https://registry.npmjs.org/mux/$VERSION_TO_USE"
+    META_URL="${NPM_REGISTRY}/mux/$VERSION_TO_USE"
     META_JSON="$(curl -fsSL "$META_URL" || true)"
     if [ -z "$META_JSON" ]; then
       echo "❌ Failed to fetch npm metadata: $META_URL"
@@ -136,7 +136,7 @@ if [ ! -f "$MUX_BINARY" ] || [ "${USE_CACHED}" != true ]; then
         echo "❌ Could not determine version for mux"
         exit 1
       fi
-      TARBALL_URL="https://registry.npmjs.org/mux/-/mux-$VERSION_TO_USE.tgz"
+      TARBALL_URL="${NPM_REGISTRY}/mux/-/mux-$VERSION_TO_USE.tgz"
     fi
     TMP_DIR="$(mktemp -d)"
     TAR_PATH="$TMP_DIR/mux.tgz"


### PR DESCRIPTION
## Summary

- add a new `custom_npm_registry` module variable (default `https://registry.npmjs.org`) with URL validation
- plumb `custom_npm_registry` into the mux launch template as `NPM_REGISTRY`
- update `run.sh` install paths to use the configured registry for:
  - `npm install` (`--registry`)
  - metadata fetch fallback URL
  - tarball fallback URL
- add Terraform tests for custom registry rendering and invalid registry validation
- update mux module README examples/documentation:
  - document `custom_npm_registry`
  - bump example module version references to `1.3.0`
  - update pinned example `install_version` to latest stable release `0.18.0`

## Validation

- `bun run fmt`
- `cd registry/coder/modules/mux && terraform init -upgrade && terraform test -verbose`

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Add configurable npm registry URL to the mux module

## Context / Why

The mux module's `run.sh` has two hardcoded references to `https://registry.npmjs.org` (lines 100 and 139) used in the fallback installation path when `npm` is unavailable. Additionally, when `npm` IS available, the `npm install` command (line 81) doesn't specify a `--registry` flag, so it defaults to whatever the environment has configured (usually also `registry.npmjs.org`).

Users behind corporate proxies, air-gapped environments, or using private registries (Artifactory, Verdaccio, GitHub Packages, etc.) cannot override the npm registry for mux installation without this change.

**Goal**: Add a `custom_npm_registry` variable so template admins can point mux installation at any npm-compatible registry.

## Evidence

| Source | Key Finding |
|---|---|
| `registry/coder/modules/mux/run.sh:100` | `META_URL="https://registry.npmjs.org/mux/$VERSION_TO_USE"` |
| `registry/coder/modules/mux/run.sh:139` | `TARBALL_URL="https://registry.npmjs.org/mux/-/mux-$VERSION_TO_USE.tgz"` |
| `registry/coder/modules/mux/run.sh:81` | `npm install` without `--registry` flag |
| `registry/coder/modules/mux/main.tf:146-156` | `templatefile()` call passes vars to `run.sh` |
| `registry/coder/modules/mux/mux.tftest.hcl` | Existing test suite with plan/apply tests |
| Other modules (e.g. `github-upload-public-key`) | Pattern: `variable "github_api_url" { default = "https://api.github.com" }` |

## Implementation Details

### 1. Add `custom_npm_registry` variable to `main.tf`

Insert after the `install_version` variable block (after line 68):

```hcl
variable "custom_npm_registry" {
  type        = string
  description = "The base URL of the npm registry to install Mux from (e.g. https://registry.npmjs.org, https://my-artifactory.example.com/npm)."
  default     = "https://registry.npmjs.org"
  validation {
    condition     = can(regex("^https?://", var.custom_npm_registry))
    error_message = "custom_npm_registry must be a valid URL starting with 'https://' or 'http://'."
  }
}
```

### 2. Pass the variable through `templatefile()` in `main.tf`

Add `NPM_REGISTRY` to the templatefile parameters (around line 146-156):

```hcl
  script = templatefile("${path.module}/run.sh", {
    VERSION : var.install_version,
    PORT : var.port,
    LOG_PATH : var.log_path,
    ADD_PROJECT : var.add-project == null ? "" : var.add-project,
    ADDITIONAL_ARGUMENTS : var.additional_arguments,
    INSTALL_PREFIX : var.install_prefix,
    OFFLINE : !var.install,
    USE_CACHED : var.use_cached,
    AUTH_TOKEN : local.mux_auth_token,
    NPM_REGISTRY : var.custom_npm_registry,   # ← new
  })
```

### 3. Update `run.sh` — replace both hardcoded URLs

**Line 81** — add `--registry` to the `npm install` command:

```bash
# Before:
    if ! npm install --no-audit --no-fund --omit=dev --ignore-scripts "$PKG_SPEC"; then

# After:
    if ! npm install --no-audit --no-fund --omit=dev --ignore-scripts --registry "${NPM_REGISTRY}" "$PKG_SPEC"; then
```

**Line 100** — use the variable for metadata URL:

```bash
# Before:
    META_URL="https://registry.npmjs.org/mux/$VERSION_TO_USE"

# After:
    META_URL="${NPM_REGISTRY}/mux/$VERSION_TO_USE"
```

**Line 139** — use the variable for tarball fallback URL:

```bash
# Before:
      TARBALL_URL="https://registry.npmjs.org/mux/-/mux-$VERSION_TO_USE.tgz"

# After:
      TARBALL_URL="${NPM_REGISTRY}/mux/-/mux-$VERSION_TO_USE.tgz"
```

### 4. Add test case in `mux.tftest.hcl`

Append a new test run to verify the custom registry flows into the script:

```hcl
run "custom_npm_registry" {
  command = plan

  variables {
    agent_id           = "foo"
    custom_npm_registry = "https://my-artifactory.example.com/npm"
  }

  assert {
    condition     = strcontains(resource.coder_script.mux.script, "https://my-artifactory.example.com/npm")
    error_message = "mux launch script must use the configured custom npm registry URL"
  }

  assert {
    condition     = !strcontains(resource.coder_script.mux.script, "registry.npmjs.org")
    error_message = "mux launch script must not contain hardcoded registry.npmjs.org when custom registry is set"
  }
}

run "custom_npm_registry_validation" {
  command = plan

  variables {
    agent_id           = "foo"
    custom_npm_registry = "not-a-url"
  }

  expect_failures = [
    var.custom_npm_registry
  ]
}
```

### 5. Bump module version

Run `.github/scripts/version-bump.sh minor` from the module directory (this is a new feature, not a bugfix or breaking change).

### 6. Update README

Add `custom_npm_registry` to the README's variable table / usage examples if one exists. Ensure the new version number is reflected.

## File Change Summary

| File | Change |
|---|---|
| `registry/coder/modules/mux/main.tf` | Add `custom_npm_registry` variable; pass `NPM_REGISTRY` to templatefile |
| `registry/coder/modules/mux/run.sh` | Replace 2 hardcoded URLs (lines 100, 139) with `${NPM_REGISTRY}`; add `--registry` to npm install (line 81) |
| `registry/coder/modules/mux/mux.tftest.hcl` | Add 2 new test runs: custom registry + validation |
| `registry/coder/modules/mux/README.md` | Document new variable |

## Validation

```bash
cd registry/coder/modules/mux
terraform init -upgrade && terraform test -verbose   # All existing + new tests pass
bun run fmt                                           # Format before commit
```

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh`_
