### PR TITLE
feat(agentapi): add agentapi_cache_dir for persistent binary caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,4 @@ gha-creds-*.json
 
 # IDEs
 .idea
+.serena

--- a/registry/coder/modules/agentapi/README.md
+++ b/registry/coder/modules/agentapi/README.md
@@ -16,7 +16,7 @@ The AgentAPI module is a building block for modules that need to run an AgentAPI
 ```tf
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "2.1.1"
+  version = "2.2.0"
 
   agent_id             = var.agent_id
   web_app_slug         = local.app_slug
@@ -61,6 +61,19 @@ module "agentapi" {
   task_log_snapshot = true # default: true
 }
 ```
+
+## Caching the AgentAPI binary
+
+When `agentapi_cache_dir` is set, the AgentAPI binary is cached to that directory after the first download. On subsequent workspace starts, the cached binary is used instead of re-downloading from GitHub. This is particularly useful when workspaces use a persistent volume.
+
+```tf
+module "agentapi" {
+  # ... other config
+  agentapi_cache_dir = "/home/coder/.cache/agentapi"
+}
+```
+
+The cached binary is stored with a name that includes the architecture and version (e.g., `agentapi-linux-amd64-v0.10.0`) so different versions can coexist in the same cache directory.
 
 ## For module developers
 

--- a/registry/coder/modules/agentapi/main.test.ts
+++ b/registry/coder/modules/agentapi/main.test.ts
@@ -163,9 +163,15 @@ describe("agentapi", async () => {
       },
     });
 
+    // Derive the binary name from the container's architecture so the test is
+    // portable across amd64 and arm64 hosts.
+    const archResult = await execContainer(id, ["uname", "-m"]);
+    expect(archResult.exitCode).toBe(0);
+    const agentArch =
+      archResult.stdout.trim() === "aarch64" ? "linux-arm64" : "linux-amd64";
+
     // Pre-populate the cache directory with a fake agentapi binary.
-    // The binary is named after the arch and pinned version.
-    const cachedBinary = `${cacheDir}/agentapi-linux-amd64-${pinnedVersion}`;
+    const cachedBinary = `${cacheDir}/agentapi-${agentArch}-${pinnedVersion}`;
     await execContainer(id, [
       "bash",
       "-c",
@@ -195,7 +201,14 @@ describe("agentapi", async () => {
       },
     });
 
-    const cachedBinary = `${cacheDir}/agentapi-linux-amd64-${pinnedVersion}`;
+    // Derive the binary name from the container's architecture so the test is
+    // portable across amd64 and arm64 hosts.
+    const archResult = await execContainer(id, ["uname", "-m"]);
+    expect(archResult.exitCode).toBe(0);
+    const agentArch =
+      archResult.stdout.trim() === "aarch64" ? "linux-arm64" : "linux-amd64";
+
+    const cachedBinary = `${cacheDir}/agentapi-${agentArch}-${pinnedVersion}`;
     const respModuleScript = await execModuleScript(id);
     expect(respModuleScript.exitCode).toBe(0);
     expect(respModuleScript.stdout).toContain(

--- a/registry/coder/modules/agentapi/main.test.ts
+++ b/registry/coder/modules/agentapi/main.test.ts
@@ -149,6 +149,71 @@ describe("agentapi", async () => {
     expect(respAgentAPI.exitCode).toBe(0);
   });
 
+  test("cache-dir-uses-cached-binary", async () => {
+    // Verify that when a cached binary exists in the cache dir, it is used
+    // instead of downloading. Use a pinned version so the cache filename is
+    // deterministic (resolving "latest" requires a network call).
+    const cacheDir = "/home/coder/.agentapi-cache";
+    const pinnedVersion = "v0.10.0";
+    const { id } = await setup({
+      moduleVariables: {
+        install_agentapi: "true",
+        agentapi_cache_dir: cacheDir,
+        agentapi_version: pinnedVersion,
+      },
+    });
+
+    // Pre-populate the cache directory with a fake agentapi binary.
+    // The binary is named after the arch and pinned version.
+    const cachedBinary = `${cacheDir}/agentapi-linux-amd64-${pinnedVersion}`;
+    await execContainer(id, [
+      "bash",
+      "-c",
+      `mkdir -p ${cacheDir} && cp /usr/bin/agentapi ${cachedBinary}`,
+    ]);
+
+    const respModuleScript = await execModuleScript(id);
+    expect(respModuleScript.exitCode).toBe(0);
+    expect(respModuleScript.stdout).toContain(
+      `Using cached AgentAPI binary from ${cachedBinary}`,
+    );
+
+    await expectAgentAPIStarted(id);
+  });
+
+  test("cache-dir-saves-binary-after-download", async () => {
+    // Verify that after downloading agentapi, the binary is saved to the cache
+    // dir under the resolved version name. Use a pinned version so the cache
+    // filename is deterministic.
+    const cacheDir = "/home/coder/.agentapi-cache";
+    const pinnedVersion = "v0.10.0";
+    const { id } = await setup({
+      skipAgentAPIMock: true,
+      moduleVariables: {
+        agentapi_cache_dir: cacheDir,
+        agentapi_version: pinnedVersion,
+      },
+    });
+
+    const cachedBinary = `${cacheDir}/agentapi-linux-amd64-${pinnedVersion}`;
+    const respModuleScript = await execModuleScript(id);
+    expect(respModuleScript.exitCode).toBe(0);
+    expect(respModuleScript.stdout).toContain(
+      `Caching AgentAPI binary to ${cachedBinary}`,
+    );
+
+    await expectAgentAPIStarted(id);
+
+    // Verify the binary was saved to the cache directory.
+    const respCacheCheck = await execContainer(id, [
+      "bash",
+      "-c",
+      `test -f ${cachedBinary} && echo "cached"`,
+    ]);
+    expect(respCacheCheck.exitCode).toBe(0);
+    expect(respCacheCheck.stdout).toContain("cached");
+  });
+
   test("no-subdomain-base-path", async () => {
     const { id } = await setup({
       moduleVariables: {

--- a/registry/coder/modules/agentapi/main.tf
+++ b/registry/coder/modules/agentapi/main.tf
@@ -164,6 +164,11 @@ variable "module_dir_name" {
   description = "Name of the subdirectory in the home directory for module files."
 }
 
+variable "agentapi_cache_dir" {
+  type        = string
+  description = "Path to a directory where the AgentAPI binary will be cached after download. On subsequent workspace starts, the cached binary is used instead of downloading again. Useful with persistent volumes to avoid repeated downloads."
+  default     = ""
+}
 
 locals {
   # we always trim the slash for consistency
@@ -209,6 +214,7 @@ resource "coder_script" "agentapi" {
     ARG_AGENTAPI_CHAT_BASE_PATH='${local.agentapi_chat_base_path}' \
     ARG_TASK_ID='${try(data.coder_task.me.id, "")}' \
     ARG_TASK_LOG_SNAPSHOT='${var.task_log_snapshot}' \
+    ARG_CACHE_DIR='${var.agentapi_cache_dir}' \
     /tmp/main.sh
     EOT
   run_on_start = true

--- a/registry/coder/modules/agentapi/main.tf
+++ b/registry/coder/modules/agentapi/main.tf
@@ -214,7 +214,7 @@ resource "coder_script" "agentapi" {
     ARG_AGENTAPI_CHAT_BASE_PATH='${local.agentapi_chat_base_path}' \
     ARG_TASK_ID='${try(data.coder_task.me.id, "")}' \
     ARG_TASK_LOG_SNAPSHOT='${var.task_log_snapshot}' \
-    ARG_CACHE_DIR='${var.agentapi_cache_dir}' \
+    ARG_CACHE_DIR="$(echo -n '${base64encode(var.agentapi_cache_dir)}' | base64 -d)" \
     /tmp/main.sh
     EOT
   run_on_start = true


### PR DESCRIPTION
## Description

Add an opt-in `agentapi_cache_dir` variable to avoid re-downloading the AgentAPI binary on every workspace start. When set, the binary is stored in that directory after the first download and reused on subsequent starts — useful with a shared persistent volume.

The binary is cached with a versioned filename (e.g. `agentapi-linux-amd64-v0.10.0`) so multiple versions coexist safely. When `agentapi_version = "latest"`, the actual release tag is resolved via GitHub's redirect before computing the cache key, so the cache never gets stuck on a stale binary. The resolution request is skipped entirely when `agentapi_cache_dir` is not set.

## Type of Change

- [ ] New module
- [ ] New template
- [ ] Bug fix
- [x] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder/modules/agentapi`
**New version:** `v2.2.0`
**Breaking change:** [ ] Yes [x] No

## Testing & Validation

- [x] Tests pass (`bun test` — all agentapi-specific tests pass)
- [x] Code formatted (`bun fmt`)
- [x] Changes tested locally

## Related Issues

None