### PR TITLE
feat: propagate agentapi_cache_dir to all agentapi-wrapping modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,4 @@ gha-creds-*.json
 
 # IDEs
 .idea
+.serena

--- a/registry/coder-labs/modules/auggie/README.md
+++ b/registry/coder-labs/modules/auggie/README.md
@@ -13,7 +13,7 @@ Run Auggie CLI in your workspace to access Augment's AI coding assistant with ad
 ```tf
 module "auggie" {
   source   = "registry.coder.com/coder-labs/auggie/coder"
-  version  = "0.3.0"
+  version  = "0.4.0"
   agent_id = coder_agent.example.id
   folder   = "/home/coder/project"
 }
@@ -47,7 +47,7 @@ module "coder-login" {
 
 module "auggie" {
   source   = "registry.coder.com/coder-labs/auggie/coder"
-  version  = "0.3.0"
+  version  = "0.4.0"
   agent_id = coder_agent.example.id
   folder   = "/home/coder/project"
 
@@ -103,7 +103,7 @@ EOF
 ```tf
 module "auggie" {
   source   = "registry.coder.com/coder-labs/auggie/coder"
-  version  = "0.3.0"
+  version  = "0.4.0"
   agent_id = coder_agent.example.id
   folder   = "/home/coder/project"
 

--- a/registry/coder-labs/modules/auggie/main.tf
+++ b/registry/coder-labs/modules/auggie/main.tf
@@ -73,6 +73,12 @@ variable "agentapi_version" {
   }
 }
 
+variable "agentapi_cache_dir" {
+  type        = string
+  description = "Path to a directory where the AgentAPI binary will be cached after download. On subsequent workspace starts, the cached binary is used instead of downloading again."
+  default     = ""
+}
+
 variable "pre_install_script" {
   type        = string
   description = "Custom script to run before installing Auggie."
@@ -179,7 +185,7 @@ locals {
 
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "2.0.0"
+  version = "2.2.0"
 
   agent_id             = var.agent_id
   folder               = local.folder
@@ -194,6 +200,7 @@ module "agentapi" {
   module_dir_name      = local.module_dir_name
   install_agentapi     = var.install_agentapi
   agentapi_version     = var.agentapi_version
+  agentapi_cache_dir   = var.agentapi_cache_dir
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script
   start_script         = <<-EOT

--- a/registry/coder-labs/modules/codex/README.md
+++ b/registry/coder-labs/modules/codex/README.md
@@ -13,7 +13,7 @@ Run Codex CLI in your workspace to access OpenAI's models through the Codex inte
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "4.1.1"
+  version        = "4.2.0"
   agent_id       = coder_agent.example.id
   openai_api_key = var.openai_api_key
   workdir        = "/home/coder/project"
@@ -32,7 +32,7 @@ module "codex" {
 module "codex" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "4.1.1"
+  version        = "4.2.0"
   agent_id       = coder_agent.example.id
   openai_api_key = "..."
   workdir        = "/home/coder/project"
@@ -51,7 +51,7 @@ For tasks integration with AI Bridge, add `enable_aibridge = true` to the [Usage
 ```tf
 module "codex" {
   source          = "registry.coder.com/coder-labs/codex/coder"
-  version         = "4.1.1"
+  version         = "4.2.0"
   agent_id        = coder_agent.example.id
   workdir         = "/home/coder/project"
   enable_aibridge = true
@@ -94,7 +94,7 @@ data "coder_task" "me" {}
 
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "4.1.1"
+  version        = "4.2.0"
   agent_id       = coder_agent.example.id
   openai_api_key = "..."
   ai_prompt      = data.coder_task.me.prompt
@@ -112,7 +112,7 @@ This example shows additional configuration options for custom models, MCP serve
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "4.1.1"
+  version        = "4.2.0"
   agent_id       = coder_agent.example.id
   openai_api_key = "..."
   workdir        = "/home/coder/project"

--- a/registry/coder-labs/modules/codex/main.tf
+++ b/registry/coder-labs/modules/codex/main.tf
@@ -134,6 +134,12 @@ variable "agentapi_version" {
   default     = "v0.11.8"
 }
 
+variable "agentapi_cache_dir" {
+  type        = string
+  description = "Path to a directory where the AgentAPI binary will be cached after download. On subsequent workspace starts, the cached binary is used instead of downloading again."
+  default     = ""
+}
+
 variable "codex_model" {
   type        = string
   description = "The model for Codex to use. Defaults to gpt-5.2-codex."
@@ -205,7 +211,7 @@ locals {
 
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "2.0.0"
+  version = "2.2.0"
 
   agent_id             = var.agent_id
   folder               = local.workdir
@@ -221,6 +227,7 @@ module "agentapi" {
   install_agentapi     = var.install_agentapi
   agentapi_subdomain   = var.subdomain
   agentapi_version     = var.agentapi_version
+  agentapi_cache_dir   = var.agentapi_cache_dir
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script
   start_script         = <<-EOT

--- a/registry/coder-labs/modules/copilot/README.md
+++ b/registry/coder-labs/modules/copilot/README.md
@@ -13,7 +13,7 @@ Run [GitHub Copilot CLI](https://docs.github.com/copilot/concepts/agents/about-c
 ```tf
 module "copilot" {
   source   = "registry.coder.com/coder-labs/copilot/coder"
-  version  = "0.3.0"
+  version  = "0.4.0"
   agent_id = coder_agent.example.id
   workdir  = "/home/coder/projects"
 }
@@ -51,7 +51,7 @@ data "coder_parameter" "ai_prompt" {
 
 module "copilot" {
   source   = "registry.coder.com/coder-labs/copilot/coder"
-  version  = "0.3.0"
+  version  = "0.4.0"
   agent_id = coder_agent.example.id
   workdir  = "/home/coder/projects"
 
@@ -71,7 +71,7 @@ Customize tool permissions, MCP servers, and Copilot settings:
 ```tf
 module "copilot" {
   source   = "registry.coder.com/coder-labs/copilot/coder"
-  version  = "0.3.0"
+  version  = "0.4.0"
   agent_id = coder_agent.example.id
   workdir  = "/home/coder/projects"
 
@@ -142,7 +142,7 @@ variable "github_token" {
 
 module "copilot" {
   source       = "registry.coder.com/coder-labs/copilot/coder"
-  version      = "0.3.0"
+  version      = "0.4.0"
   agent_id     = coder_agent.example.id
   workdir      = "/home/coder/projects"
   github_token = var.github_token
@@ -156,7 +156,7 @@ Run Copilot as a command-line tool without task reporting or web interface. This
 ```tf
 module "copilot" {
   source       = "registry.coder.com/coder-labs/copilot/coder"
-  version      = "0.3.0"
+  version      = "0.4.0"
   agent_id     = coder_agent.example.id
   workdir      = "/home/coder"
   report_tasks = false

--- a/registry/coder-labs/modules/copilot/main.tf
+++ b/registry/coder-labs/modules/copilot/main.tf
@@ -101,6 +101,12 @@ variable "agentapi_version" {
   default     = "v0.10.0"
 }
 
+variable "agentapi_cache_dir" {
+  type        = string
+  description = "Path to a directory where the AgentAPI binary will be cached after download. On subsequent workspace starts, the cached binary is used instead of downloading again."
+  default     = ""
+}
+
 variable "copilot_version" {
   type        = string
   description = "The version of GitHub Copilot CLI to install. Use 'latest' for the latest version or specify a version like '0.0.334'."
@@ -242,7 +248,7 @@ resource "coder_env" "github_token" {
 
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "2.0.0"
+  version = "2.2.0"
 
   agent_id             = var.agent_id
   folder               = local.workdir
@@ -259,6 +265,7 @@ module "agentapi" {
   module_dir_name      = local.module_dir_name
   install_agentapi     = var.install_agentapi
   agentapi_version     = var.agentapi_version
+  agentapi_cache_dir   = var.agentapi_cache_dir
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script
 

--- a/registry/coder-labs/modules/cursor-cli/README.md
+++ b/registry/coder-labs/modules/cursor-cli/README.md
@@ -13,7 +13,7 @@ Run the Cursor Agent CLI in your workspace for interactive coding assistance and
 ```tf
 module "cursor_cli" {
   source   = "registry.coder.com/coder-labs/cursor-cli/coder"
-  version  = "0.3.0"
+  version  = "0.4.0"
   agent_id = coder_agent.main.id
   folder   = "/home/coder/project"
 }
@@ -42,7 +42,7 @@ module "coder-login" {
 
 module "cursor_cli" {
   source   = "registry.coder.com/coder-labs/cursor-cli/coder"
-  version  = "0.3.0"
+  version  = "0.4.0"
   agent_id = coder_agent.main.id
   folder   = "/home/coder/project"
 

--- a/registry/coder-labs/modules/cursor-cli/main.tf
+++ b/registry/coder-labs/modules/cursor-cli/main.tf
@@ -59,6 +59,12 @@ variable "agentapi_version" {
   default     = "v0.10.0"
 }
 
+variable "agentapi_cache_dir" {
+  type        = string
+  description = "Path to a directory where the AgentAPI binary will be cached after download. On subsequent workspace starts, the cached binary is used instead of downloading again."
+  default     = ""
+}
+
 variable "force" {
   type        = bool
   description = "Force allow commands unless explicitly denied"
@@ -132,7 +138,7 @@ resource "coder_env" "cursor_api_key" {
 
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "2.0.0"
+  version = "2.2.0"
 
   agent_id             = var.agent_id
   folder               = local.folder
@@ -146,6 +152,7 @@ module "agentapi" {
   module_dir_name      = local.module_dir_name
   install_agentapi     = var.install_agentapi
   agentapi_version     = var.agentapi_version
+  agentapi_cache_dir   = var.agentapi_cache_dir
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script
   start_script         = <<-EOT

--- a/registry/coder-labs/modules/gemini/README.md
+++ b/registry/coder-labs/modules/gemini/README.md
@@ -13,7 +13,7 @@ Run [Gemini CLI](https://github.com/google-gemini/gemini-cli) in your workspace 
 ```tf
 module "gemini" {
   source   = "registry.coder.com/coder-labs/gemini/coder"
-  version  = "3.0.0"
+  version  = "3.1.0"
   agent_id = coder_agent.main.id
   folder   = "/home/coder/project"
 }
@@ -46,7 +46,7 @@ variable "gemini_api_key" {
 
 module "gemini" {
   source         = "registry.coder.com/coder-labs/gemini/coder"
-  version        = "3.0.0"
+  version        = "3.1.0"
   agent_id       = coder_agent.main.id
   gemini_api_key = var.gemini_api_key
   folder         = "/home/coder/project"
@@ -94,7 +94,7 @@ data "coder_parameter" "ai_prompt" {
 module "gemini" {
   count                = data.coder_workspace.me.start_count
   source               = "registry.coder.com/coder-labs/gemini/coder"
-  version              = "3.0.0"
+  version              = "3.1.0"
   agent_id             = coder_agent.main.id
   gemini_api_key       = var.gemini_api_key
   gemini_model         = "gemini-2.5-flash"
@@ -118,7 +118,7 @@ For enterprise users who prefer Google's Vertex AI platform:
 ```tf
 module "gemini" {
   source         = "registry.coder.com/coder-labs/gemini/coder"
-  version        = "3.0.0"
+  version        = "3.1.0"
   agent_id       = coder_agent.main.id
   gemini_api_key = var.gemini_api_key
   folder         = "/home/coder/project"

--- a/registry/coder-labs/modules/gemini/main.tf
+++ b/registry/coder-labs/modules/gemini/main.tf
@@ -84,6 +84,12 @@ variable "agentapi_version" {
   default     = "v0.10.0"
 }
 
+variable "agentapi_cache_dir" {
+  type        = string
+  description = "Path to a directory where the AgentAPI binary will be cached after download. On subsequent workspace starts, the cached binary is used instead of downloading again."
+  default     = ""
+}
+
 variable "gemini_model" {
   type        = string
   description = "The model to use for Gemini (e.g., gemini-2.5-pro)."
@@ -177,7 +183,7 @@ EOT
 
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "2.0.0"
+  version = "2.2.0"
 
   agent_id             = var.agent_id
   folder               = local.folder
@@ -191,6 +197,7 @@ module "agentapi" {
   module_dir_name      = local.module_dir_name
   install_agentapi     = var.install_agentapi
   agentapi_version     = var.agentapi_version
+  agentapi_cache_dir   = var.agentapi_cache_dir
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script
   install_script       = <<-EOT

--- a/registry/coder-labs/modules/opencode/README.md
+++ b/registry/coder-labs/modules/opencode/README.md
@@ -13,7 +13,7 @@ Run [OpenCode](https://opencode.ai) AI coding assistant in your workspace for in
 ```tf
 module "opencode" {
   source   = "registry.coder.com/coder-labs/opencode/coder"
-  version  = "0.1.1"
+  version  = "0.2.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 }
@@ -34,7 +34,7 @@ resource "coder_ai_task" "task" {
 
 module "opencode" {
   source   = "registry.coder.com/coder-labs/opencode/coder"
-  version  = "0.1.1"
+  version  = "0.2.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -89,7 +89,7 @@ Run OpenCode as a command-line tool without web interface or task reporting:
 ```tf
 module "opencode" {
   source       = "registry.coder.com/coder-labs/opencode/coder"
-  version      = "0.1.1"
+  version      = "0.2.0"
   agent_id     = coder_agent.main.id
   workdir      = "/home/coder"
   report_tasks = false

--- a/registry/coder-labs/modules/opencode/main.tf
+++ b/registry/coder-labs/modules/opencode/main.tf
@@ -89,6 +89,12 @@ variable "agentapi_version" {
   default     = "v0.11.2"
 }
 
+variable "agentapi_cache_dir" {
+  type        = string
+  description = "Path to a directory where the AgentAPI binary will be cached after download. On subsequent workspace starts, the cached binary is used instead of downloading again."
+  default     = ""
+}
+
 variable "ai_prompt" {
   type        = string
   description = "Initial task prompt for OpenCode."
@@ -147,7 +153,7 @@ locals {
 
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "2.0.0"
+  version = "2.2.0"
 
   agent_id             = var.agent_id
   web_app_slug         = local.app_slug
@@ -163,6 +169,7 @@ module "agentapi" {
   module_dir_name      = local.module_dir_name
   install_agentapi     = var.install_agentapi
   agentapi_version     = var.agentapi_version
+  agentapi_cache_dir   = var.agentapi_cache_dir
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script
   start_script         = <<-EOT

--- a/registry/coder-labs/modules/sourcegraph-amp/README.md
+++ b/registry/coder-labs/modules/sourcegraph-amp/README.md
@@ -13,7 +13,7 @@ Run [Amp CLI](https://ampcode.com/) in your workspace to access Sourcegraph's AI
 ```tf
 module "amp-cli" {
   source           = "registry.coder.com/coder-labs/sourcegraph-amp/coder"
-  version          = "3.0.0"
+  version          = "3.1.0"
   agent_id         = coder_agent.example.id
   amp_api_key      = var.amp_api_key
   install_amp      = true

--- a/registry/coder-labs/modules/sourcegraph-amp/main.tf
+++ b/registry/coder-labs/modules/sourcegraph-amp/main.tf
@@ -58,6 +58,12 @@ variable "agentapi_version" {
   default     = "v0.11.1"
 }
 
+variable "agentapi_cache_dir" {
+  type        = string
+  description = "Path to a directory where the AgentAPI binary will be cached after download. On subsequent workspace starts, the cached binary is used instead of downloading again."
+  default     = ""
+}
+
 variable "cli_app" {
   type        = bool
   description = "Whether to create a CLI app for Claude Code"
@@ -220,7 +226,7 @@ locals {
 
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "2.0.0"
+  version = "2.2.0"
 
   agent_id             = var.agent_id
   folder               = local.workdir
@@ -235,6 +241,7 @@ module "agentapi" {
   module_dir_name      = local.module_dir_name
   install_agentapi     = var.install_agentapi
   agentapi_version     = var.agentapi_version
+  agentapi_cache_dir   = var.agentapi_cache_dir
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script
   start_script         = <<-EOT

--- a/registry/coder/modules/aider/README.md
+++ b/registry/coder/modules/aider/README.md
@@ -19,7 +19,7 @@ variable "api_key" {
 
 module "aider" {
   source      = "registry.coder.com/coder/aider/coder"
-  version     = "2.0.1"
+  version     = "2.1.0"
   agent_id    = coder_agent.main.id
   api_key     = var.api_key
   ai_provider = "google"
@@ -50,7 +50,7 @@ variable "gemini_api_key" {
 
 module "aider" {
   source           = "registry.coder.com/coder/aider/coder"
-  version          = "2.0.1"
+  version          = "2.1.0"
   agent_id         = coder_agent.main.id
   api_key          = var.gemini_api_key
   install_aider    = true
@@ -75,7 +75,7 @@ variable "custom_api_key" {
 module "aider" {
   count               = data.coder_workspace.me.start_count
   source              = "registry.coder.com/coder/aider/coder"
-  version             = "2.0.1"
+  version             = "2.1.0"
   agent_id            = coder_agent.main.id
   workdir             = "/home/coder"
   ai_provider         = "custom"

--- a/registry/coder/modules/aider/main.tf
+++ b/registry/coder/modules/aider/main.tf
@@ -96,6 +96,12 @@ variable "agentapi_version" {
   default     = "v0.10.0"
 }
 
+variable "agentapi_cache_dir" {
+  type        = string
+  description = "Path to a directory where the AgentAPI binary will be cached after download. On subsequent workspace starts, the cached binary is used instead of downloading again."
+  default     = ""
+}
+
 variable "ai_prompt" {
   type        = string
   description = "Initial task prompt for Aider."
@@ -229,7 +235,7 @@ details, or encounter blockers
 
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "1.2.0"
+  version = "2.2.0"
 
   agent_id             = var.agent_id
   web_app_slug         = local.app_slug
@@ -244,6 +250,7 @@ module "agentapi" {
   module_dir_name      = local.module_dir_name
   install_agentapi     = var.install_agentapi
   agentapi_version     = var.agentapi_version
+  agentapi_cache_dir   = var.agentapi_cache_dir
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script
   start_script         = <<-EOT

--- a/registry/coder/modules/amazon-q/README.md
+++ b/registry/coder/modules/amazon-q/README.md
@@ -13,7 +13,7 @@ Run [Amazon Q](https://aws.amazon.com/q/) in your workspace to access Amazon's A
 ```tf
 module "amazon-q" {
   source   = "registry.coder.com/coder/amazon-q/coder"
-  version  = "3.0.1"
+  version  = "3.1.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder"
 
@@ -102,7 +102,7 @@ data "coder_parameter" "ai_prompt" {
 
 module "amazon-q" {
   source          = "registry.coder.com/coder/amazon-q/coder"
-  version         = "3.0.1"
+  version         = "3.1.0"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder"
   auth_tarball    = var.amazon_q_auth_tarball
@@ -228,7 +228,7 @@ If no custom `agent_config` is provided, the default agent name "agent" is used.
 ```tf
 module "amazon-q" {
   source       = "registry.coder.com/coder/amazon-q/coder"
-  version      = "3.0.1"
+  version      = "3.1.0"
   agent_id     = coder_agent.main.id
   workdir      = "/home/coder"
   auth_tarball = var.amazon_q_auth_tarball
@@ -258,7 +258,7 @@ This example will:
 ```tf
 module "amazon-q" {
   source          = "registry.coder.com/coder/amazon-q/coder"
-  version         = "3.0.1"
+  version         = "3.1.0"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder"
   auth_tarball    = var.amazon_q_auth_tarball
@@ -279,7 +279,7 @@ module "amazon-q" {
 ```tf
 module "amazon-q" {
   source       = "registry.coder.com/coder/amazon-q/coder"
-  version      = "3.0.1"
+  version      = "3.1.0"
   agent_id     = coder_agent.main.id
   workdir      = "/home/coder"
   auth_tarball = var.amazon_q_auth_tarball
@@ -305,7 +305,7 @@ module "amazon-q" {
 ```tf
 module "amazon-q" {
   source           = "registry.coder.com/coder/amazon-q/coder"
-  version          = "3.0.1"
+  version          = "3.1.0"
   agent_id         = coder_agent.main.id
   workdir          = "/home/coder"
   auth_tarball     = var.amazon_q_auth_tarball
@@ -319,7 +319,7 @@ module "amazon-q" {
 ```tf
 module "amazon-q" {
   source       = "registry.coder.com/coder/amazon-q/coder"
-  version      = "3.0.1"
+  version      = "3.1.0"
   agent_id     = coder_agent.main.id
   workdir      = "/home/coder"
   auth_tarball = var.amazon_q_auth_tarball
@@ -341,7 +341,7 @@ module "amazon-q" {
 ```tf
 module "amazon-q" {
   source       = "registry.coder.com/coder/amazon-q/coder"
-  version      = "3.0.1"
+  version      = "3.1.0"
   agent_id     = coder_agent.main.id
   workdir      = "/home/coder"
   auth_tarball = var.amazon_q_auth_tarball
@@ -359,7 +359,7 @@ For environments without direct internet access, you can host Amazon Q installat
 ```tf
 module "amazon-q" {
   source       = "registry.coder.com/coder/amazon-q/coder"
-  version      = "3.0.1"
+  version      = "3.1.0"
   agent_id     = coder_agent.main.id
   workdir      = "/home/coder"
   auth_tarball = var.amazon_q_auth_tarball

--- a/registry/coder/modules/amazon-q/main.tf
+++ b/registry/coder/modules/amazon-q/main.tf
@@ -91,6 +91,12 @@ variable "agentapi_version" {
   default     = "v0.10.0"
 }
 
+variable "agentapi_cache_dir" {
+  type        = string
+  description = "Path to a directory where the AgentAPI binary will be cached after download. On subsequent workspace starts, the cached binary is used instead of downloading again."
+  default     = ""
+}
+
 variable "workdir" {
   type        = string
   description = "The folder to run Amazon Q in."
@@ -214,7 +220,7 @@ locals {
 
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "2.0.0"
+  version = "2.2.0"
 
   agent_id             = var.agent_id
   folder               = local.workdir
@@ -229,6 +235,7 @@ module "agentapi" {
   module_dir_name      = local.module_dir_name
   install_agentapi     = var.install_agentapi
   agentapi_version     = var.agentapi_version
+  agentapi_cache_dir   = var.agentapi_cache_dir
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script
 

--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Run the [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
 ```tf
 module "claude-code" {
   source         = "registry.coder.com/coder/claude-code/coder"
-  version        = "4.7.5"
+  version        = "4.8.0"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   claude_api_key = "xxxx-xxxxx-xxxx"
@@ -47,7 +47,7 @@ By default, when `enable_boundary = true`, the module uses `coder boundary` subc
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.7.5"
+  version         = "4.8.0"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_boundary = true
@@ -68,7 +68,7 @@ For tasks integration with AI Bridge, add `enable_aibridge = true` to the [Usage
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.7.5"
+  version         = "4.8.0"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_aibridge = true
@@ -97,7 +97,7 @@ data "coder_task" "me" {}
 
 module "claude-code" {
   source    = "registry.coder.com/coder/claude-code/coder"
-  version   = "4.7.5"
+  version   = "4.8.0"
   agent_id  = coder_agent.main.id
   workdir   = "/home/coder/project"
   ai_prompt = data.coder_task.me.prompt
@@ -120,7 +120,7 @@ This example shows additional configuration options for version pinning, custom 
 ```tf
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.7.5"
+  version  = "4.8.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -176,7 +176,7 @@ Run and configure Claude Code as a standalone CLI in your workspace.
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "4.7.5"
+  version             = "4.8.0"
   agent_id            = coder_agent.main.id
   workdir             = "/home/coder/project"
   install_claude_code = true
@@ -198,7 +198,7 @@ variable "claude_code_oauth_token" {
 
 module "claude-code" {
   source                  = "registry.coder.com/coder/claude-code/coder"
-  version                 = "4.7.5"
+  version                 = "4.8.0"
   agent_id                = coder_agent.main.id
   workdir                 = "/home/coder/project"
   claude_code_oauth_token = var.claude_code_oauth_token
@@ -271,7 +271,7 @@ resource "coder_env" "bedrock_api_key" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.7.5"
+  version  = "4.8.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -328,7 +328,7 @@ resource "coder_env" "google_application_credentials" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.7.5"
+  version  = "4.8.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "claude-sonnet-4@20250514"

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -89,6 +89,12 @@ variable "agentapi_version" {
   default     = "v0.11.8"
 }
 
+variable "agentapi_cache_dir" {
+  type        = string
+  description = "Path to a directory where the AgentAPI binary will be cached after download. On subsequent workspace starts, the cached binary is used instead of downloading again."
+  default     = ""
+}
+
 variable "ai_prompt" {
   type        = string
   description = "Initial task prompt for Claude Code."
@@ -356,7 +362,7 @@ locals {
 
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "2.0.0"
+  version = "2.2.0"
 
   agent_id             = var.agent_id
   web_app_slug         = local.app_slug
@@ -372,6 +378,7 @@ module "agentapi" {
   module_dir_name      = local.module_dir_name
   install_agentapi     = var.install_agentapi
   agentapi_version     = var.agentapi_version
+  agentapi_cache_dir   = var.agentapi_cache_dir
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script
   start_script         = <<-EOT

--- a/registry/coder/modules/goose/README.md
+++ b/registry/coder/modules/goose/README.md
@@ -13,7 +13,7 @@ Run the [Goose](https://block.github.io/goose/) agent in your workspace to gener
 ```tf
 module "goose" {
   source           = "registry.coder.com/coder/goose/coder"
-  version          = "3.0.1"
+  version          = "3.1.0"
   agent_id         = coder_agent.main.id
   folder           = "/home/coder"
   install_goose    = true
@@ -79,7 +79,7 @@ resource "coder_agent" "main" {
 module "goose" {
   count            = data.coder_workspace.me.start_count
   source           = "registry.coder.com/coder/goose/coder"
-  version          = "3.0.1"
+  version          = "3.1.0"
   agent_id         = coder_agent.main.id
   folder           = "/home/coder"
   install_goose    = true

--- a/registry/coder/modules/goose/main.tf
+++ b/registry/coder/modules/goose/main.tf
@@ -66,6 +66,12 @@ variable "agentapi_version" {
   default     = "v0.10.0"
 }
 
+variable "agentapi_cache_dir" {
+  type        = string
+  description = "Path to a directory where the AgentAPI binary will be cached after download. On subsequent workspace starts, the cached binary is used instead of downloading again."
+  default     = ""
+}
+
 variable "subdomain" {
   type        = bool
   description = "Whether to use a subdomain for AgentAPI."
@@ -140,7 +146,7 @@ EOT
 
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "2.0.0"
+  version = "2.2.0"
 
   agent_id             = var.agent_id
   web_app_slug         = local.app_slug
@@ -153,6 +159,7 @@ module "agentapi" {
   module_dir_name      = local.module_dir_name
   install_agentapi     = var.install_agentapi
   agentapi_version     = var.agentapi_version
+  agentapi_cache_dir   = var.agentapi_cache_dir
   agentapi_subdomain   = var.subdomain
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script

--- a/registry/harleylrn/modules/kiro-cli/README.md
+++ b/registry/harleylrn/modules/kiro-cli/README.md
@@ -13,7 +13,7 @@ Run [Kiro CLI](https://kiro.dev/) in your workspace to access AI coding assistan
 ```tf
 module "kiro-cli" {
   source   = "registry.coder.com/harleylrn/kiro-cli/coder"
-  version  = "1.0.1"
+  version  = "1.1.0"
   agent_id = coder_agent.example.id
   workdir  = "/home/coder"
 
@@ -96,7 +96,7 @@ data "coder_task" "me" {}
 module "kiro-cli" {
   count           = data.coder_task.me.enabled ? data.coder_workspace.me.start_count : 0
   source          = "registry.coder.com/harleylrn/kiro-cli/coder"
-  version         = "1.0.1"
+  version         = "1.1.0"
   agent_id        = coder_agent.example.id
   workdir         = "/home/coder"
   auth_tarball    = var.kiro_cli_auth_tarball
@@ -221,7 +221,7 @@ If no custom `agent_config` is provided, the default agent name "agent" is used.
 ```tf
 module "kiro-cli" {
   source       = "registry.coder.com/harleylrn/kiro-cli/coder"
-  version      = "1.0.1"
+  version      = "1.1.0"
   agent_id     = coder_agent.example.id
   workdir      = "/home/coder"
   auth_tarball = var.kiro_cli_auth_tarball
@@ -251,7 +251,7 @@ This example will:
 ```tf
 module "kiro-cli" {
   source          = "registry.coder.com/harleylrn/kiro-cli/coder"
-  version         = "1.0.1"
+  version         = "1.1.0"
   agent_id        = coder_agent.example.id
   workdir         = "/home/coder"
   auth_tarball    = var.kiro_cli_auth_tarball
@@ -272,7 +272,7 @@ module "kiro-cli" {
 ```tf
 module "kiro-cli" {
   source       = "registry.coder.com/harleylrn/kiro-cli/coder"
-  version      = "1.0.1"
+  version      = "1.1.0"
   agent_id     = coder_agent.example.id
   workdir      = "/home/coder"
   auth_tarball = var.kiro_cli_auth_tarball
@@ -298,7 +298,7 @@ module "kiro-cli" {
 ```tf
 module "kiro-cli" {
   source           = "registry.coder.com/harleylrn/kiro-cli/coder"
-  version          = "1.0.1"
+  version          = "1.1.0"
   agent_id         = coder_agent.example.id
   workdir          = "/home/coder"
   auth_tarball     = var.kiro_cli_auth_tarball
@@ -312,7 +312,7 @@ module "kiro-cli" {
 ```tf
 module "kiro-cli" {
   source       = "registry.coder.com/harleylrn/kiro-cli/coder"
-  version      = "1.0.1"
+  version      = "1.1.0"
   agent_id     = coder_agent.example.id
   workdir      = "/home/coder"
   auth_tarball = var.kiro_cli_auth_tarball
@@ -333,7 +333,7 @@ module "kiro-cli" {
 ```tf
 module "kiro-cli" {
   source       = "registry.coder.com/harleylrn/kiro-cli/coder"
-  version      = "1.0.1"
+  version      = "1.1.0"
   agent_id     = coder_agent.example.id
   workdir      = "/home/coder"
   auth_tarball = var.kiro_cli_auth_tarball
@@ -351,7 +351,7 @@ For environments without direct internet access, you can host Kiro CLI installat
 ```tf
 module "kiro-cli" {
   source       = "registry.coder.com/harleylrn/kiro-cli/coder"
-  version      = "1.0.1"
+  version      = "1.1.0"
   agent_id     = coder_agent.example.id
   workdir      = "/home/coder"
   auth_tarball = var.kiro_cli_auth_tarball

--- a/registry/harleylrn/modules/kiro-cli/main.tf
+++ b/registry/harleylrn/modules/kiro-cli/main.tf
@@ -91,6 +91,12 @@ variable "agentapi_version" {
   default     = "v0.10.0"
 }
 
+variable "agentapi_cache_dir" {
+  type        = string
+  description = "Path to a directory where the AgentAPI binary will be cached after download. On subsequent workspace starts, the cached binary is used instead of downloading again."
+  default     = ""
+}
+
 variable "workdir" {
   type        = string
   description = "The folder to run Kiro CLI in."
@@ -215,7 +221,7 @@ locals {
 
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "2.0.0"
+  version = "2.2.0"
 
   agent_id             = var.agent_id
   folder               = local.workdir
@@ -230,6 +236,7 @@ module "agentapi" {
   module_dir_name      = local.module_dir_name
   install_agentapi     = var.install_agentapi
   agentapi_version     = var.agentapi_version
+  agentapi_cache_dir   = var.agentapi_cache_dir
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script
 


### PR DESCRIPTION
## Description

Expose the `agentapi_cache_dir` variable (added in agentapi v2.2.0) in all 12 modules that wrap agentapi: `claude-code`, `amazon-q`, `aider`, `goose`, `auggie`, `codex`, `gemini`, `opencode`, `sourcegraph-amp`, `copilot`, `cursor-cli`, `kiro-cli`.

Bumps the agentapi dependency to `v2.2.0` in each and minor-bumps each wrapper's own version.

## Type of Change

- [ ] New module
- [ ] New template
- [ ] Bug fix
- [x] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder/modules/{claude-code,amazon-q,aider,goose}`, `registry/coder-labs/modules/{auggie,codex,gemini,opencode,sourcegraph-amp,copilot,cursor-cli}`, `registry/harleylrn/modules/kiro-cli`
**New version:** minor bump on each wrapper
**Breaking change:** [ ] Yes [x] No

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun fmt`)
- [x] Changes tested locally

## Related Issues

Depends on: `feat/agentapi-cache-dir` (https://github.com/coder/registry/pull/769) (agentapi v2.2.0 must be released first)