### PR TITLE
fix(registry/coder/modules): write bootstrap scripts to module dir instead of /tmp

### DIFF
--- a/registry/coder/modules/agentapi/README.md
+++ b/registry/coder/modules/agentapi/README.md
@@ -16,7 +16,7 @@ The AgentAPI module is a building block for modules that need to run an AgentAPI
 ```tf
 module "agentapi" {
   source  = "registry.coder.com/coder/agentapi/coder"
-  version = "2.1.1"
+  version = "2.1.2"
 
   agent_id             = var.agent_id
   web_app_slug         = local.app_slug

--- a/registry/coder/modules/agentapi/main.test.ts
+++ b/registry/coder/modules/agentapi/main.test.ts
@@ -309,16 +309,22 @@ describe("agentapi", async () => {
         "../scripts/agentapi-shutdown.sh",
       );
 
+      const shutdownScriptPath = `/home/coder/${moduleDirName}/scripts/agentapi-shutdown.sh`;
+      await execContainer(containerId, [
+        "bash",
+        "-c",
+        `mkdir -p /home/coder/${moduleDirName}/scripts`,
+      ]);
       await writeExecutable({
         containerId,
-        filePath: "/tmp/shutdown.sh",
+        filePath: shutdownScriptPath,
         content: shutdownScript,
       });
 
       return await execContainer(containerId, [
         "bash",
         "-c",
-        `ARG_TASK_ID=${taskId} ARG_AGENTAPI_PORT=3284 CODER_AGENT_URL=http://localhost:18080 CODER_AGENT_TOKEN=test-token /tmp/shutdown.sh`,
+        `ARG_TASK_ID=${taskId} ARG_AGENTAPI_PORT=3284 CODER_AGENT_URL=http://localhost:18080 CODER_AGENT_TOKEN=test-token ${shutdownScriptPath}`,
       ]);
     };
 

--- a/registry/coder/modules/agentapi/main.tf
+++ b/registry/coder/modules/agentapi/main.tf
@@ -193,8 +193,10 @@ resource "coder_script" "agentapi" {
     set -o errexit
     set -o pipefail
 
-    echo -n '${base64encode(local.main_script)}' | base64 -d > /tmp/main.sh
-    chmod +x /tmp/main.sh
+    SCRIPT_DIR="$HOME/${var.module_dir_name}/scripts"
+    mkdir -p "$SCRIPT_DIR"
+    echo -n '${base64encode(local.main_script)}' | base64 -d > "$SCRIPT_DIR/agentapi-main.sh"
+    chmod +x "$SCRIPT_DIR/agentapi-main.sh"
 
     ARG_MODULE_DIR_NAME='${var.module_dir_name}' \
     ARG_WORKDIR="$(echo -n '${base64encode(local.workdir)}' | base64 -d)" \
@@ -209,7 +211,7 @@ resource "coder_script" "agentapi" {
     ARG_AGENTAPI_CHAT_BASE_PATH='${local.agentapi_chat_base_path}' \
     ARG_TASK_ID='${try(data.coder_task.me.id, "")}' \
     ARG_TASK_LOG_SNAPSHOT='${var.task_log_snapshot}' \
-    /tmp/main.sh
+    "$SCRIPT_DIR/agentapi-main.sh"
     EOT
   run_on_start = true
 }
@@ -223,13 +225,15 @@ resource "coder_script" "agentapi_shutdown" {
     #!/bin/bash
     set -o pipefail
 
-    echo -n '${base64encode(local.shutdown_script)}' | base64 -d > /tmp/agentapi-shutdown.sh
-    chmod +x /tmp/agentapi-shutdown.sh
+    SCRIPT_DIR="$HOME/${var.module_dir_name}/scripts"
+    mkdir -p "$SCRIPT_DIR"
+    echo -n '${base64encode(local.shutdown_script)}' | base64 -d > "$SCRIPT_DIR/agentapi-shutdown.sh"
+    chmod +x "$SCRIPT_DIR/agentapi-shutdown.sh"
 
     ARG_TASK_ID='${try(data.coder_task.me.id, "")}' \
     ARG_TASK_LOG_SNAPSHOT='${var.task_log_snapshot}' \
     ARG_AGENTAPI_PORT='${var.agentapi_port}' \
-    /tmp/agentapi-shutdown.sh
+    "$SCRIPT_DIR/agentapi-shutdown.sh"
     EOT
 }
 

--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Run the [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
 ```tf
 module "claude-code" {
   source         = "registry.coder.com/coder/claude-code/coder"
-  version        = "4.7.5"
+  version        = "4.7.6"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   claude_api_key = "xxxx-xxxxx-xxxx"
@@ -47,7 +47,7 @@ By default, when `enable_boundary = true`, the module uses `coder boundary` subc
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.7.5"
+  version         = "4.7.6"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_boundary = true
@@ -68,7 +68,7 @@ For tasks integration with AI Bridge, add `enable_aibridge = true` to the [Usage
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.7.5"
+  version         = "4.7.6"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_aibridge = true
@@ -97,7 +97,7 @@ data "coder_task" "me" {}
 
 module "claude-code" {
   source    = "registry.coder.com/coder/claude-code/coder"
-  version   = "4.7.5"
+  version   = "4.7.6"
   agent_id  = coder_agent.main.id
   workdir   = "/home/coder/project"
   ai_prompt = data.coder_task.me.prompt
@@ -120,7 +120,7 @@ This example shows additional configuration options for version pinning, custom 
 ```tf
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.7.5"
+  version  = "4.7.6"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -176,7 +176,7 @@ Run and configure Claude Code as a standalone CLI in your workspace.
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "4.7.5"
+  version             = "4.7.6"
   agent_id            = coder_agent.main.id
   workdir             = "/home/coder/project"
   install_claude_code = true
@@ -198,7 +198,7 @@ variable "claude_code_oauth_token" {
 
 module "claude-code" {
   source                  = "registry.coder.com/coder/claude-code/coder"
-  version                 = "4.7.5"
+  version                 = "4.7.6"
   agent_id                = coder_agent.main.id
   workdir                 = "/home/coder/project"
   claude_code_oauth_token = var.claude_code_oauth_token
@@ -271,7 +271,7 @@ resource "coder_env" "bedrock_api_key" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.7.5"
+  version  = "4.7.6"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -328,7 +328,7 @@ resource "coder_env" "google_application_credentials" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.7.5"
+  version  = "4.7.6"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "claude-sonnet-4@20250514"

--- a/registry/coder/modules/claude-code/scripts/install.sh
+++ b/registry/coder/modules/claude-code/scripts/install.sh
@@ -17,6 +17,7 @@ ARG_CLAUDE_BINARY_PATH="${ARG_CLAUDE_BINARY_PATH//\$HOME/$HOME}"
 ARG_INSTALL_VIA_NPM=${ARG_INSTALL_VIA_NPM:-false}
 ARG_REPORT_TASKS=${ARG_REPORT_TASKS:-true}
 ARG_MCP_APP_STATUS_SLUG=${ARG_MCP_APP_STATUS_SLUG:-}
+ARG_AGENTAPI_PORT=${ARG_AGENTAPI_PORT:-3284}
 ARG_MCP=$(echo -n "${ARG_MCP:-}" | base64 -d)
 ARG_MCP_CONFIG_REMOTE_PATH=$(echo -n "${ARG_MCP_CONFIG_REMOTE_PATH:-}" | base64 -d)
 ARG_ALLOWED_TOOLS=${ARG_ALLOWED_TOOLS:-}
@@ -34,6 +35,7 @@ printf "ARG_CLAUDE_BINARY_PATH: %s\n" "$ARG_CLAUDE_BINARY_PATH"
 printf "ARG_INSTALL_VIA_NPM: %s\n" "$ARG_INSTALL_VIA_NPM"
 printf "ARG_REPORT_TASKS: %s\n" "$ARG_REPORT_TASKS"
 printf "ARG_MCP_APP_STATUS_SLUG: %s\n" "$ARG_MCP_APP_STATUS_SLUG"
+printf "ARG_AGENTAPI_PORT: %s\n" "$ARG_AGENTAPI_PORT"
 printf "ARG_MCP: %s\n" "$ARG_MCP"
 printf "ARG_MCP_CONFIG_REMOTE_PATH: %s\n" "$ARG_MCP_CONFIG_REMOTE_PATH"
 printf "ARG_ALLOWED_TOOLS: %s\n" "$ARG_ALLOWED_TOOLS"
@@ -228,7 +230,7 @@ function report_tasks() {
   if [ "$ARG_REPORT_TASKS" = "true" ]; then
     echo "Configuring Claude Code to report tasks via Coder MCP..."
     export CODER_MCP_APP_STATUS_SLUG="$ARG_MCP_APP_STATUS_SLUG"
-    export CODER_MCP_AI_AGENTAPI_URL="http://localhost:3284"
+    export CODER_MCP_AI_AGENTAPI_URL="http://localhost:${ARG_AGENTAPI_PORT:-3284}"
     coder exp mcp configure claude-code "$ARG_WORKDIR"
   else
     configure_standalone_mode


### PR DESCRIPTION
Bootstrap scripts used fixed /tmp paths with generic names like
/tmp/main.sh, making them easy to collide with or accidentally
overwrite. Write them into $HOME/<module_dir_name>/scripts/ instead,
following the pattern used by the agent-helper module.

Also fix install.sh hardcoding port 3284 instead of using
ARG_AGENTAPI_PORT.

Refs #736
