### PR TITLE
Remove '--retry-all-errors' from curl command

### DIFF
--- a/registry/coder/modules/agentapi/scripts/main.sh
+++ b/registry/coder/modules/agentapi/scripts/main.sh
@@ -73,7 +73,6 @@ if [ "${INSTALL_AGENTAPI}" = "true" ]; then
     --retry 5 \
     --retry-delay 5 \
     --fail \
-    --retry-all-errors \
     -L \
     -C - \
     -o agentapi \


### PR DESCRIPTION
Removed the '--retry-all-errors' option from curl command.

## Description

<!-- Briefly describe what this PR does and why -->

## Type of Change

- [ ] New module
- [ ] New template
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information


## Template Information


## Testing & Validation

- [ ] Tests pass (`bun test`)
- [ ] Code formatted (`bun fmt`)
- [ ] Changes tested locally

## Related Issues
https://github.com/coder/registry/issues/778
