### PR TITLE
ci: remove branch filter to support stacked PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 on:
   pull_request:
-    branches: [main]
+
 # Cancel in-progress runs for pull requests when developers push new changes
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description

Remove `branches: [main]` filter from the CI workflow so it triggers on PRs targeting any branch, not just `main`. This enables CI to run on stacked PRs (where the base branch is another PR branch, not `main`).

This matches the approach used in [coder/coder](https://github.com/coder/coder/blob/main/.github/workflows/ci.yaml#L9). 

## Type of Change

- [ ] New module
- [ ] New template
- [ ] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [x] Other

Related to internal Slack thread: https://codercom.slack.com/archives/C08PHACTZRB/p1772702628637129?thread_ts=1772538788.281829&cid=C08PHACTZRB
