### PR TITLE
feat: enhance boundary configuration options in Claude Code module

### DIFF
--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Run the [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
 ```tf
 module "claude-code" {
   source         = "registry.coder.com/coder/claude-code/coder"
-  version        = "4.9.2"
+  version = "4.9.3"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   claude_api_key = "xxxx-xxxxx-xxxx"
@@ -67,7 +67,7 @@ The module writes the config to `~/.config/coder_boundary/config.yaml` automatic
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.9.2"
+  version = "4.9.3"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_boundary = true
@@ -87,7 +87,7 @@ Use this when the config file is provisioned separately or managed outside the t
 ```tf
 module "claude-code" {
   source               = "registry.coder.com/coder/claude-code/coder"
-  version              = "4.9.2"
+  version = "4.9.3"
   agent_id             = coder_agent.main.id
   workdir              = "/home/coder/project"
   enable_boundary      = true
@@ -109,7 +109,7 @@ For tasks integration with AI Bridge, add `enable_aibridge = true` to the [Usage
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.9.2"
+  version = "4.9.3"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_aibridge = true
@@ -138,7 +138,7 @@ data "coder_task" "me" {}
 
 module "claude-code" {
   source    = "registry.coder.com/coder/claude-code/coder"
-  version   = "4.9.2"
+  version = "4.9.3"
   agent_id  = coder_agent.main.id
   workdir   = "/home/coder/project"
   ai_prompt = data.coder_task.me.prompt
@@ -161,7 +161,7 @@ This example shows additional configuration options for version pinning, custom 
 ```tf
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.9.2"
+  version = "4.9.3"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -217,7 +217,7 @@ Run and configure Claude Code as a standalone CLI in your workspace.
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "4.9.2"
+  version = "4.9.3"
   agent_id            = coder_agent.main.id
   workdir             = "/home/coder/project"
   install_claude_code = true
@@ -239,7 +239,7 @@ variable "claude_code_oauth_token" {
 
 module "claude-code" {
   source                  = "registry.coder.com/coder/claude-code/coder"
-  version                 = "4.9.2"
+  version = "4.9.3"
   agent_id                = coder_agent.main.id
   workdir                 = "/home/coder/project"
   claude_code_oauth_token = var.claude_code_oauth_token
@@ -312,7 +312,7 @@ resource "coder_env" "bedrock_api_key" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.9.2"
+  version = "4.9.3"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -369,7 +369,7 @@ resource "coder_env" "google_application_credentials" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.9.2"
+  version = "4.9.3"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "claude-sonnet-4@20250514"

--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -87,7 +87,7 @@ Use this when the config file is provisioned separately or managed outside the t
 ```tf
 module "claude-code" {
   source               = "registry.coder.com/coder/claude-code/coder"
-  version              = "4.8.0"
+  version              = "4.9.0"
   agent_id             = coder_agent.main.id
   workdir              = "/home/coder/project"
   enable_boundary      = true

--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Run the [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
 ```tf
 module "claude-code" {
   source         = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.3"
+  version        = "4.9.3"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   claude_api_key = "xxxx-xxxxx-xxxx"
@@ -67,7 +67,7 @@ The module writes the config to `~/.config/coder_boundary/config.yaml` automatic
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.3"
+  version         = "4.9.3"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_boundary = true
@@ -87,7 +87,7 @@ Use this when the config file is provisioned separately or managed outside the t
 ```tf
 module "claude-code" {
   source               = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.3"
+  version              = "4.9.3"
   agent_id             = coder_agent.main.id
   workdir              = "/home/coder/project"
   enable_boundary      = true
@@ -109,7 +109,7 @@ For tasks integration with AI Bridge, add `enable_aibridge = true` to the [Usage
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.3"
+  version         = "4.9.3"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_aibridge = true
@@ -138,7 +138,7 @@ data "coder_task" "me" {}
 
 module "claude-code" {
   source    = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.3"
+  version   = "4.9.3"
   agent_id  = coder_agent.main.id
   workdir   = "/home/coder/project"
   ai_prompt = data.coder_task.me.prompt
@@ -161,7 +161,7 @@ This example shows additional configuration options for version pinning, custom 
 ```tf
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.3"
+  version  = "4.9.3"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -217,7 +217,7 @@ Run and configure Claude Code as a standalone CLI in your workspace.
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.3"
+  version             = "4.9.3"
   agent_id            = coder_agent.main.id
   workdir             = "/home/coder/project"
   install_claude_code = true
@@ -239,7 +239,7 @@ variable "claude_code_oauth_token" {
 
 module "claude-code" {
   source                  = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.3"
+  version                 = "4.9.3"
   agent_id                = coder_agent.main.id
   workdir                 = "/home/coder/project"
   claude_code_oauth_token = var.claude_code_oauth_token
@@ -312,7 +312,7 @@ resource "coder_env" "bedrock_api_key" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.3"
+  version  = "4.9.3"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -369,7 +369,7 @@ resource "coder_env" "google_application_credentials" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.3"
+  version  = "4.9.3"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "claude-sonnet-4@20250514"

--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Run the [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
 ```tf
 module "claude-code" {
   source         = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.2"
+  version        = "4.9.2"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   claude_api_key = "xxxx-xxxxx-xxxx"
@@ -67,7 +67,7 @@ The module writes the config to `~/.config/coder_boundary/config.yaml` automatic
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.2"
+  version         = "4.9.2"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_boundary = true
@@ -87,7 +87,7 @@ Use this when the config file is provisioned separately or managed outside the t
 ```tf
 module "claude-code" {
   source               = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.2"
+  version              = "4.9.2"
   agent_id             = coder_agent.main.id
   workdir              = "/home/coder/project"
   enable_boundary      = true
@@ -109,7 +109,7 @@ For tasks integration with AI Bridge, add `enable_aibridge = true` to the [Usage
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.2"
+  version         = "4.9.2"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_aibridge = true
@@ -138,7 +138,7 @@ data "coder_task" "me" {}
 
 module "claude-code" {
   source    = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.2"
+  version   = "4.9.2"
   agent_id  = coder_agent.main.id
   workdir   = "/home/coder/project"
   ai_prompt = data.coder_task.me.prompt
@@ -161,7 +161,7 @@ This example shows additional configuration options for version pinning, custom 
 ```tf
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.2"
+  version  = "4.9.2"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -217,7 +217,7 @@ Run and configure Claude Code as a standalone CLI in your workspace.
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.2"
+  version             = "4.9.2"
   agent_id            = coder_agent.main.id
   workdir             = "/home/coder/project"
   install_claude_code = true
@@ -239,7 +239,7 @@ variable "claude_code_oauth_token" {
 
 module "claude-code" {
   source                  = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.2"
+  version                 = "4.9.2"
   agent_id                = coder_agent.main.id
   workdir                 = "/home/coder/project"
   claude_code_oauth_token = var.claude_code_oauth_token
@@ -312,7 +312,7 @@ resource "coder_env" "bedrock_api_key" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.2"
+  version  = "4.9.2"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -369,7 +369,7 @@ resource "coder_env" "google_application_credentials" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version = "4.9.2"
+  version  = "4.9.2"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "claude-sonnet-4@20250514"

--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -55,7 +55,14 @@ module "claude-code" {
 
 This example shows how to configure the Claude Code module to run the agent behind a process-level boundary that restricts its network access.
 
-By default, when `enable_boundary = true`, the module uses `coder boundary` subcommand (provided by Coder) without requiring any installation.
+When `enable_boundary = true`, you must provide network filtering rules via one of two options:
+
+- `boundary_config` — inline YAML string (config lives in the template)
+- `boundary_config_path` — path to a config file already on disk
+
+The module writes the config to `~/.config/coder_boundary/config.yaml` automatically.
+
+#### Inline boundary config
 
 ```tf
 module "claude-code" {
@@ -64,6 +71,27 @@ module "claude-code" {
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_boundary = true
+
+  boundary_config = <<-EOT
+    allow:
+      - "*.anthropic.com"
+      - "*.github.com"
+  EOT
+}
+```
+
+#### Boundary config from file path
+
+Use this when the config file is provisioned separately or managed outside the template:
+
+```tf
+module "claude-code" {
+  source               = "registry.coder.com/coder/claude-code/coder"
+  version              = "4.8.0"
+  agent_id             = coder_agent.main.id
+  workdir              = "/home/coder/project"
+  enable_boundary      = true
+  boundary_config_path = "/home/coder/.config/coder_boundary/config.yaml"
 }
 ```
 

--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Run the [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
 ```tf
 module "claude-code" {
   source         = "registry.coder.com/coder/claude-code/coder"
-  version        = "4.9.2"
+  version = "4.9.2"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   claude_api_key = "xxxx-xxxxx-xxxx"
@@ -67,7 +67,7 @@ The module writes the config to `~/.config/coder_boundary/config.yaml` automatic
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.9.2"
+  version = "4.9.2"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_boundary = true
@@ -87,7 +87,7 @@ Use this when the config file is provisioned separately or managed outside the t
 ```tf
 module "claude-code" {
   source               = "registry.coder.com/coder/claude-code/coder"
-  version              = "4.9.2"
+  version = "4.9.2"
   agent_id             = coder_agent.main.id
   workdir              = "/home/coder/project"
   enable_boundary      = true
@@ -109,7 +109,7 @@ For tasks integration with AI Bridge, add `enable_aibridge = true` to the [Usage
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.9.2"
+  version = "4.9.2"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_aibridge = true
@@ -138,7 +138,7 @@ data "coder_task" "me" {}
 
 module "claude-code" {
   source    = "registry.coder.com/coder/claude-code/coder"
-  version   = "4.9.2"
+  version = "4.9.2"
   agent_id  = coder_agent.main.id
   workdir   = "/home/coder/project"
   ai_prompt = data.coder_task.me.prompt
@@ -161,7 +161,7 @@ This example shows additional configuration options for version pinning, custom 
 ```tf
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.9.2"
+  version = "4.9.2"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -217,7 +217,7 @@ Run and configure Claude Code as a standalone CLI in your workspace.
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "4.9.2"
+  version = "4.9.2"
   agent_id            = coder_agent.main.id
   workdir             = "/home/coder/project"
   install_claude_code = true
@@ -239,7 +239,7 @@ variable "claude_code_oauth_token" {
 
 module "claude-code" {
   source                  = "registry.coder.com/coder/claude-code/coder"
-  version                 = "4.9.2"
+  version = "4.9.2"
   agent_id                = coder_agent.main.id
   workdir                 = "/home/coder/project"
   claude_code_oauth_token = var.claude_code_oauth_token
@@ -312,7 +312,7 @@ resource "coder_env" "bedrock_api_key" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.9.2"
+  version = "4.9.2"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -369,7 +369,7 @@ resource "coder_env" "google_application_credentials" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.9.2"
+  version = "4.9.2"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "claude-sonnet-4@20250514"

--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Run the [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
 ```tf
 module "claude-code" {
   source         = "registry.coder.com/coder/claude-code/coder"
-  version        = "4.9.1"
+  version = "4.9.2"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   claude_api_key = "xxxx-xxxxx-xxxx"
@@ -67,7 +67,7 @@ The module writes the config to `~/.config/coder_boundary/config.yaml` automatic
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.9.1"
+  version = "4.9.2"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_boundary = true
@@ -87,7 +87,7 @@ Use this when the config file is provisioned separately or managed outside the t
 ```tf
 module "claude-code" {
   source               = "registry.coder.com/coder/claude-code/coder"
-  version              = "4.9.0"
+  version = "4.9.2"
   agent_id             = coder_agent.main.id
   workdir              = "/home/coder/project"
   enable_boundary      = true
@@ -109,7 +109,7 @@ For tasks integration with AI Bridge, add `enable_aibridge = true` to the [Usage
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.9.1"
+  version = "4.9.2"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_aibridge = true
@@ -138,7 +138,7 @@ data "coder_task" "me" {}
 
 module "claude-code" {
   source    = "registry.coder.com/coder/claude-code/coder"
-  version   = "4.9.1"
+  version = "4.9.2"
   agent_id  = coder_agent.main.id
   workdir   = "/home/coder/project"
   ai_prompt = data.coder_task.me.prompt
@@ -161,7 +161,7 @@ This example shows additional configuration options for version pinning, custom 
 ```tf
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.9.1"
+  version = "4.9.2"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -217,7 +217,7 @@ Run and configure Claude Code as a standalone CLI in your workspace.
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "4.9.1"
+  version = "4.9.2"
   agent_id            = coder_agent.main.id
   workdir             = "/home/coder/project"
   install_claude_code = true
@@ -239,7 +239,7 @@ variable "claude_code_oauth_token" {
 
 module "claude-code" {
   source                  = "registry.coder.com/coder/claude-code/coder"
-  version                 = "4.9.1"
+  version = "4.9.2"
   agent_id                = coder_agent.main.id
   workdir                 = "/home/coder/project"
   claude_code_oauth_token = var.claude_code_oauth_token
@@ -312,7 +312,7 @@ resource "coder_env" "bedrock_api_key" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.9.1"
+  version = "4.9.2"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -369,7 +369,7 @@ resource "coder_env" "google_application_credentials" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.9.1"
+  version = "4.9.2"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "claude-sonnet-4@20250514"

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -233,12 +233,12 @@ variable "enable_boundary" {
   default     = false
 
   validation {
-    condition     = !var.enable_boundary || var.boundary_config == null || var.boundary_config_path == null
+    condition     = !var.enable_boundary || (var.boundary_config == null || trimspace(var.boundary_config) == "") || (var.boundary_config_path == null || trimspace(var.boundary_config_path) == "")
     error_message = "Only one of boundary_config or boundary_config_path can be provided, not both."
   }
 
   validation {
-    condition     = (var.boundary_config == null && var.boundary_config_path == null) || var.enable_boundary
+    condition     = ((var.boundary_config == null || trimspace(var.boundary_config) == "") && (var.boundary_config_path == null || trimspace(var.boundary_config_path) == "")) || var.enable_boundary
     error_message = "boundary_config and boundary_config_path can only be set when enable_boundary is true."
   }
 }

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -364,7 +364,7 @@ locals {
   module_dir_name = ".claude-module"
   # Extract hostname from access_url for boundary --allow flag
   coder_host          = replace(replace(data.coder_workspace.me.access_url, "https://", ""), "http://", "")
-  boundary_config_b64 = var.boundary_config != null ? base64encode(var.boundary_config) : ""
+  boundary_config_b64 = var.boundary_config != null && trimspace(var.boundary_config) != "" ? base64encode(var.boundary_config) : ""
   claude_api_key      = var.enable_aibridge ? data.coder_workspace_owner.me.session_token : var.claude_api_key
 
   # Required prompts for the module to properly report task status to Coder
@@ -441,7 +441,7 @@ module "agentapi" {
     ARG_USE_BOUNDARY_DIRECTLY='${var.use_boundary_directly}' \
     ARG_CODER_HOST='${local.coder_host}' \
     ARG_BOUNDARY_CONFIG='${local.boundary_config_b64}' \
-    ARG_BOUNDARY_CONFIG_PATH='${var.boundary_config_path != null ? var.boundary_config_path : ""}' \
+    ARG_BOUNDARY_CONFIG_PATH='${var.boundary_config_path != null && trimspace(var.boundary_config_path) != "" ? trimspace(var.boundary_config_path) : ""}' \
     ARG_CLAUDE_BINARY_PATH='${var.claude_binary_path}' \
     /tmp/start.sh
   EOT

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -233,11 +233,6 @@ variable "enable_boundary" {
   default     = false
 
   validation {
-    condition     = !var.enable_boundary || var.boundary_config != null || var.boundary_config_path != null
-    error_message = "When enable_boundary is true, at least one of boundary_config or boundary_config_path must be provided."
-  }
-
-  validation {
     condition     = !var.enable_boundary || var.boundary_config == null || var.boundary_config_path == null
     error_message = "Only one of boundary_config or boundary_config_path can be provided, not both."
   }
@@ -358,8 +353,9 @@ locals {
   start_script    = file("${path.module}/scripts/start.sh")
   module_dir_name = ".claude-module"
   # Extract hostname from access_url for boundary --allow flag
-  coder_host     = replace(replace(data.coder_workspace.me.access_url, "https://", ""), "http://", "")
-  claude_api_key = var.enable_aibridge ? data.coder_workspace_owner.me.session_token : var.claude_api_key
+  coder_host          = replace(replace(data.coder_workspace.me.access_url, "https://", ""), "http://", "")
+  boundary_config_b64 = var.boundary_config != null ? base64encode(var.boundary_config) : ""
+  claude_api_key      = var.enable_aibridge ? data.coder_workspace_owner.me.session_token : var.claude_api_key
 
   # Required prompts for the module to properly report task status to Coder
   report_tasks_system_prompt = <<-EOT
@@ -434,7 +430,7 @@ module "agentapi" {
     ARG_COMPILE_FROM_SOURCE='${var.compile_boundary_from_source}' \
     ARG_USE_BOUNDARY_DIRECTLY='${var.use_boundary_directly}' \
     ARG_CODER_HOST='${local.coder_host}' \
-    ARG_BOUNDARY_CONFIG='${var.boundary_config != null ? base64encode(var.boundary_config) : ""}' \
+    ARG_BOUNDARY_CONFIG='${local.boundary_config_b64}' \
     ARG_BOUNDARY_CONFIG_PATH='${var.boundary_config_path != null ? var.boundary_config_path : ""}' \
     ARG_CLAUDE_BINARY_PATH='${var.claude_binary_path}' \
     /tmp/start.sh

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -231,6 +231,33 @@ variable "enable_boundary" {
   type        = bool
   description = "Whether to enable coder boundary for network filtering"
   default     = false
+
+  validation {
+    condition     = !var.enable_boundary || var.boundary_config != null || var.boundary_config_path != null
+    error_message = "When enable_boundary is true, at least one of boundary_config or boundary_config_path must be provided."
+  }
+
+  validation {
+    condition     = !var.enable_boundary || var.boundary_config == null || var.boundary_config_path == null
+    error_message = "Only one of boundary_config or boundary_config_path can be provided, not both."
+  }
+
+  validation {
+    condition     = (var.boundary_config == null && var.boundary_config_path == null) || var.enable_boundary
+    error_message = "boundary_config and boundary_config_path can only be set when enable_boundary is true."
+  }
+}
+
+variable "boundary_config" {
+  type        = string
+  description = "Inline YAML config for coder boundary network filtering rules. Written to ~/.config/coder_boundary/config.yaml before boundary starts. Mutually exclusive with boundary_config_path."
+  default     = null
+}
+
+variable "boundary_config_path" {
+  type        = string
+  description = "Path to an existing boundary config file on disk. Symlinked to ~/.config/coder_boundary/config.yaml before boundary starts. Mutually exclusive with boundary_config."
+  default     = null
 }
 
 variable "boundary_version" {
@@ -407,6 +434,8 @@ module "agentapi" {
     ARG_COMPILE_FROM_SOURCE='${var.compile_boundary_from_source}' \
     ARG_USE_BOUNDARY_DIRECTLY='${var.use_boundary_directly}' \
     ARG_CODER_HOST='${local.coder_host}' \
+    ARG_BOUNDARY_CONFIG='${var.boundary_config != null ? base64encode(var.boundary_config) : ""}' \
+    ARG_BOUNDARY_CONFIG_PATH='${var.boundary_config_path != null ? var.boundary_config_path : ""}' \
     ARG_CLAUDE_BINARY_PATH='${var.claude_binary_path}' \
     /tmp/start.sh
   EOT

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -247,12 +247,22 @@ variable "boundary_config" {
   type        = string
   description = "Inline YAML config for coder boundary network filtering rules. Written to ~/.config/coder_boundary/config.yaml before boundary starts. Mutually exclusive with boundary_config_path."
   default     = null
+
+  validation {
+    condition     = var.boundary_config == null || trimspace(var.boundary_config) != ""
+    error_message = "boundary_config must not be empty or whitespace-only when provided."
+  }
 }
 
 variable "boundary_config_path" {
   type        = string
   description = "Path to an existing boundary config file on disk. Symlinked to ~/.config/coder_boundary/config.yaml before boundary starts. Mutually exclusive with boundary_config."
   default     = null
+
+  validation {
+    condition     = var.boundary_config_path == null || trimspace(var.boundary_config_path) != ""
+    error_message = "boundary_config_path must not be empty or whitespace-only when provided."
+  }
 }
 
 variable "boundary_version" {

--- a/registry/coder/modules/claude-code/main.tftest.hcl
+++ b/registry/coder/modules/claude-code/main.tftest.hcl
@@ -317,6 +317,66 @@ run "test_boundary_config_path_without_boundary_fails" {
   ]
 }
 
+run "test_boundary_empty_config_fails" {
+  command = plan
+
+  variables {
+    agent_id        = "test-agent-empty-config"
+    workdir         = "/home/coder/boundary-test"
+    enable_boundary = true
+    boundary_config = ""
+  }
+
+  expect_failures = [
+    var.boundary_config,
+  ]
+}
+
+run "test_boundary_empty_config_path_fails" {
+  command = plan
+
+  variables {
+    agent_id             = "test-agent-empty-config-path"
+    workdir              = "/home/coder/boundary-test"
+    enable_boundary      = true
+    boundary_config_path = ""
+  }
+
+  expect_failures = [
+    var.boundary_config_path,
+  ]
+}
+
+run "test_boundary_whitespace_config_fails" {
+  command = plan
+
+  variables {
+    agent_id        = "test-agent-whitespace-config"
+    workdir         = "/home/coder/boundary-test"
+    enable_boundary = true
+    boundary_config = "   "
+  }
+
+  expect_failures = [
+    var.boundary_config,
+  ]
+}
+
+run "test_boundary_whitespace_config_path_fails" {
+  command = plan
+
+  variables {
+    agent_id             = "test-agent-whitespace-config-path"
+    workdir              = "/home/coder/boundary-test"
+    enable_boundary      = true
+    boundary_config_path = "   "
+  }
+
+  expect_failures = [
+    var.boundary_config_path,
+  ]
+}
+
 run "test_claude_code_system_prompt" {
   command = plan
 

--- a/registry/coder/modules/claude-code/main.tftest.hcl
+++ b/registry/coder/modules/claude-code/main.tftest.hcl
@@ -188,13 +188,18 @@ run "test_claude_code_permission_mode_validation" {
   }
 }
 
-run "test_claude_code_with_boundary" {
+run "test_claude_code_with_boundary_inline_config" {
   command = plan
 
   variables {
     agent_id        = "test-agent-boundary"
     workdir         = "/home/coder/boundary-test"
     enable_boundary = true
+    boundary_config = <<-EOT
+      allow:
+        - "*.anthropic.com"
+        - "*.github.com"
+    EOT
   }
 
   assert {
@@ -203,9 +208,95 @@ run "test_claude_code_with_boundary" {
   }
 
   assert {
+    condition     = var.boundary_config != null
+    error_message = "Boundary config should be set"
+  }
+
+  assert {
     condition     = local.coder_host != ""
     error_message = "Coder host should be extracted from access URL"
   }
+}
+
+run "test_claude_code_with_boundary_config_path" {
+  command = plan
+
+  variables {
+    agent_id             = "test-agent-boundary-path"
+    workdir              = "/home/coder/boundary-test"
+    enable_boundary      = true
+    boundary_config_path = "/home/coder/.config/coder_boundary/config.yaml"
+  }
+
+  assert {
+    condition     = var.enable_boundary == true
+    error_message = "Boundary should be enabled"
+  }
+
+  assert {
+    condition     = var.boundary_config_path == "/home/coder/.config/coder_boundary/config.yaml"
+    error_message = "Boundary config path should be set correctly"
+  }
+}
+
+run "test_boundary_without_config_fails" {
+  command = plan
+
+  variables {
+    agent_id        = "test-agent-boundary-fail"
+    workdir         = "/home/coder/boundary-test"
+    enable_boundary = true
+  }
+
+  expect_failures = [
+    var.enable_boundary,
+  ]
+}
+
+run "test_boundary_both_configs_fails" {
+  command = plan
+
+  variables {
+    agent_id             = "test-agent-boundary-both"
+    workdir              = "/home/coder/boundary-test"
+    enable_boundary      = true
+    boundary_config      = "allow:\n  - '*.example.com'"
+    boundary_config_path = "/home/coder/.config/coder_boundary/config.yaml"
+  }
+
+  expect_failures = [
+    var.enable_boundary,
+  ]
+}
+
+run "test_boundary_config_without_boundary_fails" {
+  command = plan
+
+  variables {
+    agent_id        = "test-agent-no-boundary"
+    workdir         = "/home/coder/boundary-test"
+    enable_boundary = false
+    boundary_config = "allow:\n  - '*.example.com'"
+  }
+
+  expect_failures = [
+    var.enable_boundary,
+  ]
+}
+
+run "test_boundary_config_path_without_boundary_fails" {
+  command = plan
+
+  variables {
+    agent_id             = "test-agent-no-boundary-path"
+    workdir              = "/home/coder/boundary-test"
+    enable_boundary      = false
+    boundary_config_path = "/home/coder/.config/coder_boundary/config.yaml"
+  }
+
+  expect_failures = [
+    var.enable_boundary,
+  ]
 }
 
 run "test_claude_code_system_prompt" {

--- a/registry/coder/modules/claude-code/main.tftest.hcl
+++ b/registry/coder/modules/claude-code/main.tftest.hcl
@@ -202,6 +202,13 @@ run "test_claude_code_with_boundary_inline_config" {
     EOT
   }
 
+  override_data {
+    target = data.coder_workspace.me
+    values = {
+      access_url = "https://coder.example.com"
+    }
+  }
+
   assert {
     condition     = var.enable_boundary == true
     error_message = "Boundary should be enabled"
@@ -213,8 +220,18 @@ run "test_claude_code_with_boundary_inline_config" {
   }
 
   assert {
-    condition     = local.coder_host != ""
-    error_message = "Coder host should be extracted from access URL"
+    condition     = local.coder_host == "coder.example.com"
+    error_message = "Coder host should be 'coder.example.com' after stripping https:// from access URL"
+  }
+
+  assert {
+    condition     = local.boundary_config_b64 != ""
+    error_message = "Boundary config should be base64-encoded for the start script"
+  }
+
+  assert {
+    condition     = base64decode(local.boundary_config_b64) == var.boundary_config
+    error_message = "Base64-encoded boundary config should decode back to the original config"
   }
 }
 
@@ -239,18 +256,19 @@ run "test_claude_code_with_boundary_config_path" {
   }
 }
 
-run "test_boundary_without_config_fails" {
+run "test_claude_code_with_boundary_no_config" {
   command = plan
 
   variables {
-    agent_id        = "test-agent-boundary-fail"
+    agent_id        = "test-agent-boundary"
     workdir         = "/home/coder/boundary-test"
     enable_boundary = true
   }
 
-  expect_failures = [
-    var.enable_boundary,
-  ]
+  assert {
+    condition     = var.enable_boundary == true
+    error_message = "Boundary should be enabled"
+  }
 }
 
 run "test_boundary_both_configs_fails" {

--- a/registry/coder/modules/claude-code/scripts/start.sh
+++ b/registry/coder/modules/claude-code/scripts/start.sh
@@ -26,6 +26,8 @@ ARG_USE_BOUNDARY_DIRECTLY=${ARG_USE_BOUNDARY_DIRECTLY:-false}
 ARG_CODER_HOST=${ARG_CODER_HOST:-}
 ARG_BOUNDARY_CONFIG=${ARG_BOUNDARY_CONFIG:-}
 ARG_BOUNDARY_CONFIG_PATH=${ARG_BOUNDARY_CONFIG_PATH:-}
+ARG_BOUNDARY_CONFIG_PATH="${ARG_BOUNDARY_CONFIG_PATH/#\~/$HOME}"
+ARG_BOUNDARY_CONFIG_PATH="${ARG_BOUNDARY_CONFIG_PATH//\$HOME/$HOME}"
 
 echo "--------------------------------"
 
@@ -238,6 +240,11 @@ function start_agentapi() {
         mkdir -p "$BOUNDARY_CONFIG_DIR"
         ln -sf "$ARG_BOUNDARY_CONFIG_PATH" "$BOUNDARY_CONFIG_FILE"
       fi
+    fi
+
+    if [ ! -s "$BOUNDARY_CONFIG_FILE" ]; then
+      printf "Error: boundary configuration file '%s' does not exist or is empty. Check boundary_config/boundary_config_path.\n" "$BOUNDARY_CONFIG_FILE" >&2
+      exit 1
     fi
 
     install_boundary

--- a/registry/coder/modules/claude-code/scripts/start.sh
+++ b/registry/coder/modules/claude-code/scripts/start.sh
@@ -24,6 +24,8 @@ ARG_BOUNDARY_VERSION=${ARG_BOUNDARY_VERSION:-"latest"}
 ARG_COMPILE_FROM_SOURCE=${ARG_COMPILE_FROM_SOURCE:-false}
 ARG_USE_BOUNDARY_DIRECTLY=${ARG_USE_BOUNDARY_DIRECTLY:-false}
 ARG_CODER_HOST=${ARG_CODER_HOST:-}
+ARG_BOUNDARY_CONFIG=${ARG_BOUNDARY_CONFIG:-}
+ARG_BOUNDARY_CONFIG_PATH=${ARG_BOUNDARY_CONFIG_PATH:-}
 
 echo "--------------------------------"
 
@@ -223,6 +225,21 @@ function start_agentapi() {
   printf "Running claude code with args: %s\n" "$(printf '%q ' "${ARGS[@]}")"
 
   if [ "$ARG_ENABLE_BOUNDARY" = "true" ]; then
+    BOUNDARY_CONFIG_DIR="$HOME/.config/coder_boundary"
+    BOUNDARY_CONFIG_FILE="$BOUNDARY_CONFIG_DIR/config.yaml"
+
+    if [ -n "$ARG_BOUNDARY_CONFIG" ]; then
+      printf "Writing inline boundary config to %s\n" "$BOUNDARY_CONFIG_FILE"
+      mkdir -p "$BOUNDARY_CONFIG_DIR"
+      echo -n "$ARG_BOUNDARY_CONFIG" | base64 -d > "$BOUNDARY_CONFIG_FILE"
+    elif [ -n "$ARG_BOUNDARY_CONFIG_PATH" ]; then
+      printf "Linking boundary config from %s to %s\n" "$ARG_BOUNDARY_CONFIG_PATH" "$BOUNDARY_CONFIG_FILE"
+      if [ "$ARG_BOUNDARY_CONFIG_PATH" != "$BOUNDARY_CONFIG_FILE" ]; then
+        mkdir -p "$BOUNDARY_CONFIG_DIR"
+        ln -sf "$ARG_BOUNDARY_CONFIG_PATH" "$BOUNDARY_CONFIG_FILE"
+      fi
+    fi
+
     install_boundary
 
     printf "Starting with coder boundary enabled\n"

--- a/registry/coder/modules/claude-code/scripts/start.sh
+++ b/registry/coder/modules/claude-code/scripts/start.sh
@@ -250,6 +250,11 @@ function start_agentapi() {
       fi
     fi
 
+    if [ ! -s "$BOUNDARY_CONFIG_FILE" ]; then
+      printf "Error: boundary configuration file '%s' does not exist or is empty. Check ARG_BOUNDARY_CONFIG/ARG_BOUNDARY_CONFIG_PATH.\n" "$BOUNDARY_CONFIG_FILE" >&2
+      exit 1
+    fi
+
     install_boundary
 
     printf "Starting with coder boundary enabled\n"

--- a/registry/coder/modules/claude-code/scripts/start.sh
+++ b/registry/coder/modules/claude-code/scripts/start.sh
@@ -234,17 +234,20 @@ function start_agentapi() {
       printf "Writing inline boundary config to %s\n" "$BOUNDARY_CONFIG_FILE"
       mkdir -p "$BOUNDARY_CONFIG_DIR"
       echo -n "$ARG_BOUNDARY_CONFIG" | base64 -d > "$BOUNDARY_CONFIG_FILE"
+      if [ ! -s "$BOUNDARY_CONFIG_FILE" ]; then
+        printf "Error: boundary configuration file '%s' does not exist or is empty after writing inline config.\n" "$BOUNDARY_CONFIG_FILE" >&2
+        exit 1
+      fi
     elif [ -n "$ARG_BOUNDARY_CONFIG_PATH" ]; then
       printf "Linking boundary config from %s to %s\n" "$ARG_BOUNDARY_CONFIG_PATH" "$BOUNDARY_CONFIG_FILE"
       if [ "$ARG_BOUNDARY_CONFIG_PATH" != "$BOUNDARY_CONFIG_FILE" ]; then
         mkdir -p "$BOUNDARY_CONFIG_DIR"
         ln -sf "$ARG_BOUNDARY_CONFIG_PATH" "$BOUNDARY_CONFIG_FILE"
       fi
-    fi
-
-    if [ ! -s "$BOUNDARY_CONFIG_FILE" ]; then
-      printf "Error: boundary configuration file '%s' does not exist or is empty. Check boundary_config/boundary_config_path.\n" "$BOUNDARY_CONFIG_FILE" >&2
-      exit 1
+      if [ ! -s "$BOUNDARY_CONFIG_FILE" ]; then
+        printf "Error: boundary configuration file '%s' does not exist or is empty. Check that '%s' exists and is not empty.\n" "$BOUNDARY_CONFIG_FILE" "$ARG_BOUNDARY_CONFIG_PATH" >&2
+        exit 1
+      fi
     fi
 
     install_boundary

--- a/registry/coder/modules/claude-code/scripts/start.sh
+++ b/registry/coder/modules/claude-code/scripts/start.sh
@@ -239,6 +239,9 @@ function start_agentapi() {
         exit 1
       fi
     elif [ -n "$ARG_BOUNDARY_CONFIG_PATH" ]; then
+      # Expand leading tilde and literal $HOME so paths like ~/.config/... work correctly
+      ARG_BOUNDARY_CONFIG_PATH="${ARG_BOUNDARY_CONFIG_PATH/#\~/$HOME}"
+      ARG_BOUNDARY_CONFIG_PATH="${ARG_BOUNDARY_CONFIG_PATH/\$HOME/$HOME}"
       printf "Linking boundary config from %s to %s\n" "$ARG_BOUNDARY_CONFIG_PATH" "$BOUNDARY_CONFIG_FILE"
       if [ "$ARG_BOUNDARY_CONFIG_PATH" != "$BOUNDARY_CONFIG_FILE" ]; then
         mkdir -p "$BOUNDARY_CONFIG_DIR"

--- a/registry/coder/modules/claude-code/scripts/start.sh
+++ b/registry/coder/modules/claude-code/scripts/start.sh
@@ -240,13 +240,13 @@ function start_agentapi() {
       fi
     elif [ -n "$ARG_BOUNDARY_CONFIG_PATH" ]; then
       printf "Linking boundary config from %s to %s\n" "$ARG_BOUNDARY_CONFIG_PATH" "$BOUNDARY_CONFIG_FILE"
-      if [ "$ARG_BOUNDARY_CONFIG_PATH" != "$BOUNDARY_CONFIG_FILE" ]; then
-        mkdir -p "$BOUNDARY_CONFIG_DIR"
-        ln -sf "$ARG_BOUNDARY_CONFIG_PATH" "$BOUNDARY_CONFIG_FILE"
-      fi
       if [ ! -f "$ARG_BOUNDARY_CONFIG_PATH" ]; then
         printf "Error: boundary_config_path '%s' does not exist or is not a regular file. Ensure the file exists at this path before starting.\n" "$ARG_BOUNDARY_CONFIG_PATH" >&2
         exit 1
+      fi
+      if [ "$ARG_BOUNDARY_CONFIG_PATH" != "$BOUNDARY_CONFIG_FILE" ]; then
+        mkdir -p "$BOUNDARY_CONFIG_DIR"
+        ln -sf "$ARG_BOUNDARY_CONFIG_PATH" "$BOUNDARY_CONFIG_FILE"
       fi
       if [ ! -s "$BOUNDARY_CONFIG_FILE" ]; then
         printf "Error: boundary configuration file '%s' does not exist or is empty. Check that '%s' exists and is not empty.\n" "$BOUNDARY_CONFIG_FILE" "$ARG_BOUNDARY_CONFIG_PATH" >&2

--- a/registry/coder/modules/claude-code/scripts/start.sh
+++ b/registry/coder/modules/claude-code/scripts/start.sh
@@ -244,6 +244,10 @@ function start_agentapi() {
         mkdir -p "$BOUNDARY_CONFIG_DIR"
         ln -sf "$ARG_BOUNDARY_CONFIG_PATH" "$BOUNDARY_CONFIG_FILE"
       fi
+      if [ ! -f "$ARG_BOUNDARY_CONFIG_PATH" ]; then
+        printf "Error: boundary_config_path '%s' does not exist or is not a regular file. Ensure the file exists at this path before starting.\n" "$ARG_BOUNDARY_CONFIG_PATH" >&2
+        exit 1
+      fi
       if [ ! -s "$BOUNDARY_CONFIG_FILE" ]; then
         printf "Error: boundary configuration file '%s' does not exist or is empty. Check that '%s' exists and is not empty.\n" "$BOUNDARY_CONFIG_FILE" "$ARG_BOUNDARY_CONFIG_PATH" >&2
         exit 1

--- a/registry/coder/modules/claude-code/scripts/start.sh
+++ b/registry/coder/modules/claude-code/scripts/start.sh
@@ -239,9 +239,6 @@ function start_agentapi() {
         exit 1
       fi
     elif [ -n "$ARG_BOUNDARY_CONFIG_PATH" ]; then
-      # Expand leading tilde and literal $HOME so paths like ~/.config/... work correctly
-      ARG_BOUNDARY_CONFIG_PATH="${ARG_BOUNDARY_CONFIG_PATH/#\~/$HOME}"
-      ARG_BOUNDARY_CONFIG_PATH="${ARG_BOUNDARY_CONFIG_PATH/\$HOME/$HOME}"
       printf "Linking boundary config from %s to %s\n" "$ARG_BOUNDARY_CONFIG_PATH" "$BOUNDARY_CONFIG_FILE"
       if [ "$ARG_BOUNDARY_CONFIG_PATH" != "$BOUNDARY_CONFIG_FILE" ]; then
         mkdir -p "$BOUNDARY_CONFIG_DIR"


### PR DESCRIPTION
## Description

Adds first-class support for passing Coder Boundary network filtering rules inline or by path into the `claude-code` module.

- Introduces `boundary_config` (inline YAML) and `boundary_config_path` (existing file path) inputs and wires them into the startup script.
- Adds Terraform validations to enforce correct boundary configuration combinations and reject empty/whitespace-only strings.
- Updates README examples and expands `tftest` coverage for boundary configuration scenarios.

## Review Comment Fixes

All 4 review comments have been addressed:

1. **main.tf** — `boundary_config` and `boundary_config_path` per-variable validations use `trimspace()` checks to reject empty/whitespace-only strings (not just null).
2. **main.tftest.hcl** — Failure test cases added for `boundary_config = ""`, `boundary_config_path = ""`, and whitespace-only variants (`"   "`): `test_boundary_empty_config_fails`, `test_boundary_empty_config_path_fails`, `test_boundary_whitespace_config_fails`, `test_boundary_whitespace_config_path_fails`.
3. **scripts/start.sh** — Source file existence check runs before `ln -sf` to avoid creating a broken symlink. Unified post-write/link safety check also added after the `if/elif/fi` block: if `$BOUNDARY_CONFIG_FILE` does not exist or is empty, the script exits with a clear error message.
4. **scripts/start.sh** — `ARG_BOUNDARY_CONFIG_PATH` is normalized at script startup with tilde and `$HOME` expansion (lines 29-30), matching the pattern used for `ARG_CLAUDE_BINARY_PATH`.

## Type of Change

- [ ] New module
- [ ] New template
- [ ] Bug fix
- [X] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder/modules/claude-code`  
**New version:** `v4.9.3`  
**Breaking change:** [ ] Yes [X] No

## Testing & Validation

- [X] Tests pass (`bun test`)
- [X] Code formatted (`bun fmt`)

Closes #792

Generated with OpenClaw using Claude