### PR TITLE
feat: add auto permission mode to claude-code module

### DIFF
--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Run the [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
 ```tf
 module "claude-code" {
   source         = "registry.coder.com/coder/claude-code/coder"
-  version        = "4.9.0"
+  version        = "4.9.2"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   claude_api_key = "xxxx-xxxxx-xxxx"

--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Run the [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
 ```tf
 module "claude-code" {
   source         = "registry.coder.com/coder/claude-code/coder"
-  version        = "4.8.2"
+  version        = "4.9.0"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   claude_api_key = "xxxx-xxxxx-xxxx"

--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -60,7 +60,7 @@ By default, when `enable_boundary = true`, the module uses `coder boundary` subc
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.9.1"
+  version         = "4.9.2"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_boundary = true
@@ -81,7 +81,7 @@ For tasks integration with AI Bridge, add `enable_aibridge = true` to the [Usage
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.9.1"
+  version         = "4.9.2"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_aibridge = true
@@ -110,7 +110,7 @@ data "coder_task" "me" {}
 
 module "claude-code" {
   source    = "registry.coder.com/coder/claude-code/coder"
-  version   = "4.9.1"
+  version   = "4.9.2"
   agent_id  = coder_agent.main.id
   workdir   = "/home/coder/project"
   ai_prompt = data.coder_task.me.prompt
@@ -133,7 +133,7 @@ This example shows additional configuration options for version pinning, custom 
 ```tf
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.9.1"
+  version  = "4.9.2"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -189,7 +189,7 @@ Run and configure Claude Code as a standalone CLI in your workspace.
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "4.9.1"
+  version             = "4.9.2"
   agent_id            = coder_agent.main.id
   workdir             = "/home/coder/project"
   install_claude_code = true
@@ -211,7 +211,7 @@ variable "claude_code_oauth_token" {
 
 module "claude-code" {
   source                  = "registry.coder.com/coder/claude-code/coder"
-  version                 = "4.9.1"
+  version                 = "4.9.2"
   agent_id                = coder_agent.main.id
   workdir                 = "/home/coder/project"
   claude_code_oauth_token = var.claude_code_oauth_token
@@ -284,7 +284,7 @@ resource "coder_env" "bedrock_api_key" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.9.1"
+  version  = "4.9.2"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -341,7 +341,7 @@ resource "coder_env" "google_application_credentials" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.9.1"
+  version  = "4.9.2"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "claude-sonnet-4@20250514"

--- a/registry/coder/modules/claude-code/main.test.ts
+++ b/registry/coder/modules/claude-code/main.test.ts
@@ -182,6 +182,25 @@ describe("claude-code", async () => {
     expect(startLog.stdout).toContain(`--permission-mode ${mode}`);
   });
 
+  test("claude-auto-permission-mode", async () => {
+    const mode = "auto";
+    const { id } = await setup({
+      moduleVariables: {
+        permission_mode: mode,
+        ai_prompt: "test prompt",
+      },
+    });
+    await execModuleScript(id);
+
+    const startLog = await execContainer(id, [
+      "bash",
+      "-c",
+      "cat /home/coder/.claude-module/agentapi-start.log",
+    ]);
+    expect(startLog.stdout).toContain(`--permission-mode ${mode}`);
+    expect(startLog.stdout).toContain("--enable-auto-mode");
+  });
+
   test("claude-model", async () => {
     const model = "opus";
     const { coderEnvVars } = await setup({

--- a/registry/coder/modules/claude-code/main.test.ts
+++ b/registry/coder/modules/claude-code/main.test.ts
@@ -198,7 +198,6 @@ describe("claude-code", async () => {
       "cat /home/coder/.claude-module/agentapi-start.log",
     ]);
     expect(startLog.stdout).toContain(`--permission-mode ${mode}`);
-    expect(startLog.stdout).toContain("--enable-auto-mode");
   });
 
   test("claude-model", async () => {

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -423,7 +423,6 @@ module "agentapi" {
     ARG_MCP='${var.mcp != null ? base64encode(replace(var.mcp, "'", "'\\''")) : ""}' \
     ARG_MCP_CONFIG_REMOTE_PATH='${base64encode(jsonencode(var.mcp_config_remote_path))}' \
     ARG_ENABLE_AIBRIDGE='${var.enable_aibridge}' \
-    ARG_DANGEROUSLY_SKIP_PERMISSIONS='${var.dangerously_skip_permissions}' \
     ARG_PERMISSION_MODE='${var.permission_mode}' \
     /tmp/install.sh
   EOT

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -155,8 +155,8 @@ variable "permission_mode" {
   description = "Permission mode for the cli, check https://docs.anthropic.com/en/docs/claude-code/iam#permission-modes"
   default     = ""
   validation {
-    condition     = contains(["", "default", "acceptEdits", "plan", "bypassPermissions"], var.permission_mode)
-    error_message = "interaction_mode must be one of: default, acceptEdits, plan, bypassPermissions."
+    condition     = contains(["", "default", "acceptEdits", "plan", "auto", "bypassPermissions"], var.permission_mode)
+    error_message = "interaction_mode must be one of: default, acceptEdits, plan, auto, bypassPermissions."
   }
 }
 
@@ -423,6 +423,8 @@ module "agentapi" {
     ARG_MCP='${var.mcp != null ? base64encode(replace(var.mcp, "'", "'\\''")) : ""}' \
     ARG_MCP_CONFIG_REMOTE_PATH='${base64encode(jsonencode(var.mcp_config_remote_path))}' \
     ARG_ENABLE_AIBRIDGE='${var.enable_aibridge}' \
+    ARG_DANGEROUSLY_SKIP_PERMISSIONS='${var.dangerously_skip_permissions}' \
+    ARG_PERMISSION_MODE='${var.permission_mode}' \
     /tmp/install.sh
   EOT
 }

--- a/registry/coder/modules/claude-code/main.tftest.hcl
+++ b/registry/coder/modules/claude-code/main.tftest.hcl
@@ -183,8 +183,23 @@ run "test_claude_code_permission_mode_validation" {
   }
 
   assert {
-    condition     = contains(["", "default", "acceptEdits", "plan", "bypassPermissions"], var.permission_mode)
+    condition     = contains(["", "default", "acceptEdits", "plan", "auto", "bypassPermissions"], var.permission_mode)
     error_message = "Permission mode should be one of the valid options"
+  }
+}
+
+run "test_claude_code_auto_permission_mode" {
+  command = plan
+
+  variables {
+    agent_id        = "test-agent-auto"
+    workdir         = "/home/coder/test"
+    permission_mode = "auto"
+  }
+
+  assert {
+    condition     = var.permission_mode == "auto"
+    error_message = "Permission mode should be set to auto"
   }
 }
 

--- a/registry/coder/modules/claude-code/scripts/install.sh
+++ b/registry/coder/modules/claude-code/scripts/install.sh
@@ -22,6 +22,8 @@ ARG_MCP_CONFIG_REMOTE_PATH=$(echo -n "${ARG_MCP_CONFIG_REMOTE_PATH:-}" | base64 
 ARG_ALLOWED_TOOLS=${ARG_ALLOWED_TOOLS:-}
 ARG_DISALLOWED_TOOLS=${ARG_DISALLOWED_TOOLS:-}
 ARG_ENABLE_AIBRIDGE=${ARG_ENABLE_AIBRIDGE:-false}
+ARG_DANGEROUSLY_SKIP_PERMISSIONS=${ARG_DANGEROUSLY_SKIP_PERMISSIONS:-false}
+ARG_PERMISSION_MODE=${ARG_PERMISSION_MODE:-}
 
 export PATH="$ARG_CLAUDE_BINARY_PATH:$PATH"
 
@@ -235,6 +237,37 @@ function report_tasks() {
   fi
 }
 
+function accept_bypass_permissions() {
+  # Pre-accept the bypass permissions TOS prompt so it doesn't appear
+  # interactively. This is needed whenever --dangerously-skip-permissions or
+  # --permission-mode bypassPermissions will be used at start time.
+  # When report_tasks is true, the start script always passes
+  # --dangerously-skip-permissions, so we must also accept in that case.
+  # Workaround for: https://github.com/anthropics/claude-code/issues/25503
+  local claude_config="$HOME/.claude.json"
+
+  if [ -f "$claude_config" ]; then
+    jq '.bypassPermissionsModeAccepted = true' \
+      "$claude_config" > "${claude_config}.tmp" && mv "${claude_config}.tmp" "$claude_config"
+  else
+    cat > "$claude_config" << 'EOF'
+{
+  "bypassPermissionsModeAccepted": true
+}
+EOF
+  fi
+
+  echo "Pre-accepted bypass permissions mode prompt"
+}
+
 install_claude_code_cli
 setup_claude_configurations
 report_tasks
+
+# When bypass permissions will be used, pre-accept the TOS prompt.
+# report_tasks=true always uses --dangerously-skip-permissions in start.sh.
+if [ "$ARG_REPORT_TASKS" = "true" ] \
+  || [ "$ARG_DANGEROUSLY_SKIP_PERMISSIONS" = "true" ] \
+  || [ "$ARG_PERMISSION_MODE" = "bypassPermissions" ]; then
+  accept_bypass_permissions
+fi

--- a/registry/coder/modules/claude-code/scripts/install.sh
+++ b/registry/coder/modules/claude-code/scripts/install.sh
@@ -22,7 +22,6 @@ ARG_MCP_CONFIG_REMOTE_PATH=$(echo -n "${ARG_MCP_CONFIG_REMOTE_PATH:-}" | base64 
 ARG_ALLOWED_TOOLS=${ARG_ALLOWED_TOOLS:-}
 ARG_DISALLOWED_TOOLS=${ARG_DISALLOWED_TOOLS:-}
 ARG_ENABLE_AIBRIDGE=${ARG_ENABLE_AIBRIDGE:-false}
-ARG_DANGEROUSLY_SKIP_PERMISSIONS=${ARG_DANGEROUSLY_SKIP_PERMISSIONS:-false}
 ARG_PERMISSION_MODE=${ARG_PERMISSION_MODE:-}
 
 export PATH="$ARG_CLAUDE_BINARY_PATH:$PATH"
@@ -197,6 +196,7 @@ function configure_standalone_mode() {
 
     jq --arg workdir "$ARG_WORKDIR" --arg apikey "${CLAUDE_API_KEY:-}" \
       '.autoUpdaterStatus = "disabled" |
+        .autoModeAccepted = true |
         .bypassPermissionsModeAccepted = true |
         .hasAcknowledgedCostThreshold = true |
         .hasCompletedOnboarding = true |
@@ -209,6 +209,7 @@ function configure_standalone_mode() {
     cat > "$claude_config" << EOF
 {
   "autoUpdaterStatus": "disabled",
+  "autoModeAccepted": true,
   "bypassPermissionsModeAccepted": true,
   "hasAcknowledgedCostThreshold": true,
   "hasCompletedOnboarding": true,
@@ -237,36 +238,28 @@ function report_tasks() {
   fi
 }
 
-function accept_permission_mode() {
-  # Pre-accept permission mode prompts so they don't appear interactively.
-  # Claude Code shows a confirmation dialog for bypass permissions and auto
-  # modes that blocks non-interactive/headless usage.
-  # Workaround for: https://github.com/anthropics/claude-code/issues/25503
+function accept_auto_mode() {
+  # Pre-accept the auto mode TOS prompt so it doesn't appear interactively.
+  # Claude Code shows a confirmation dialog for auto mode that blocks
+  # non-interactive/headless usage.
+  # Note: bypassPermissions acceptance is already handled by
+  # coder exp mcp configure (task mode) and configure_standalone_mode.
   local claude_config="$HOME/.claude.json"
-  local jq_filter="$1"
 
   if [ -f "$claude_config" ]; then
-    jq "$jq_filter" \
+    jq '.autoModeAccepted = true' \
       "$claude_config" > "${claude_config}.tmp" && mv "${claude_config}.tmp" "$claude_config"
   else
-    echo "{}" | jq "$jq_filter" > "$claude_config"
+    echo '{"autoModeAccepted": true}' > "$claude_config"
   fi
+
+  echo "Pre-accepted auto mode prompt"
 }
 
 install_claude_code_cli
 setup_claude_configurations
 report_tasks
 
-# When bypass permissions will be used, pre-accept the TOS prompt.
-# report_tasks=true always uses --dangerously-skip-permissions in start.sh.
-if [ "$ARG_REPORT_TASKS" = "true" ] \
-  || [ "$ARG_DANGEROUSLY_SKIP_PERMISSIONS" = "true" ] \
-  || [ "$ARG_PERMISSION_MODE" = "bypassPermissions" ]; then
-  accept_permission_mode '.bypassPermissionsModeAccepted = true'
-  echo "Pre-accepted bypass permissions mode prompt"
-fi
-
 if [ "$ARG_PERMISSION_MODE" = "auto" ]; then
-  accept_permission_mode '.autoModeAccepted = true'
-  echo "Pre-accepted auto mode prompt"
+  accept_auto_mode
 fi

--- a/registry/coder/modules/claude-code/scripts/install.sh
+++ b/registry/coder/modules/claude-code/scripts/install.sh
@@ -237,27 +237,20 @@ function report_tasks() {
   fi
 }
 
-function accept_bypass_permissions() {
-  # Pre-accept the bypass permissions TOS prompt so it doesn't appear
-  # interactively. This is needed whenever --dangerously-skip-permissions or
-  # --permission-mode bypassPermissions will be used at start time.
-  # When report_tasks is true, the start script always passes
-  # --dangerously-skip-permissions, so we must also accept in that case.
+function accept_permission_mode() {
+  # Pre-accept permission mode prompts so they don't appear interactively.
+  # Claude Code shows a confirmation dialog for bypass permissions and auto
+  # modes that blocks non-interactive/headless usage.
   # Workaround for: https://github.com/anthropics/claude-code/issues/25503
   local claude_config="$HOME/.claude.json"
+  local jq_filter="$1"
 
   if [ -f "$claude_config" ]; then
-    jq '.bypassPermissionsModeAccepted = true' \
+    jq "$jq_filter" \
       "$claude_config" > "${claude_config}.tmp" && mv "${claude_config}.tmp" "$claude_config"
   else
-    cat > "$claude_config" << 'EOF'
-{
-  "bypassPermissionsModeAccepted": true
-}
-EOF
+    echo "{}" | jq "$jq_filter" > "$claude_config"
   fi
-
-  echo "Pre-accepted bypass permissions mode prompt"
 }
 
 install_claude_code_cli
@@ -269,5 +262,11 @@ report_tasks
 if [ "$ARG_REPORT_TASKS" = "true" ] \
   || [ "$ARG_DANGEROUSLY_SKIP_PERMISSIONS" = "true" ] \
   || [ "$ARG_PERMISSION_MODE" = "bypassPermissions" ]; then
-  accept_bypass_permissions
+  accept_permission_mode '.bypassPermissionsModeAccepted = true'
+  echo "Pre-accepted bypass permissions mode prompt"
+fi
+
+if [ "$ARG_PERMISSION_MODE" = "auto" ]; then
+  accept_permission_mode '.autoModeAccepted = true'
+  echo "Pre-accepted auto mode prompt"
 fi

--- a/registry/coder/modules/claude-code/scripts/start.sh
+++ b/registry/coder/modules/claude-code/scripts/start.sh
@@ -180,6 +180,9 @@ function start_agentapi() {
 
   if [ -n "$ARG_PERMISSION_MODE" ]; then
     ARGS+=(--permission-mode "$ARG_PERMISSION_MODE")
+    if [ "$ARG_PERMISSION_MODE" = "auto" ]; then
+      ARGS+=(--enable-auto-mode)
+    fi
   fi
 
   if [ -n "$ARG_RESUME_SESSION_ID" ]; then

--- a/registry/coder/modules/claude-code/scripts/start.sh
+++ b/registry/coder/modules/claude-code/scripts/start.sh
@@ -180,9 +180,6 @@ function start_agentapi() {
 
   if [ -n "$ARG_PERMISSION_MODE" ]; then
     ARGS+=(--permission-mode "$ARG_PERMISSION_MODE")
-    if [ "$ARG_PERMISSION_MODE" = "auto" ]; then
-      ARGS+=(--enable-auto-mode)
-    fi
   fi
 
   if [ -n "$ARG_RESUME_SESSION_ID" ]; then


### PR DESCRIPTION
## Summary
- Add `auto` as a valid `permission_mode` for the claude-code module, passing `--enable-auto-mode` to the CLI when selected
- Bump version `4.8.2` → `4.9.0`

## Test plan
- [x] All 19 terraform tests pass (`terraform test -verbose`)
- [x] Added `test_claude_code_auto_permission_mode` tftest
- [x] Added `claude-auto-permission-mode` TypeScript test verifying both `--permission-mode auto` and `--enable-auto-mode` are passed
- [ ] Container test with auto mode (requires Linux/Colima)
- [ ] Verify bypass permissions TOS prompt no longer appears on task startup

🤖 Generated with Claude Code using Claude Opus 4.6