### PR TITLE
fix(copilot): remove hardcoded model enum to allow any Copilot model

### DIFF
--- a/registry/coder-labs/modules/copilot/README.md
+++ b/registry/coder-labs/modules/copilot/README.md
@@ -13,7 +13,7 @@ Run [GitHub Copilot CLI](https://docs.github.com/copilot/concepts/agents/about-c
 ```tf
 module "copilot" {
   source   = "registry.coder.com/coder-labs/copilot/coder"
-  version  = "0.4.0"
+  version  = "0.4.1"
   agent_id = coder_agent.example.id
   workdir  = "/home/coder/projects"
 }
@@ -51,7 +51,7 @@ data "coder_parameter" "ai_prompt" {
 
 module "copilot" {
   source   = "registry.coder.com/coder-labs/copilot/coder"
-  version  = "0.4.0"
+  version  = "0.4.1"
   agent_id = coder_agent.example.id
   workdir  = "/home/coder/projects"
 
@@ -71,7 +71,7 @@ Customize tool permissions, MCP servers, and Copilot settings:
 ```tf
 module "copilot" {
   source   = "registry.coder.com/coder-labs/copilot/coder"
-  version  = "0.4.0"
+  version  = "0.4.1"
   agent_id = coder_agent.example.id
   workdir  = "/home/coder/projects"
 
@@ -142,7 +142,7 @@ variable "github_token" {
 
 module "copilot" {
   source       = "registry.coder.com/coder-labs/copilot/coder"
-  version      = "0.4.0"
+  version      = "0.4.1"
   agent_id     = coder_agent.example.id
   workdir      = "/home/coder/projects"
   github_token = var.github_token
@@ -156,7 +156,7 @@ Run Copilot as a command-line tool without task reporting or web interface. This
 ```tf
 module "copilot" {
   source       = "registry.coder.com/coder-labs/copilot/coder"
-  version      = "0.4.0"
+  version      = "0.4.1"
   agent_id     = coder_agent.example.id
   workdir      = "/home/coder"
   report_tasks = false
@@ -179,7 +179,7 @@ module "aibridge-proxy" {
 
 module "copilot" {
   source                   = "registry.coder.com/coder-labs/copilot/coder"
-  version                  = "0.4.0"
+  version                  = "0.4.1"
   agent_id                 = coder_agent.main.id
   workdir                  = "/home/coder/projects"
   enable_aibridge_proxy    = true

--- a/registry/coder-labs/modules/copilot/copilot.tftest.hcl
+++ b/registry/coder-labs/modules/copilot/copilot.tftest.hcl
@@ -117,18 +117,23 @@ run "copilot_model_not_created_for_default" {
   }
 }
 
-run "model_validation_accepts_valid_models" {
+run "copilot_model_accepts_custom_model" {
   command = plan
 
   variables {
     agent_id      = "test-agent"
     workdir       = "/home/coder"
-    copilot_model = "gpt-5"
+    copilot_model = "o3-pro"
   }
 
   assert {
-    condition     = contains(["claude-sonnet-4", "claude-sonnet-4.5", "gpt-5"], var.copilot_model)
-    error_message = "Model should be one of the valid options"
+    condition     = var.copilot_model == "o3-pro"
+    error_message = "copilot_model should accept any model string"
+  }
+
+  assert {
+    condition     = length(resource.coder_env.copilot_model) == 1
+    error_message = "copilot_model env var should be created for non-default model"
   }
 }
 

--- a/registry/coder-labs/modules/copilot/main.tf
+++ b/registry/coder-labs/modules/copilot/main.tf
@@ -33,12 +33,8 @@ variable "github_token" {
 
 variable "copilot_model" {
   type        = string
-  description = "Model to use. Supported values: claude-sonnet-4, claude-sonnet-4.5 (default), gpt-5."
+  description = "The model to use for Copilot. Any model supported by GitHub Copilot can be used."
   default     = "claude-sonnet-4.5"
-  validation {
-    condition     = contains(["claude-sonnet-4", "claude-sonnet-4.5", "gpt-5"], var.copilot_model)
-    error_message = "copilot_model must be one of: claude-sonnet-4, claude-sonnet-4.5, gpt-5."
-  }
 }
 
 variable "copilot_config" {


### PR DESCRIPTION
The `copilot_model` variable was restricted to a hardcoded enum of three models (`claude-sonnet-4`, `claude-sonnet-4.5`, `gpt-5`). Models change fast and this validation was blocking users from using newer models.

## Changes

- Remove `validation` block from `copilot_model` variable in `main.tf`
- Update variable description to indicate any Copilot-supported model can be used
- Replace enum validation test with a test that verifies arbitrary model strings are accepted
- Bump module version to `0.4.1` in README examples

Closes #832

> 🤖 This PR was created with the help of Coder Agents, and needs a human review. 🧑‍💻