### PR TITLE
fix: expose agentapi_port in codex/auggie/gemini/opencode modules

### DIFF
--- a/registry/coder-labs/modules/auggie/README.md
+++ b/registry/coder-labs/modules/auggie/README.md
@@ -13,7 +13,7 @@ Run Auggie CLI in your workspace to access Augment's AI coding assistant with ad
 ```tf
 module "auggie" {
   source   = "registry.coder.com/coder-labs/auggie/coder"
-  version  = "0.3.0"
+  version = "0.3.1"
   agent_id = coder_agent.example.id
   folder   = "/home/coder/project"
 }
@@ -47,7 +47,7 @@ module "coder-login" {
 
 module "auggie" {
   source   = "registry.coder.com/coder-labs/auggie/coder"
-  version  = "0.3.0"
+  version = "0.3.1"
   agent_id = coder_agent.example.id
   folder   = "/home/coder/project"
 
@@ -103,7 +103,7 @@ EOF
 ```tf
 module "auggie" {
   source   = "registry.coder.com/coder-labs/auggie/coder"
-  version  = "0.3.0"
+  version = "0.3.1"
   agent_id = coder_agent.example.id
   folder   = "/home/coder/project"
 

--- a/registry/coder-labs/modules/auggie/auggie.tftest.hcl
+++ b/registry/coder-labs/modules/auggie/auggie.tftest.hcl
@@ -170,6 +170,35 @@ run "test_auggie_with_scripts" {
   }
 }
 
+run "test_auggie_default_agentapi_port" {
+  command = plan
+
+  variables {
+    agent_id = "test-agent"
+    folder   = "/home/coder"
+  }
+
+  assert {
+    condition     = var.agentapi_port == 3284
+    error_message = "agentapi_port should default to 3284"
+  }
+}
+
+run "test_auggie_custom_agentapi_port" {
+  command = plan
+
+  variables {
+    agent_id      = "test-agent"
+    folder        = "/home/coder"
+    agentapi_port = 3285
+  }
+
+  assert {
+    condition     = var.agentapi_port == 3285
+    error_message = "agentapi_port should be configurable"
+  }
+}
+
 run "test_auggie_interaction_mode_validation" {
   command = plan
 

--- a/registry/coder-labs/modules/auggie/main.tf
+++ b/registry/coder-labs/modules/auggie/main.tf
@@ -73,6 +73,12 @@ variable "agentapi_version" {
   }
 }
 
+variable "agentapi_port" {
+  type        = number
+  description = "The port used by AgentAPI."
+  default     = 3284
+}
+
 variable "pre_install_script" {
   type        = string
   description = "Custom script to run before installing Auggie."
@@ -194,6 +200,7 @@ module "agentapi" {
   module_dir_name      = local.module_dir_name
   install_agentapi     = var.install_agentapi
   agentapi_version     = var.agentapi_version
+  agentapi_port        = var.agentapi_port
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script
   start_script         = <<-EOT

--- a/registry/coder-labs/modules/auggie/main.tf
+++ b/registry/coder-labs/modules/auggie/main.tf
@@ -234,6 +234,7 @@ module "agentapi" {
     ARG_MCP_APP_STATUS_SLUG='${local.app_slug}' \
     ARG_AUGGIE_RULES='${base64encode(var.rules)}' \
     ARG_MCP_CONFIG='${var.mcp != null ? base64encode(replace(var.mcp, "'", "'\\''")) : ""}' \
+    ARG_AGENTAPI_PORT='${var.agentapi_port}' \
     /tmp/install.sh
   EOT
 }

--- a/registry/coder-labs/modules/auggie/scripts/install.sh
+++ b/registry/coder-labs/modules/auggie/scripts/install.sh
@@ -85,7 +85,7 @@ function create_coder_mcp() {
      "command": "coder",
      "env": {
        "CODER_MCP_APP_STATUS_SLUG": "${ARG_MCP_APP_STATUS_SLUG}",
-       "CODER_MCP_AI_AGENTAPI_URL": "http://localhost:3284",
+       "CODER_MCP_AI_AGENTAPI_URL": "http://localhost:${ARG_AGENTAPI_PORT:-3284}",
        "CODER_AGENT_URL": "${CODER_AGENT_URL:-}",
        "CODER_AGENT_TOKEN": "${CODER_AGENT_TOKEN:-}"
      }

--- a/registry/coder-labs/modules/codex/README.md
+++ b/registry/coder-labs/modules/codex/README.md
@@ -13,7 +13,7 @@ Run Codex CLI in your workspace to access OpenAI's models through the Codex inte
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "4.3.1"
+  version = "4.3.2"
   agent_id       = coder_agent.example.id
   openai_api_key = var.openai_api_key
   workdir        = "/home/coder/project"
@@ -32,7 +32,7 @@ module "codex" {
 module "codex" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "4.3.1"
+  version = "4.3.2"
   agent_id       = coder_agent.example.id
   openai_api_key = "..."
   workdir        = "/home/coder/project"
@@ -51,7 +51,7 @@ For tasks integration with AI Bridge, add `enable_aibridge = true` to the [Usage
 ```tf
 module "codex" {
   source          = "registry.coder.com/coder-labs/codex/coder"
-  version         = "4.3.1"
+  version = "4.3.2"
   agent_id        = coder_agent.example.id
   workdir         = "/home/coder/project"
   enable_aibridge = true
@@ -89,7 +89,7 @@ data "coder_task" "me" {}
 
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "4.3.1"
+  version = "4.3.2"
   agent_id       = coder_agent.example.id
   openai_api_key = "..."
   ai_prompt      = data.coder_task.me.prompt
@@ -109,7 +109,7 @@ By default, when `enable_boundary = true`, the module uses `coder boundary` subc
 ```tf
 module "codex" {
   source          = "registry.coder.com/coder-labs/codex/coder"
-  version         = "4.3.1"
+  version = "4.3.2"
   agent_id        = coder_agent.main.id
   openai_api_key  = var.openai_api_key
   workdir         = "/home/coder/project"
@@ -127,7 +127,7 @@ This example shows additional configuration options for custom models, MCP serve
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "4.3.1"
+  version = "4.3.2"
   agent_id       = coder_agent.example.id
   openai_api_key = "..."
   workdir        = "/home/coder/project"

--- a/registry/coder-labs/modules/codex/main.tf
+++ b/registry/coder-labs/modules/codex/main.tf
@@ -134,6 +134,12 @@ variable "agentapi_version" {
   default     = "v0.12.1"
 }
 
+variable "agentapi_port" {
+  type        = number
+  description = "The port used by AgentAPI."
+  default     = 3284
+}
+
 variable "codex_model" {
   type        = string
   description = "The model for Codex to use. Defaults to gpt-5.3-codex."
@@ -254,6 +260,7 @@ module "agentapi" {
   install_agentapi             = var.install_agentapi
   agentapi_subdomain           = var.subdomain
   agentapi_version             = var.agentapi_version
+  agentapi_port                = var.agentapi_port
   enable_state_persistence     = var.enable_state_persistence
   pre_install_script           = var.pre_install_script
   post_install_script          = var.post_install_script

--- a/registry/coder-labs/modules/codex/main.tf
+++ b/registry/coder-labs/modules/codex/main.tf
@@ -307,6 +307,7 @@ module "agentapi" {
     ARG_CODEX_START_DIRECTORY='${local.workdir}' \
     ARG_MODEL_REASONING_EFFORT='${var.model_reasoning_effort}' \
     ARG_CODEX_INSTRUCTION_PROMPT='${base64encode(var.codex_system_prompt)}' \
+    ARG_AGENTAPI_PORT='${var.agentapi_port}' \
     /tmp/install.sh
   EOT
 }

--- a/registry/coder-labs/modules/codex/main.tftest.hcl
+++ b/registry/coder-labs/modules/codex/main.tftest.hcl
@@ -167,6 +167,37 @@ run "test_custom_options" {
   }
 }
 
+run "test_default_agentapi_port" {
+  command = plan
+
+  variables {
+    agent_id       = "test-agent"
+    workdir        = "/home/coder"
+    openai_api_key = "test-key"
+  }
+
+  assert {
+    condition     = var.agentapi_port == 3284
+    error_message = "agentapi_port should default to 3284"
+  }
+}
+
+run "test_custom_agentapi_port" {
+  command = plan
+
+  variables {
+    agent_id       = "test-agent"
+    workdir        = "/home/coder"
+    openai_api_key = "test-key"
+    agentapi_port  = 3285
+  }
+
+  assert {
+    condition     = var.agentapi_port == 3285
+    error_message = "agentapi_port should be configurable"
+  }
+}
+
 run "test_no_api_key_no_aibridge" {
   command = plan
 

--- a/registry/coder-labs/modules/codex/scripts/install.sh
+++ b/registry/coder-labs/modules/codex/scripts/install.sh
@@ -129,7 +129,7 @@ append_mcp_servers_section() {
     ARG_CODER_MCP_APP_STATUS_SLUG=""
     CODER_MCP_AI_AGENTAPI_URL=""
   else
-    CODER_MCP_AI_AGENTAPI_URL="http://localhost:3284"
+    CODER_MCP_AI_AGENTAPI_URL="http://localhost:${ARG_AGENTAPI_PORT:-3284}"
   fi
 
   cat << EOF >> "$config_path"

--- a/registry/coder-labs/modules/gemini/README.md
+++ b/registry/coder-labs/modules/gemini/README.md
@@ -13,7 +13,7 @@ Run [Gemini CLI](https://github.com/google-gemini/gemini-cli) in your workspace 
 ```tf
 module "gemini" {
   source   = "registry.coder.com/coder-labs/gemini/coder"
-  version  = "3.0.0"
+  version = "3.0.1"
   agent_id = coder_agent.main.id
   folder   = "/home/coder/project"
 }
@@ -46,7 +46,7 @@ variable "gemini_api_key" {
 
 module "gemini" {
   source         = "registry.coder.com/coder-labs/gemini/coder"
-  version        = "3.0.0"
+  version = "3.0.1"
   agent_id       = coder_agent.main.id
   gemini_api_key = var.gemini_api_key
   folder         = "/home/coder/project"
@@ -94,7 +94,7 @@ data "coder_parameter" "ai_prompt" {
 module "gemini" {
   count                = data.coder_workspace.me.start_count
   source               = "registry.coder.com/coder-labs/gemini/coder"
-  version              = "3.0.0"
+  version = "3.0.1"
   agent_id             = coder_agent.main.id
   gemini_api_key       = var.gemini_api_key
   gemini_model         = "gemini-2.5-flash"
@@ -118,7 +118,7 @@ For enterprise users who prefer Google's Vertex AI platform:
 ```tf
 module "gemini" {
   source         = "registry.coder.com/coder-labs/gemini/coder"
-  version        = "3.0.0"
+  version = "3.0.1"
   agent_id       = coder_agent.main.id
   gemini_api_key = var.gemini_api_key
   folder         = "/home/coder/project"

--- a/registry/coder-labs/modules/gemini/main.tf
+++ b/registry/coder-labs/modules/gemini/main.tf
@@ -84,6 +84,12 @@ variable "agentapi_version" {
   default     = "v0.10.0"
 }
 
+variable "agentapi_port" {
+  type        = number
+  description = "The port used by AgentAPI."
+  default     = 3284
+}
+
 variable "gemini_model" {
   type        = string
   description = "The model to use for Gemini (e.g., gemini-2.5-pro)."
@@ -191,6 +197,7 @@ module "agentapi" {
   module_dir_name      = local.module_dir_name
   install_agentapi     = var.install_agentapi
   agentapi_version     = var.agentapi_version
+  agentapi_port        = var.agentapi_port
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script
   install_script       = <<-EOT

--- a/registry/coder-labs/modules/gemini/main.tf
+++ b/registry/coder-labs/modules/gemini/main.tf
@@ -164,7 +164,7 @@ locals {
     "enabled": true,
     "env": {
       "CODER_MCP_APP_STATUS_SLUG": "${local.app_slug}",
-      "CODER_MCP_AI_AGENTAPI_URL": "http://localhost:3284"
+      "CODER_MCP_AI_AGENTAPI_URL": "http://localhost:${var.agentapi_port}"
     },
     "name": "Coder",
     "timeout": 3000,
@@ -214,6 +214,7 @@ module "agentapi" {
     ADDITIONAL_EXTENSIONS='${base64encode(replace(var.additional_extensions != null ? var.additional_extensions : "", "'", "'\\''"))}' \
     GEMINI_START_DIRECTORY='${var.folder}' \
     GEMINI_SYSTEM_PROMPT='${base64encode(var.gemini_system_prompt)}' \
+    ARG_AGENTAPI_PORT='${var.agentapi_port}' \
     /tmp/install.sh
   EOT
   start_script         = <<-EOT

--- a/registry/coder-labs/modules/gemini/main.tftest.hcl
+++ b/registry/coder-labs/modules/gemini/main.tftest.hcl
@@ -1,0 +1,26 @@
+run "test_default_agentapi_port" {
+  command = plan
+
+  variables {
+    agent_id = "test-agent"
+  }
+
+  assert {
+    condition     = var.agentapi_port == 3284
+    error_message = "agentapi_port should default to 3284"
+  }
+}
+
+run "test_custom_agentapi_port" {
+  command = plan
+
+  variables {
+    agent_id      = "test-agent"
+    agentapi_port = 3285
+  }
+
+  assert {
+    condition     = var.agentapi_port == 3285
+    error_message = "agentapi_port should be configurable"
+  }
+}

--- a/registry/coder-labs/modules/gemini/scripts/install.sh
+++ b/registry/coder-labs/modules/gemini/scripts/install.sh
@@ -142,7 +142,7 @@ function add_system_prompt_if_exists() {
 
 function configure_mcp() {
   export CODER_MCP_APP_STATUS_SLUG="gemini"
-  export CODER_MCP_AI_AGENTAPI_URL="http://localhost:3284"
+  export CODER_MCP_AI_AGENTAPI_URL="http://localhost:${ARG_AGENTAPI_PORT:-3284}"
   coder exp mcp configure gemini "${GEMINI_START_DIRECTORY}"
 }
 

--- a/registry/coder-labs/modules/opencode/README.md
+++ b/registry/coder-labs/modules/opencode/README.md
@@ -13,7 +13,7 @@ Run [OpenCode](https://opencode.ai) AI coding assistant in your workspace for in
 ```tf
 module "opencode" {
   source   = "registry.coder.com/coder-labs/opencode/coder"
-  version  = "0.1.2"
+  version = "0.1.3"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 }
@@ -34,7 +34,7 @@ resource "coder_ai_task" "task" {
 
 module "opencode" {
   source   = "registry.coder.com/coder-labs/opencode/coder"
-  version  = "0.1.2"
+  version = "0.1.3"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -89,7 +89,7 @@ Run OpenCode as a command-line tool without web interface or task reporting:
 ```tf
 module "opencode" {
   source       = "registry.coder.com/coder-labs/opencode/coder"
-  version      = "0.1.2"
+  version = "0.1.3"
   agent_id     = coder_agent.main.id
   workdir      = "/home/coder"
   report_tasks = false

--- a/registry/coder-labs/modules/opencode/main.tf
+++ b/registry/coder-labs/modules/opencode/main.tf
@@ -201,6 +201,7 @@ module "agentapi" {
     ARG_WORKDIR='${local.workdir}' \
     ARG_AUTH_JSON='${var.auth_json != null ? base64encode(replace(var.auth_json, "'", "'\\''")) : ""}' \
     ARG_OPENCODE_CONFIG='${var.config_json != null ? base64encode(replace(var.config_json, "'", "'\\''")) : ""}' \
+    ARG_AGENTAPI_PORT='${var.agentapi_port}' \
     /tmp/install.sh
   EOT
 }

--- a/registry/coder-labs/modules/opencode/main.tf
+++ b/registry/coder-labs/modules/opencode/main.tf
@@ -89,6 +89,12 @@ variable "agentapi_version" {
   default     = "v0.11.2"
 }
 
+variable "agentapi_port" {
+  type        = number
+  description = "The port used by AgentAPI."
+  default     = 3284
+}
+
 variable "ai_prompt" {
   type        = string
   description = "Initial task prompt for OpenCode."
@@ -163,6 +169,7 @@ module "agentapi" {
   module_dir_name      = local.module_dir_name
   install_agentapi     = var.install_agentapi
   agentapi_version     = var.agentapi_version
+  agentapi_port        = var.agentapi_port
   pre_install_script   = var.pre_install_script
   post_install_script  = var.post_install_script
   start_script         = <<-EOT

--- a/registry/coder-labs/modules/opencode/main.tftest.hcl
+++ b/registry/coder-labs/modules/opencode/main.tftest.hcl
@@ -372,3 +372,32 @@ run "continue_flag_configuration" {
     error_message = "Continue flag should be enabled when specified"
   }
 }
+
+run "default_agentapi_port" {
+  command = plan
+
+  variables {
+    agent_id = "test-agent"
+    workdir  = "/home/coder/project"
+  }
+
+  assert {
+    condition     = var.agentapi_port == 3284
+    error_message = "agentapi_port should default to 3284"
+  }
+}
+
+run "custom_agentapi_port" {
+  command = plan
+
+  variables {
+    agent_id      = "test-agent"
+    workdir       = "/home/coder/project"
+    agentapi_port = 3285
+  }
+
+  assert {
+    condition     = var.agentapi_port == 3285
+    error_message = "agentapi_port should be configurable"
+  }
+}

--- a/registry/coder-labs/modules/opencode/scripts/install.sh
+++ b/registry/coder-labs/modules/opencode/scripts/install.sh
@@ -94,7 +94,7 @@ setup_coder_mcp_server() {
   # Set environment variables based on task reporting setting
   echo "Configuring OpenCode task reporting"
   export CODER_MCP_APP_STATUS_SLUG="$ARG_MCP_APP_STATUS_SLUG"
-  export CODER_MCP_AI_AGENTAPI_URL="http://localhost:3284"
+  export CODER_MCP_AI_AGENTAPI_URL="http://localhost:${ARG_AGENTAPI_PORT:-3284}"
   echo "Coder integration configured for task reporting"
 
   # Add coder MCP server configuration to the JSON file


### PR DESCRIPTION
## Summary

When multiple AI coding tools (e.g. Claude Code + Codex, or Gemini + OpenCode) are installed in the same Coder workspace, they all hardcode AgentAPI to port 3284, causing port conflicts that prevent the second tool from starting.

The underlying `agentapi` submodule already supports a configurable `agentapi_port` parameter, but the parent modules (codex, auggie, gemini, opencode) don't expose or pass it through. This PR adds a `agentapi_port` variable (defaulting to 3284 for backward compatibility) to all four modules and passes it to the `agentapi` submodule.

## Changes

For each of the 4 modules (`codex`, `auggie`, `gemini`, `opencode`):
1. Added `variable "agentapi_port"` with type `number`, default `3284`
2. Added `agentapi_port = var.agentapi_port` in the `module "agentapi"` block

## Related Issues

Fixes #666
Fixes #837