### PR TITLE
fix(claude-code): don't pass --dangerously-skip-permissions in auto mode

### DIFF
--- a/registry/coder/modules/claude-code/main.test.ts
+++ b/registry/coder/modules/claude-code/main.test.ts
@@ -180,6 +180,8 @@ describe("claude-code", async () => {
       "cat /home/coder/.claude-module/agentapi-start.log",
     ]);
     expect(startLog.stdout).toContain(`--permission-mode ${mode}`);
+    // Auto mode should not include --dangerously-skip-permissions
+    expect(startLog.stdout).not.toContain("--dangerously-skip-permissions");
   });
 
   test("claude-model", async () => {
@@ -228,7 +230,46 @@ SESSIONEOF`,
     expect(startLog.stdout).toContain("--resume");
     expect(startLog.stdout).toContain(taskSessionId);
     expect(startLog.stdout).toContain("Resuming task session");
+    // Default (no permission_mode) should still include --dangerously-skip-permissions
     expect(startLog.stdout).toContain("--dangerously-skip-permissions");
+  });
+
+  test("claude-continue-resume-task-session-auto-mode", async () => {
+    const { id } = await setup({
+      moduleVariables: {
+        continue: "true",
+        report_tasks: "true",
+        permission_mode: "auto",
+        ai_prompt: "test prompt",
+      },
+    });
+
+    // Create a mock task session file with the hardcoded task session ID
+    const taskSessionId = "cd32e253-ca16-4fd3-9825-d837e74ae3c2";
+    const sessionDir = `/home/coder/.claude/projects/-home-coder-project`;
+    await execContainer(id, ["mkdir", "-p", sessionDir]);
+    await execContainer(id, [
+      "bash",
+      "-c",
+      `cat > ${sessionDir}/${taskSessionId}.jsonl << 'SESSIONEOF'
+{"sessionId":"${taskSessionId}","message":{"content":"Task"},"timestamp":"2020-01-01T10:00:00.000Z"}
+{"type":"assistant","message":{"content":"Response"},"timestamp":"2020-01-01T10:00:05.000Z"}
+SESSIONEOF`,
+    ]);
+
+    await execModuleScript(id);
+
+    const startLog = await execContainer(id, [
+      "bash",
+      "-c",
+      "cat /home/coder/.claude-module/agentapi-start.log",
+    ]);
+    expect(startLog.stdout).toContain("--resume");
+    expect(startLog.stdout).toContain(taskSessionId);
+    expect(startLog.stdout).toContain("Resuming task session");
+    expect(startLog.stdout).toContain("--permission-mode auto");
+    // Auto mode should NOT include --dangerously-skip-permissions
+    expect(startLog.stdout).not.toContain("--dangerously-skip-permissions");
   });
 
   test("pre-post-install-scripts", async () => {

--- a/registry/coder/modules/claude-code/scripts/start.sh
+++ b/registry/coder/modules/claude-code/scripts/start.sh
@@ -195,10 +195,19 @@ function start_agentapi() {
 
       if task_session_exists && is_valid_session "$session_file"; then
         echo "Resuming task session: $TASK_SESSION_ID"
-        ARGS+=(--resume "$TASK_SESSION_ID" --dangerously-skip-permissions)
+        ARGS+=(--resume "$TASK_SESSION_ID")
+        # Only add --dangerously-skip-permissions when no explicit permission mode
+        # is set (backward compat) or when bypassPermissions is chosen.
+        # Other modes like "auto" handle permissions themselves.
+        if [ -z "$ARG_PERMISSION_MODE" ] || [ "$ARG_PERMISSION_MODE" = "bypassPermissions" ]; then
+          ARGS+=(--dangerously-skip-permissions)
+        fi
       else
         echo "Starting new task session: $TASK_SESSION_ID"
-        ARGS+=(--session-id "$TASK_SESSION_ID" --dangerously-skip-permissions)
+        ARGS+=(--session-id "$TASK_SESSION_ID")
+        if [ -z "$ARG_PERMISSION_MODE" ] || [ "$ARG_PERMISSION_MODE" = "bypassPermissions" ]; then
+          ARGS+=(--dangerously-skip-permissions)
+        fi
         [ -n "$ARG_AI_PROMPT" ] && ARGS+=(-- "$ARG_AI_PROMPT")
       fi
 


### PR DESCRIPTION
## Summary
- The task reporting code path in `start.sh` unconditionally adds `--dangerously-skip-permissions` regardless of the configured `permission_mode`
- Workspaces using `permission_mode = "auto"` get both `--permission-mode auto` and `--dangerously-skip-permissions`, which defeats the purpose of auto mode
- Only add `--dangerously-skip-permissions` when no explicit permission mode is set (backward compat) or when `bypassPermissions` is chosen

## Test plan
- [x] Added `claude-continue-resume-task-session-auto-mode` test verifying `--dangerously-skip-permissions` is NOT passed when `permission_mode=auto`
- [x] Updated `claude-auto-permission-mode` test to assert `--dangerously-skip-permissions` is absent
- [x] Existing `claude-continue-resume-task-session` test still verifies default (no permission_mode) includes `--dangerously-skip-permissions`