### PR TITLE
fix(claude-code): pre-accept dangerous permissions startup modal

### DIFF
--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Run the [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude
 ```tf
 module "claude-code" {
   source         = "registry.coder.com/coder/claude-code/coder"
-  version        = "4.9.2"
+  version        = "4.9.3"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   claude_api_key = "xxxx-xxxxx-xxxx"
@@ -60,7 +60,7 @@ By default, when `enable_boundary = true`, the module uses `coder boundary` subc
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.9.2"
+  version         = "4.9.3"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_boundary = true
@@ -81,7 +81,7 @@ For tasks integration with AI Bridge, add `enable_aibridge = true` to the [Usage
 ```tf
 module "claude-code" {
   source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.9.2"
+  version         = "4.9.3"
   agent_id        = coder_agent.main.id
   workdir         = "/home/coder/project"
   enable_aibridge = true
@@ -110,7 +110,7 @@ data "coder_task" "me" {}
 
 module "claude-code" {
   source    = "registry.coder.com/coder/claude-code/coder"
-  version   = "4.9.2"
+  version   = "4.9.3"
   agent_id  = coder_agent.main.id
   workdir   = "/home/coder/project"
   ai_prompt = data.coder_task.me.prompt
@@ -133,7 +133,7 @@ This example shows additional configuration options for version pinning, custom 
 ```tf
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.9.2"
+  version  = "4.9.3"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -189,7 +189,7 @@ Run and configure Claude Code as a standalone CLI in your workspace.
 ```tf
 module "claude-code" {
   source              = "registry.coder.com/coder/claude-code/coder"
-  version             = "4.9.2"
+  version             = "4.9.3"
   agent_id            = coder_agent.main.id
   workdir             = "/home/coder/project"
   install_claude_code = true
@@ -211,7 +211,7 @@ variable "claude_code_oauth_token" {
 
 module "claude-code" {
   source                  = "registry.coder.com/coder/claude-code/coder"
-  version                 = "4.9.2"
+  version                 = "4.9.3"
   agent_id                = coder_agent.main.id
   workdir                 = "/home/coder/project"
   claude_code_oauth_token = var.claude_code_oauth_token
@@ -284,7 +284,7 @@ resource "coder_env" "bedrock_api_key" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.9.2"
+  version  = "4.9.3"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -341,7 +341,7 @@ resource "coder_env" "google_application_credentials" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "4.9.2"
+  version  = "4.9.3"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "claude-sonnet-4@20250514"

--- a/registry/coder/modules/claude-code/main.test.ts
+++ b/registry/coder/modules/claude-code/main.test.ts
@@ -321,6 +321,18 @@ SESSIONEOF`,
     expect(startLog.stdout).toContain(`--dangerously-skip-permissions`);
   });
 
+  test("dangerous-mode-startup-modal-pre-accepted", async () => {
+    const { id } = await setup();
+    await execModuleScript(id);
+
+    const settings = await readFileContainer(
+      id,
+      "/home/coder/.claude/settings.json",
+    );
+    const parsed = JSON.parse(settings);
+    expect(parsed.permissions.skipDangerousModePermissionPrompt).toBe(true);
+  });
+
   test("subdomain-false", async () => {
     const { id } = await setup({
       skipAgentAPIMock: true,

--- a/registry/coder/modules/claude-code/scripts/install.sh
+++ b/registry/coder/modules/claude-code/scripts/install.sh
@@ -256,9 +256,31 @@ function accept_auto_mode() {
   echo "Pre-accepted auto mode prompt"
 }
 
+function accept_dangerous_mode() {
+  # Pre-accept the --dangerously-skip-permissions startup modal so it
+  # doesn't block non-interactive/headless usage. As of Claude Code
+  # >= 2.1.87 the legacy `bypassPermissionsModeAccepted` flag in
+  # ~/.claude.json no longer suppresses this modal — the check moved
+  # to ~/.claude/settings.json under permissions.skipDangerousModePermissionPrompt.
+  # The key is idempotent and only has effect when the flag is passed,
+  # so it is safe to write unconditionally.
+  local settings="$HOME/.claude/settings.json"
+  mkdir -p "$(dirname "$settings")"
+
+  if [ -f "$settings" ]; then
+    jq '.permissions.skipDangerousModePermissionPrompt = true' \
+      "$settings" > "${settings}.tmp" && mv "${settings}.tmp" "$settings"
+  else
+    echo '{"permissions":{"skipDangerousModePermissionPrompt":true}}' > "$settings"
+  fi
+
+  echo "Pre-accepted dangerous permissions mode"
+}
+
 install_claude_code_cli
 setup_claude_configurations
 report_tasks
+accept_dangerous_mode
 
 if [ "$ARG_PERMISSION_MODE" = "auto" ]; then
   accept_auto_mode


### PR DESCRIPTION
## Summary

Pre-write `permissions.skipDangerousModePermissionPrompt = true` to `~/.claude/settings.json` so agents launched with `--dangerously-skip-permissions` stop hanging on the "Bypass Permissions mode — Yes, I accept" startup modal.

## Root cause

The module pre-accepts onboarding by writing `bypassPermissionsModeAccepted: true` to `~/.claude.json` — directly in `configure_standalone_mode`, and via `coder exp mcp configure claude-code` (see `cli/exp_mcp.go::configureClaude` in coder/coder) in task mode.

As of Claude Code >= 2.1.87 that key no longer suppresses the startup modal. The check moved to `~/.claude/settings.json` under `permissions.skipDangerousModePermissionPrompt`. Reproduced on 2.1.116 and still broken on 2.1.117.

## Fix

New `accept_dangerous_mode` in `scripts/install.sh` that jq-merges the new key into `~/.claude/settings.json`, same pattern as `accept_auto_mode`. Called unconditionally — the key is idempotent and only takes effect when the flag is passed.

## Upstream refs

- anthropics/claude-code#25503 — flag alone should bypass the dialog (open)
- anthropics/claude-code#48668 — user-scope key ignored on NixOS/symlinked setups (open, not typical for Coder workspaces)

## Module

`registry/coder/modules/claude-code`, v4.9.2 → v4.9.3 (patch). Not a breaking change.

## Test plan

- [x] New test asserts `~/.claude/settings.json` has `.permissions.skipDangerousModePermissionPrompt == true` after install
- [x] `terraform test` 19/19
- [x] `bun run fmt` clean

---

Generated with [Claude Code](https://claude.com/claude-code) using claude-opus-4-7
