### PR TITLE
feat(claude-code): add api_key_helper for short-lived credentials; mark anthropic_api_key sensitive

### DIFF
--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -218,6 +218,52 @@ module "claude-code" {
 }
 ```
 
+### Short-lived credentials via api_key_helper
+
+For production deployments we recommend `api_key_helper` over a static `claude_api_key`. The module writes the helper script into the workspace and registers it via Claude Code's [`apiKeyHelper` setting](https://docs.anthropic.com/en/docs/claude-code/settings#available-settings). Claude invokes the script whenever it needs a key and caches the result for `ttl_ms` milliseconds (default 5 minutes), so the credential never lands in Terraform state, the agent environment, or `~/.claude.json`.
+
+#### HashiCorp Vault
+
+```tf
+module "claude-code" {
+  source   = "registry.coder.com/coder/claude-code/coder"
+  version  = "4.9.2"
+  agent_id = coder_agent.main.id
+  workdir  = "/home/coder/project"
+
+  api_key_helper = {
+    script = <<-EOT
+      #!/bin/sh
+      exec vault kv get -field=key secret/anthropic
+    EOT
+    ttl_ms = 300000
+  }
+}
+```
+
+#### AWS Secrets Manager
+
+```tf
+module "claude-code" {
+  source   = "registry.coder.com/coder/claude-code/coder"
+  version  = "4.9.2"
+  agent_id = coder_agent.main.id
+  workdir  = "/home/coder/project"
+
+  api_key_helper = {
+    script = <<-EOT
+      #!/bin/sh
+      exec aws secretsmanager get-secret-value \
+        --secret-id anthropic/api-key \
+        --query SecretString --output text
+    EOT
+  }
+}
+```
+
+> [!NOTE]
+> `api_key_helper` is mutually exclusive with `claude_api_key`, `claude_code_oauth_token`, and `enable_aibridge`. The script runs as the workspace user, so any CLI it calls (`vault`, `aws`, `gcloud`) must already be installed and authenticated in the workspace, for example via Workload Identity or a `pre_install_script`.
+
 ### Usage with AWS Bedrock
 
 #### Prerequisites

--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Install and configure the [Claude Code](https://docs.anthropic.com/en/docs/agent
 ```tf
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.2.0"
+  version           = "5.3.0"
   agent_id          = coder_agent.main.id
   anthropic_api_key = "xxxx-xxxxx-xxxx"
 }
@@ -27,6 +27,7 @@ module "claude-code" {
 Provide exactly one authentication method:
 
 - **Anthropic API key**: get one from the [Anthropic Console](https://console.anthropic.com/dashboard) and pass it as `anthropic_api_key`.
+- **API key helper script** (`api_key_helper`): a script that prints a short-lived Anthropic API key to stdout. Recommended for production deployments where keys come from Vault, AWS Secrets Manager, or cloud IAM. See [Short-lived credentials via api_key_helper](#short-lived-credentials-via-api_key_helper).
 - **Claude.ai OAuth token** (Pro, Max, or Enterprise accounts): generate one by running `claude setup-token` locally and pass it as `claude_code_oauth_token`.
 - **Coder AI Gateway** (Coder Premium, Coder >= 2.30.0): set `enable_ai_gateway = true`. The module authenticates against the gateway using the workspace owner's session token. Do not combine with `anthropic_api_key` or `claude_code_oauth_token`.
 
@@ -47,7 +48,7 @@ locals {
 
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.2.0"
+  version           = "5.3.0"
   agent_id          = coder_agent.main.id
   workdir           = local.claude_workdir
   anthropic_api_key = "xxxx-xxxxx-xxxx"
@@ -78,7 +79,7 @@ resource "coder_app" "claude" {
 ```tf
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.2.0"
+  version           = "5.3.0"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   enable_ai_gateway = true
@@ -102,7 +103,7 @@ The `managed_settings` input writes a policy file to `/etc/claude-code/managed-s
 ```tf
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.2.0"
+  version           = "5.3.0"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   anthropic_api_key = "xxxx-xxxxx-xxxx"
@@ -122,6 +123,50 @@ module "claude-code" {
 
 See the [Claude Code settings reference](https://docs.anthropic.com/en/docs/claude-code/settings) for the full schema. Common keys: `permissions` (`defaultMode`, `allow`, `deny`, `disableBypassPermissionsMode`, `additionalDirectories`), `env`, `model`, `apiKeyHelper`, `hooks`, `cleanupPeriodDays`.
 
+### Short-lived credentials via api_key_helper
+
+For production deployments we recommend `api_key_helper` over a static `anthropic_api_key`. The module writes the helper script into the workspace and registers it via Claude Code's [`apiKeyHelper` setting](https://docs.anthropic.com/en/docs/claude-code/settings#available-settings) at `/etc/claude-code/managed-settings.d/20-coder-apikeyhelper.json`. Claude invokes the script whenever it needs a key and caches the result for `ttl_ms` milliseconds (default 5 minutes), so the credential never lands in Terraform state, the agent environment, or `~/.claude.json`.
+
+```tf
+module "claude-code" {
+  source   = "registry.coder.com/coder/claude-code/coder"
+  version  = "5.3.0"
+  agent_id = coder_agent.main.id
+  workdir  = "/home/coder/project"
+
+  api_key_helper = {
+    script = <<-EOT
+      #!/bin/sh
+      exec vault kv get -field=key secret/anthropic
+    EOT
+    ttl_ms = 300000
+  }
+}
+```
+
+Or, sourcing from AWS Secrets Manager:
+
+```tf
+module "claude-code" {
+  source   = "registry.coder.com/coder/claude-code/coder"
+  version  = "5.3.0"
+  agent_id = coder_agent.main.id
+  workdir  = "/home/coder/project"
+
+  api_key_helper = {
+    script = <<-EOT
+      #!/bin/sh
+      exec aws secretsmanager get-secret-value \
+        --secret-id anthropic/api-key \
+        --query SecretString --output text
+    EOT
+  }
+}
+```
+
+> [!NOTE]
+> `api_key_helper` is mutually exclusive with `anthropic_api_key`, `claude_code_oauth_token`, and `enable_ai_gateway`. The script runs as the workspace user, so any CLI it calls (`vault`, `aws`, `gcloud`) must already be installed and authenticated in the workspace, for example via Workload Identity, IRSA, or a `pre_install_script`.
+
 ### Advanced Configuration
 
 This example shows version pinning, a pre-installed binary path, a custom model, and MCP servers.
@@ -129,7 +174,7 @@ This example shows version pinning, a pre-installed binary path, a custom model,
 ```tf
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "5.2.0"
+  version  = "5.3.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -193,7 +238,7 @@ Downstream `coder_script` resources can wait for this module's install pipeline 
 ```tf
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.2.0"
+  version           = "5.3.0"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   anthropic_api_key = "xxxx-xxxxx-xxxx"
@@ -279,7 +324,7 @@ resource "coder_env" "bedrock_api_key" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "5.2.0"
+  version  = "5.3.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -336,7 +381,7 @@ resource "coder_env" "google_application_credentials" {
 
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "5.2.0"
+  version  = "5.3.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
   model    = "claude-sonnet-4@20250514"
@@ -377,7 +422,7 @@ The module automatically tags every span and metric with `coder.workspace_id`, `
 ```tf
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.2.0"
+  version           = "5.3.0"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   anthropic_api_key = "xxxx-xxxxx-xxxx"

--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Install and configure the [Claude Code](https://docs.anthropic.com/en/docs/agent
 ```tf
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.3.0"
+  version           = "5.4.0"
   agent_id          = coder_agent.main.id
   anthropic_api_key = "xxxx-xxxxx-xxxx"
 }
@@ -27,6 +27,7 @@ module "claude-code" {
 Provide exactly one authentication method:
 
 - **Anthropic API key**: get one from the [Anthropic Console](https://console.anthropic.com/dashboard) and pass it as `anthropic_api_key`.
+- **API key helper script** (`api_key_helper`): a script that prints a short-lived Anthropic API key to stdout. Recommended for production deployments where keys come from Vault, AWS Secrets Manager, or cloud IAM. See [Short-lived credentials via api_key_helper](#short-lived-credentials-via-api_key_helper).
 - **Claude.ai OAuth token** (Pro, Max, or Enterprise accounts): generate one by running `claude setup-token` locally and pass it as `claude_code_oauth_token`.
 - **Coder AI Gateway** (Coder Premium, Coder >= 2.30.0): set `enable_ai_gateway = true`. The module authenticates against the gateway using the workspace owner's session token. Do not combine with `anthropic_api_key` or `claude_code_oauth_token`.
 - **Amazon Bedrock**: set `use_bedrock = true`. Authentication uses the workspace's AWS credential chain. See [Usage with AWS Bedrock](#usage-with-aws-bedrock).
@@ -50,7 +51,7 @@ locals {
 
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.3.0"
+  version           = "5.4.0"
   agent_id          = coder_agent.main.id
   workdir           = local.claude_workdir
   anthropic_api_key = "xxxx-xxxxx-xxxx"
@@ -81,7 +82,7 @@ resource "coder_app" "claude" {
 ```tf
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.3.0"
+  version           = "5.4.0"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   enable_ai_gateway = true
@@ -105,7 +106,7 @@ The `managed_settings` input writes a policy file to `/etc/claude-code/managed-s
 ```tf
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.3.0"
+  version           = "5.4.0"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   anthropic_api_key = "xxxx-xxxxx-xxxx"
@@ -125,6 +126,50 @@ module "claude-code" {
 
 See the [Claude Code settings reference](https://docs.anthropic.com/en/docs/claude-code/settings) for the full schema. Common keys: `permissions` (`defaultMode`, `allow`, `deny`, `disableBypassPermissionsMode`, `additionalDirectories`), `env`, `model`, `apiKeyHelper`, `hooks`, `cleanupPeriodDays`.
 
+### Short-lived credentials via api_key_helper
+
+For production deployments we recommend `api_key_helper` over a static `anthropic_api_key`. The module writes the helper script into the workspace and registers it via Claude Code's [`apiKeyHelper` setting](https://docs.anthropic.com/en/docs/claude-code/settings#available-settings) at `/etc/claude-code/managed-settings.d/20-coder-apikeyhelper.json`. Claude invokes the script whenever it needs a key and caches the result for `ttl_ms` milliseconds (default 5 minutes), so the credential never lands in Terraform state, the agent environment, or `~/.claude.json`.
+
+```tf
+module "claude-code" {
+  source   = "registry.coder.com/coder/claude-code/coder"
+  version  = "5.4.0"
+  agent_id = coder_agent.main.id
+  workdir  = "/home/coder/project"
+
+  api_key_helper = {
+    script = <<-EOT
+      #!/bin/sh
+      exec vault kv get -field=key secret/anthropic
+    EOT
+    ttl_ms = 300000
+  }
+}
+```
+
+Or, sourcing from AWS Secrets Manager:
+
+```tf
+module "claude-code" {
+  source   = "registry.coder.com/coder/claude-code/coder"
+  version  = "5.4.0"
+  agent_id = coder_agent.main.id
+  workdir  = "/home/coder/project"
+
+  api_key_helper = {
+    script = <<-EOT
+      #!/bin/sh
+      exec aws secretsmanager get-secret-value \
+        --secret-id anthropic/api-key \
+        --query SecretString --output text
+    EOT
+  }
+}
+```
+
+> [!NOTE]
+> `api_key_helper` is mutually exclusive with `anthropic_api_key`, `claude_code_oauth_token`, and `enable_ai_gateway`. The script runs as the workspace user, so any CLI it calls (`vault`, `aws`, `gcloud`) must already be installed and authenticated in the workspace, for example via Workload Identity, IRSA, or a `pre_install_script`.
+
 ### Advanced Configuration
 
 This example shows version pinning, a pre-installed binary path, a custom model, and MCP servers.
@@ -132,7 +177,7 @@ This example shows version pinning, a pre-installed binary path, a custom model,
 ```tf
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "5.3.0"
+  version  = "5.4.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -196,7 +241,7 @@ Downstream `coder_script` resources can wait for this module's install pipeline 
 ```tf
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.3.0"
+  version           = "5.4.0"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   anthropic_api_key = "xxxx-xxxxx-xxxx"
@@ -226,7 +271,7 @@ Set `use_bedrock = true` to route Claude Code through Amazon Bedrock. The module
 ```tf
 module "claude-code" {
   source      = "registry.coder.com/coder/claude-code/coder"
-  version     = "5.3.0"
+  version     = "5.4.0"
   agent_id    = coder_agent.main.id
   workdir     = "/home/coder/project"
   use_bedrock = true
@@ -279,7 +324,7 @@ Set `use_vertex = true` to route Claude Code through Google Vertex AI. The modul
 ```tf
 module "claude-code" {
   source     = "registry.coder.com/coder/claude-code/coder"
-  version    = "5.3.0"
+  version    = "5.4.0"
   agent_id   = coder_agent.main.id
   workdir    = "/home/coder/project"
   use_vertex = true
@@ -312,7 +357,7 @@ Set `anthropic_base_url` to point Claude Code at a self-hosted gateway or proxy 
 ```tf
 module "claude-code" {
   source             = "registry.coder.com/coder/claude-code/coder"
-  version            = "5.3.0"
+  version            = "5.4.0"
   agent_id           = coder_agent.main.id
   workdir            = "/home/coder/project"
   anthropic_base_url = "https://llm-gateway.example.com/anthropic"
@@ -331,7 +376,7 @@ The module automatically tags every span and metric with `coder.workspace_id`, `
 ```tf
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.3.0"
+  version           = "5.4.0"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   anthropic_api_key = "xxxx-xxxxx-xxxx"

--- a/registry/coder/modules/claude-code/main.test.ts
+++ b/registry/coder/modules/claude-code/main.test.ts
@@ -126,6 +126,60 @@ describe("claude-code", async () => {
     expect(envCheck.stdout).toContain("CLAUDE_API_KEY");
   });
 
+  test("claude-api-key-not-written-to-claude-json", async () => {
+    const apiKey = "sk-ant-test-do-not-persist";
+    const { id, coderEnvVars } = await setup({
+      moduleVariables: {
+        claude_api_key: apiKey,
+        report_tasks: "false",
+      },
+    });
+    await execModuleScript(id, coderEnvVars);
+
+    const claudeConfig = await readFileContainer(
+      id,
+      "/home/coder/.claude.json",
+    );
+    expect(claudeConfig).toContain("hasCompletedOnboarding");
+    expect(claudeConfig).not.toContain("primaryApiKey");
+    expect(claudeConfig).not.toContain(apiKey);
+  });
+
+  test("api-key-helper", async () => {
+    const helperBody = "#!/bin/sh\nvault kv get -field=key secret/anthropic\n";
+    const { id, coderEnvVars } = await setup({
+      moduleVariables: {
+        api_key_helper: JSON.stringify({ script: helperBody, ttl_ms: 60000 }),
+        report_tasks: "false",
+      },
+    });
+    await execModuleScript(id);
+
+    expect(coderEnvVars["CLAUDE_CODE_API_KEY_HELPER_TTL_MS"]).toBe("60000");
+
+    const helper = await execContainer(id, [
+      "bash",
+      "-c",
+      "stat -c '%a' /home/coder/.claude/coder-api-key-helper.sh && cat /home/coder/.claude/coder-api-key-helper.sh",
+    ]);
+    expect(helper.stdout).toContain("700");
+    expect(helper.stdout).toContain("vault kv get -field=key secret/anthropic");
+
+    const managed = await readFileContainer(
+      id,
+      "/etc/claude-code/managed-settings.d/20-coder-apikeyhelper.json",
+    );
+    expect(managed).toContain('"apiKeyHelper"');
+    expect(managed).toContain("/home/coder/.claude/coder-api-key-helper.sh");
+
+    const claudeConfig = await readFileContainer(
+      id,
+      "/home/coder/.claude.json",
+    );
+    expect(claudeConfig).toContain("hasCompletedOnboarding");
+    expect(claudeConfig).not.toContain("primaryApiKey");
+  });
+
   test("claude-mcp-config", async () => {
     const mcpConfig = JSON.stringify({
       mcpServers: {

--- a/registry/coder/modules/claude-code/main.test.ts
+++ b/registry/coder/modules/claude-code/main.test.ts
@@ -518,4 +518,51 @@ describe("claude-code", async () => {
     expect(coderEnvVars["OTEL_EXPORTER_OTLP_HEADERS"]).toBeUndefined();
     expect(coderEnvVars["OTEL_RESOURCE_ATTRIBUTES"]).toBeUndefined();
   });
+
+  test("api-key-helper", async () => {
+    const helperBody = "#!/bin/sh\nvault kv get -field=key secret/anthropic\n";
+    const { id, coderEnvVars, scripts } = await setup({
+      moduleVariables: {
+        api_key_helper: JSON.stringify({ script: helperBody, ttl_ms: 60000 }),
+      },
+    });
+    expect(coderEnvVars["CLAUDE_CODE_API_KEY_HELPER_TTL_MS"]).toBe("60000");
+
+    await runScripts(id, scripts, coderEnvVars);
+
+    const installLog = await readFileContainer(
+      id,
+      "/home/coder/.coder-modules/coder/claude-code/logs/install.log",
+    );
+    expect(installLog).toContain("Configuring api_key_helper");
+    expect(installLog).toContain(
+      "Wrote api_key_helper script to /home/coder/.claude/coder-api-key-helper.sh",
+    );
+    // api_key_helper counts as authentication, so onboarding bypass runs.
+    expect(installLog).not.toContain("skipping onboarding bypass");
+    expect(installLog).toContain("Standalone mode configured successfully");
+
+    const helper = await execContainer(id, [
+      "bash",
+      "-c",
+      "cat /home/coder/.claude/coder-api-key-helper.sh && stat -c '%a' /home/coder/.claude/coder-api-key-helper.sh",
+    ]);
+    expect(helper.exitCode).toBe(0);
+    expect(helper.stdout).toContain("vault kv get -field=key secret/anthropic");
+    expect(helper.stdout).toContain("700");
+
+    const managed = await readFileContainer(
+      id,
+      "/etc/claude-code/managed-settings.d/20-coder-apikeyhelper.json",
+    );
+    expect(managed).toContain('"apiKeyHelper"');
+    expect(managed).toContain("/home/coder/.claude/coder-api-key-helper.sh");
+
+    const claudeConfig = await readFileContainer(
+      id,
+      "/home/coder/.claude.json",
+    );
+    const parsed = JSON.parse(claudeConfig);
+    expect(parsed.hasCompletedOnboarding).toBe(true);
+  });
 });

--- a/registry/coder/modules/claude-code/main.test.ts
+++ b/registry/coder/modules/claude-code/main.test.ts
@@ -584,4 +584,51 @@ describe("claude-code", async () => {
     expect(installLog).toContain(baseUrl);
     expect(installLog).not.toContain("No authentication configured");
   });
+
+  test("api-key-helper", async () => {
+    const helperBody = "#!/bin/sh\nvault kv get -field=key secret/anthropic\n";
+    const { id, coderEnvVars, scripts } = await setup({
+      moduleVariables: {
+        api_key_helper: JSON.stringify({ script: helperBody, ttl_ms: 60000 }),
+      },
+    });
+    expect(coderEnvVars["CLAUDE_CODE_API_KEY_HELPER_TTL_MS"]).toBe("60000");
+
+    await runScripts(id, scripts, coderEnvVars);
+
+    const installLog = await readFileContainer(
+      id,
+      "/home/coder/.coder-modules/coder/claude-code/logs/install.log",
+    );
+    expect(installLog).toContain("Configuring api_key_helper");
+    expect(installLog).toContain(
+      "Wrote api_key_helper script to /home/coder/.claude/coder-api-key-helper.sh",
+    );
+    // api_key_helper counts as authentication, so onboarding bypass runs.
+    expect(installLog).not.toContain("skipping onboarding bypass");
+    expect(installLog).toContain("Standalone mode configured successfully");
+
+    const helper = await execContainer(id, [
+      "bash",
+      "-c",
+      "cat /home/coder/.claude/coder-api-key-helper.sh && stat -c '%a' /home/coder/.claude/coder-api-key-helper.sh",
+    ]);
+    expect(helper.exitCode).toBe(0);
+    expect(helper.stdout).toContain("vault kv get -field=key secret/anthropic");
+    expect(helper.stdout).toContain("700");
+
+    const managed = await readFileContainer(
+      id,
+      "/etc/claude-code/managed-settings.d/20-coder-apikeyhelper.json",
+    );
+    expect(managed).toContain('"apiKeyHelper"');
+    expect(managed).toContain("/home/coder/.claude/coder-api-key-helper.sh");
+
+    const claudeConfig = await readFileContainer(
+      id,
+      "/home/coder/.claude.json",
+    );
+    const parsed = JSON.parse(claudeConfig);
+    expect(parsed.hasCompletedOnboarding).toBe(true);
+  });
 });

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -62,7 +62,8 @@ variable "disable_autoupdater" {
 
 variable "anthropic_api_key" {
   type        = string
-  description = "API key passed to Claude Code via the ANTHROPIC_API_KEY env var."
+  description = "API key passed to Claude Code via the ANTHROPIC_API_KEY env var. Prefer api_key_helper for short-lived credentials."
+  sensitive   = true
   default     = ""
 }
 
@@ -136,6 +137,25 @@ variable "telemetry" {
   description = "Configure Claude Code OpenTelemetry export. When enabled, sets CLAUDE_CODE_ENABLE_TELEMETRY and the standard OTEL_EXPORTER_OTLP_* environment variables. Coder workspace identifiers (coder.workspace_id, coder.workspace_name, coder.workspace_owner, coder.template_name) are automatically appended to OTEL_RESOURCE_ATTRIBUTES so Claude Code telemetry can be joined with Coder audit and exectrace logs."
 }
 
+variable "api_key_helper" {
+  type = object({
+    script = string
+    ttl_ms = optional(number, 300000)
+  })
+  description = "Script that prints an Anthropic API key to stdout. Written to ~/.claude/coder-api-key-helper.sh and registered via the apiKeyHelper setting in /etc/claude-code/managed-settings.d/. Use for short-lived credentials from Vault, AWS Secrets Manager, cloud IAM, etc. ttl_ms is how long Claude Code caches each key (default 5 minutes)."
+  default     = null
+
+  validation {
+    condition     = var.api_key_helper == null || (var.anthropic_api_key == "" && var.claude_code_oauth_token == "")
+    error_message = "api_key_helper cannot be combined with anthropic_api_key or claude_code_oauth_token. Use exactly one authentication method."
+  }
+
+  validation {
+    condition     = var.api_key_helper == null || !var.enable_ai_gateway
+    error_message = "api_key_helper cannot be combined with enable_ai_gateway. AI Gateway authenticates using the workspace owner's session token."
+  }
+}
+
 resource "coder_env" "claude_code_oauth_token" {
   count    = var.claude_code_oauth_token != "" ? 1 : 0
   agent_id = var.agent_id
@@ -179,6 +199,13 @@ resource "coder_env" "anthropic_base_url" {
   agent_id = var.agent_id
   name     = "ANTHROPIC_BASE_URL"
   value    = "${data.coder_workspace.me.access_url}/api/v2/aibridge/anthropic"
+}
+
+resource "coder_env" "api_key_helper_ttl" {
+  count    = var.api_key_helper != null ? 1 : 0
+  agent_id = var.agent_id
+  name     = "CLAUDE_CODE_API_KEY_HELPER_TTL_MS"
+  value    = tostring(var.api_key_helper.ttl_ms)
 }
 
 locals {
@@ -244,6 +271,7 @@ locals {
     ARG_MCP_CONFIG_REMOTE_PATH = base64encode(jsonencode(var.mcp_config_remote_path))
     ARG_ENABLE_AI_GATEWAY      = tostring(var.enable_ai_gateway)
     ARG_MANAGED_SETTINGS_JSON  = var.managed_settings != null ? base64encode(jsonencode(var.managed_settings)) : ""
+    ARG_API_KEY_HELPER_SCRIPT  = var.api_key_helper != null ? base64encode(var.api_key_helper.script) : ""
   })
   module_dir_name = ".coder-modules/coder/claude-code"
 }

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -128,8 +128,9 @@ variable "disable_autoupdater" {
 
 variable "claude_api_key" {
   type        = string
-  description = "The API key to use for the Claude Code server."
+  description = "Anthropic API key. Sets ANTHROPIC_API_KEY in the workspace environment. Prefer api_key_helper for short-lived credentials."
   default     = ""
+  sensitive   = true
 }
 
 variable "model" {
@@ -196,6 +197,25 @@ variable "claude_code_oauth_token" {
   description = "Set up a long-lived authentication token (requires Claude subscription). Generated using `claude setup-token` command"
   sensitive   = true
   default     = ""
+}
+
+variable "api_key_helper" {
+  type = object({
+    script = string
+    ttl_ms = optional(number, 300000)
+  })
+  description = "Script that prints an Anthropic API key to stdout. Written to ~/.claude/coder-api-key-helper.sh and registered via the apiKeyHelper setting in /etc/claude-code/managed-settings.d/. Use for short-lived credentials from Vault, AWS Secrets Manager, cloud IAM, etc. ttl_ms is how long Claude caches each key (default 5 minutes)."
+  default     = null
+
+  validation {
+    condition     = var.api_key_helper == null || (var.claude_api_key == "" && var.claude_code_oauth_token == "")
+    error_message = "api_key_helper cannot be combined with claude_api_key or claude_code_oauth_token. Use exactly one authentication method."
+  }
+
+  validation {
+    condition     = var.api_key_helper == null || !var.enable_aibridge
+    error_message = "api_key_helper cannot be combined with enable_aibridge. AI Bridge handles authentication via the workspace owner's session token."
+  }
 }
 
 variable "system_prompt" {
@@ -305,6 +325,13 @@ resource "coder_env" "disable_autoupdater" {
   agent_id = var.agent_id
   name     = "DISABLE_AUTOUPDATER"
   value    = "1"
+}
+
+resource "coder_env" "api_key_helper_ttl_ms" {
+  count    = var.api_key_helper != null ? 1 : 0
+  agent_id = var.agent_id
+  name     = "CLAUDE_CODE_API_KEY_HELPER_TTL_MS"
+  value    = tostring(var.api_key_helper.ttl_ms)
 }
 
 
@@ -431,6 +458,7 @@ module "agentapi" {
     ARG_MCP_CONFIG_REMOTE_PATH='${base64encode(jsonencode(var.mcp_config_remote_path))}' \
     ARG_ENABLE_AIBRIDGE='${var.enable_aibridge}' \
     ARG_PERMISSION_MODE='${var.permission_mode}' \
+    ARG_API_KEY_HELPER_SCRIPT='${var.api_key_helper != null ? base64encode(var.api_key_helper.script) : ""}' \
     /tmp/install.sh
   EOT
 }

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -62,7 +62,8 @@ variable "disable_autoupdater" {
 
 variable "anthropic_api_key" {
   type        = string
-  description = "API key passed to Claude Code via the ANTHROPIC_API_KEY env var."
+  description = "API key passed to Claude Code via the ANTHROPIC_API_KEY env var. Prefer api_key_helper for short-lived credentials."
+  sensitive   = true
   default     = ""
 }
 
@@ -174,6 +175,25 @@ variable "use_vertex" {
   }
 }
 
+variable "api_key_helper" {
+  type = object({
+    script = string
+    ttl_ms = optional(number, 300000)
+  })
+  description = "Script that prints an Anthropic API key to stdout. Written to ~/.claude/coder-api-key-helper.sh and registered via the apiKeyHelper setting in /etc/claude-code/managed-settings.d/. Use for short-lived credentials from Vault, AWS Secrets Manager, cloud IAM, etc. ttl_ms is how long Claude Code caches each key (default 5 minutes)."
+  default     = null
+
+  validation {
+    condition     = var.api_key_helper == null || (var.anthropic_api_key == "" && var.claude_code_oauth_token == "")
+    error_message = "api_key_helper cannot be combined with anthropic_api_key or claude_code_oauth_token. Use exactly one authentication method."
+  }
+
+  validation {
+    condition     = var.api_key_helper == null || !var.enable_ai_gateway
+    error_message = "api_key_helper cannot be combined with enable_ai_gateway. AI Gateway authenticates using the workspace owner's session token."
+  }
+}
+
 resource "coder_env" "claude_code_oauth_token" {
   count    = var.claude_code_oauth_token != "" ? 1 : 0
   agent_id = var.agent_id
@@ -231,6 +251,13 @@ resource "coder_env" "use_vertex" {
   agent_id = var.agent_id
   name     = "CLAUDE_CODE_USE_VERTEX"
   value    = "1"
+}
+
+resource "coder_env" "api_key_helper_ttl" {
+  count    = var.api_key_helper != null ? 1 : 0
+  agent_id = var.agent_id
+  name     = "CLAUDE_CODE_API_KEY_HELPER_TTL_MS"
+  value    = tostring(var.api_key_helper.ttl_ms)
 }
 
 locals {
@@ -299,6 +326,7 @@ locals {
     ARG_USE_BEDROCK            = tostring(var.use_bedrock)
     ARG_USE_VERTEX             = tostring(var.use_vertex)
     ARG_ANTHROPIC_BASE_URL     = var.anthropic_base_url
+    ARG_API_KEY_HELPER_SCRIPT  = var.api_key_helper != null ? base64encode(var.api_key_helper.script) : ""
   })
   module_dir_name = ".coder-modules/coder/claude-code"
 }

--- a/registry/coder/modules/claude-code/main.tftest.hcl
+++ b/registry/coder/modules/claude-code/main.tftest.hcl
@@ -460,3 +460,82 @@ run "test_api_key_count_with_aibridge_no_override" {
     error_message = "CLAUDE_API_KEY env should be created when aibridge is enabled, regardless of session_token value"
   }
 }
+
+run "test_api_key_helper" {
+  command = plan
+
+  variables {
+    agent_id = "test-agent-helper"
+    workdir  = "/home/coder/test"
+    api_key_helper = {
+      script = "#!/bin/sh\nvault kv get -field=key secret/anthropic\n"
+      ttl_ms = 60000
+    }
+  }
+
+  assert {
+    condition     = length(coder_env.api_key_helper_ttl_ms) == 1
+    error_message = "CLAUDE_CODE_API_KEY_HELPER_TTL_MS env should be created when api_key_helper is set"
+  }
+
+  assert {
+    condition     = coder_env.api_key_helper_ttl_ms[0].value == "60000"
+    error_message = "CLAUDE_CODE_API_KEY_HELPER_TTL_MS should match api_key_helper.ttl_ms"
+  }
+
+  assert {
+    condition     = length(coder_env.claude_api_key) == 0
+    error_message = "CLAUDE_API_KEY env should not be created when api_key_helper is the auth source"
+  }
+}
+
+run "test_api_key_helper_default_ttl" {
+  command = plan
+
+  variables {
+    agent_id = "test-agent-helper-default"
+    workdir  = "/home/coder/test"
+    api_key_helper = {
+      script = "#!/bin/sh\necho key\n"
+    }
+  }
+
+  assert {
+    condition     = coder_env.api_key_helper_ttl_ms[0].value == "300000"
+    error_message = "ttl_ms should default to 300000 (5 minutes)"
+  }
+}
+
+run "test_api_key_helper_validation_with_api_key" {
+  command = plan
+
+  variables {
+    agent_id       = "test-agent-helper-validation"
+    workdir        = "/home/coder/test"
+    claude_api_key = "test-key"
+    api_key_helper = {
+      script = "#!/bin/sh\necho key\n"
+    }
+  }
+
+  expect_failures = [
+    var.api_key_helper,
+  ]
+}
+
+run "test_api_key_helper_validation_with_aibridge" {
+  command = plan
+
+  variables {
+    agent_id        = "test-agent-helper-validation-aibridge"
+    workdir         = "/home/coder/test"
+    enable_aibridge = true
+    api_key_helper = {
+      script = "#!/bin/sh\necho key\n"
+    }
+  }
+
+  expect_failures = [
+    var.api_key_helper,
+  ]
+}

--- a/registry/coder/modules/claude-code/main.tftest.hcl
+++ b/registry/coder/modules/claude-code/main.tftest.hcl
@@ -327,3 +327,77 @@ run "test_managed_settings_default_null" {
     error_message = "managed_settings should default to null when omitted"
   }
 }
+
+run "test_api_key_helper" {
+  command = plan
+
+  variables {
+    agent_id = "test-agent-helper"
+    workdir  = "/home/coder/test"
+    api_key_helper = {
+      script = "#!/bin/sh\nvault kv get -field=key secret/anthropic\n"
+      ttl_ms = 60000
+    }
+  }
+
+  assert {
+    condition     = coder_env.api_key_helper_ttl[0].name == "CLAUDE_CODE_API_KEY_HELPER_TTL_MS"
+    error_message = "api_key_helper_ttl env var name should be CLAUDE_CODE_API_KEY_HELPER_TTL_MS"
+  }
+
+  assert {
+    condition     = coder_env.api_key_helper_ttl[0].value == "60000"
+    error_message = "api_key_helper_ttl env var value should match ttl_ms"
+  }
+}
+
+run "test_api_key_helper_default_ttl" {
+  command = plan
+
+  variables {
+    agent_id = "test-agent-helper-default"
+    workdir  = "/home/coder/test"
+    api_key_helper = {
+      script = "#!/bin/sh\necho key\n"
+    }
+  }
+
+  assert {
+    condition     = coder_env.api_key_helper_ttl[0].value == "300000"
+    error_message = "ttl_ms should default to 300000 (5 minutes)"
+  }
+}
+
+run "test_api_key_helper_validation_with_api_key" {
+  command = plan
+
+  variables {
+    agent_id          = "test-agent-validation"
+    workdir           = "/home/coder/test"
+    anthropic_api_key = "sk-test"
+    api_key_helper = {
+      script = "echo key"
+    }
+  }
+
+  expect_failures = [
+    var.api_key_helper,
+  ]
+}
+
+run "test_api_key_helper_validation_with_ai_gateway" {
+  command = plan
+
+  variables {
+    agent_id          = "test-agent-validation"
+    workdir           = "/home/coder/test"
+    enable_ai_gateway = true
+    api_key_helper = {
+      script = "echo key"
+    }
+  }
+
+  expect_failures = [
+    var.api_key_helper,
+  ]
+}

--- a/registry/coder/modules/claude-code/main.tftest.hcl
+++ b/registry/coder/modules/claude-code/main.tftest.hcl
@@ -437,3 +437,77 @@ run "test_use_bedrock_validation_with_use_vertex" {
     var.use_bedrock,
   ]
 }
+
+run "test_api_key_helper" {
+  command = plan
+
+  variables {
+    agent_id = "test-agent-helper"
+    workdir  = "/home/coder/test"
+    api_key_helper = {
+      script = "#!/bin/sh\nvault kv get -field=key secret/anthropic\n"
+      ttl_ms = 60000
+    }
+  }
+
+  assert {
+    condition     = coder_env.api_key_helper_ttl[0].name == "CLAUDE_CODE_API_KEY_HELPER_TTL_MS"
+    error_message = "api_key_helper_ttl env var name should be CLAUDE_CODE_API_KEY_HELPER_TTL_MS"
+  }
+
+  assert {
+    condition     = coder_env.api_key_helper_ttl[0].value == "60000"
+    error_message = "api_key_helper_ttl env var value should match ttl_ms"
+  }
+}
+
+run "test_api_key_helper_default_ttl" {
+  command = plan
+
+  variables {
+    agent_id = "test-agent-helper-default"
+    workdir  = "/home/coder/test"
+    api_key_helper = {
+      script = "#!/bin/sh\necho key\n"
+    }
+  }
+
+  assert {
+    condition     = coder_env.api_key_helper_ttl[0].value == "300000"
+    error_message = "ttl_ms should default to 300000 (5 minutes)"
+  }
+}
+
+run "test_api_key_helper_validation_with_api_key" {
+  command = plan
+
+  variables {
+    agent_id          = "test-agent-validation"
+    workdir           = "/home/coder/test"
+    anthropic_api_key = "sk-test"
+    api_key_helper = {
+      script = "echo key"
+    }
+  }
+
+  expect_failures = [
+    var.api_key_helper,
+  ]
+}
+
+run "test_api_key_helper_validation_with_ai_gateway" {
+  command = plan
+
+  variables {
+    agent_id          = "test-agent-validation"
+    workdir           = "/home/coder/test"
+    enable_ai_gateway = true
+    api_key_helper = {
+      script = "echo key"
+    }
+  }
+
+  expect_failures = [
+    var.api_key_helper,
+  ]
+}

--- a/registry/coder/modules/claude-code/scripts/install.sh
+++ b/registry/coder/modules/claude-code/scripts/install.sh
@@ -23,6 +23,7 @@ ARG_ALLOWED_TOOLS=${ARG_ALLOWED_TOOLS:-}
 ARG_DISALLOWED_TOOLS=${ARG_DISALLOWED_TOOLS:-}
 ARG_ENABLE_AIBRIDGE=${ARG_ENABLE_AIBRIDGE:-false}
 ARG_PERMISSION_MODE=${ARG_PERMISSION_MODE:-}
+ARG_API_KEY_HELPER_SCRIPT=${ARG_API_KEY_HELPER_SCRIPT:-}
 
 export PATH="$ARG_CLAUDE_BINARY_PATH:$PATH"
 
@@ -180,8 +181,8 @@ function setup_claude_configurations() {
 function configure_standalone_mode() {
   echo "Configuring Claude Code for standalone mode..."
 
-  if [ -z "${CLAUDE_API_KEY:-}" ] && [ "$ARG_ENABLE_AIBRIDGE" = "false" ]; then
-    echo "Note: Neither claude_api_key nor enable_aibridge is set, skipping authentication setup"
+  if [ -z "${CLAUDE_API_KEY:-}" ] && [ "$ARG_ENABLE_AIBRIDGE" = "false" ] && [ -z "$ARG_API_KEY_HELPER_SCRIPT" ]; then
+    echo "Note: No authentication configured (claude_api_key, enable_aibridge, or api_key_helper), skipping authentication setup"
     return
   fi
 
@@ -189,18 +190,18 @@ function configure_standalone_mode() {
   local workdir_normalized
   workdir_normalized=$(echo "$ARG_WORKDIR" | tr '/' '-')
 
-  # Create or update .claude.json with minimal configuration for API key auth
-  # This skips the interactive login prompt and onboarding screens
+  # Pre-accept onboarding and trust prompts so the CLI starts non-interactively.
+  # The API key itself is supplied via env (ANTHROPIC_API_KEY / CLAUDE_API_KEY)
+  # or apiKeyHelper, never written to this file.
   if [ -f "$claude_config" ]; then
     echo "Updating existing Claude configuration at $claude_config"
 
-    jq --arg workdir "$ARG_WORKDIR" --arg apikey "${CLAUDE_API_KEY:-}" \
+    jq --arg workdir "$ARG_WORKDIR" \
       '.autoUpdaterStatus = "disabled" |
         .autoModeAccepted = true |
         .bypassPermissionsModeAccepted = true |
         .hasAcknowledgedCostThreshold = true |
         .hasCompletedOnboarding = true |
-        .primaryApiKey = $apikey |
         .projects[$workdir].hasCompletedProjectOnboarding = true |
         .projects[$workdir].hasTrustDialogAccepted = true' \
       "$claude_config" > "${claude_config}.tmp" && mv "${claude_config}.tmp" "$claude_config"
@@ -213,7 +214,6 @@ function configure_standalone_mode() {
   "bypassPermissionsModeAccepted": true,
   "hasAcknowledgedCostThreshold": true,
   "hasCompletedOnboarding": true,
-  "primaryApiKey": "${CLAUDE_API_KEY:-}",
   "projects": {
     "$ARG_WORKDIR": {
       "hasCompletedProjectOnboarding": true,
@@ -225,6 +225,30 @@ EOF
   fi
 
   echo "Standalone mode configured successfully"
+}
+
+function setup_api_key_helper() {
+  if [ -z "$ARG_API_KEY_HELPER_SCRIPT" ]; then
+    return
+  fi
+
+  echo "Configuring apiKeyHelper for short-lived credentials..."
+
+  mkdir -p "$HOME/.claude"
+  local helper_path="$HOME/.claude/coder-api-key-helper.sh"
+  echo -n "$ARG_API_KEY_HELPER_SCRIPT" | base64 -d > "$helper_path"
+  chmod 0700 "$helper_path"
+
+  local managed_dir="/etc/claude-code/managed-settings.d"
+  if command_exists sudo; then
+    sudo mkdir -p "$managed_dir"
+    printf '{\n  "apiKeyHelper": "%s"\n}\n' "$helper_path" | sudo tee "$managed_dir/20-coder-apikeyhelper.json" > /dev/null
+  else
+    mkdir -p "$managed_dir"
+    printf '{\n  "apiKeyHelper": "%s"\n}\n' "$helper_path" > "$managed_dir/20-coder-apikeyhelper.json"
+  fi
+
+  echo "apiKeyHelper registered at $helper_path (settings: $managed_dir/20-coder-apikeyhelper.json)"
 }
 
 function report_tasks() {
@@ -258,6 +282,7 @@ function accept_auto_mode() {
 
 install_claude_code_cli
 setup_claude_configurations
+setup_api_key_helper
 report_tasks
 
 if [ "$ARG_PERMISSION_MODE" = "auto" ]; then

--- a/registry/coder/modules/claude-code/scripts/install.sh.tftpl
+++ b/registry/coder/modules/claude-code/scripts/install.sh.tftpl
@@ -18,6 +18,7 @@ ARG_MCP=$(echo -n '${ARG_MCP}' | base64 -d)
 ARG_MCP_CONFIG_REMOTE_PATH=$(echo -n '${ARG_MCP_CONFIG_REMOTE_PATH}' | base64 -d)
 ARG_ENABLE_AI_GATEWAY='${ARG_ENABLE_AI_GATEWAY}'
 ARG_MANAGED_SETTINGS_JSON=$(echo -n '${ARG_MANAGED_SETTINGS_JSON}' | base64 -d)
+ARG_API_KEY_HELPER_SCRIPT=$(echo -n '${ARG_API_KEY_HELPER_SCRIPT}' | base64 -d)
 
 export PATH="$${ARG_CLAUDE_BINARY_PATH}:$PATH"
 
@@ -31,6 +32,7 @@ printf "ARG_MCP: %s\n" "$${ARG_MCP}"
 printf "ARG_MCP_CONFIG_REMOTE_PATH: %s\n" "$${ARG_MCP_CONFIG_REMOTE_PATH}"
 printf "ARG_ENABLE_AI_GATEWAY: %s\n" "$${ARG_ENABLE_AI_GATEWAY}"
 printf "ARG_MANAGED_SETTINGS_JSON: %s\n" "$${ARG_MANAGED_SETTINGS_JSON}"
+printf "ARG_API_KEY_HELPER_SCRIPT: %s\n" "$${ARG_API_KEY_HELPER_SCRIPT:+(set)}"
 
 echo "--------------------------------"
 
@@ -172,11 +174,40 @@ function write_managed_settings() {
   echo "Wrote Claude Code managed settings to $${target}"
 }
 
+function setup_api_key_helper() {
+  if [ -z "$${ARG_API_KEY_HELPER_SCRIPT}" ]; then
+    return
+  fi
+
+  echo "Configuring api_key_helper for short-lived credentials..."
+
+  mkdir -p "$HOME/.claude"
+  local helper_path="$HOME/.claude/coder-api-key-helper.sh"
+  printf '%s' "$${ARG_API_KEY_HELPER_SCRIPT}" > "$${helper_path}"
+  chmod 0700 "$${helper_path}"
+
+  local dropin_dir="/etc/claude-code/managed-settings.d"
+  local target="$${dropin_dir}/20-coder-apikeyhelper.json"
+  if command_exists sudo; then
+    sudo mkdir -p "$${dropin_dir}"
+    printf '{"apiKeyHelper":"%s"}\n' "$${helper_path}" | sudo tee "$${target}" > /dev/null
+    sudo chmod 0644 "$${target}"
+  elif mkdir -p "$${dropin_dir}" 2> /dev/null; then
+    printf '{"apiKeyHelper":"%s"}\n' "$${helper_path}" > "$${target}"
+    chmod 0644 "$${target}"
+  else
+    echo "Warning: cannot write to $${dropin_dir} (no sudo and not writable); api_key_helper will not be registered"
+    return
+  fi
+
+  echo "Wrote api_key_helper script to $${helper_path} and registered via $${target}"
+}
+
 function configure_standalone_mode() {
   echo "Configuring Claude Code for standalone mode..."
 
-  if [ -z "$${ANTHROPIC_API_KEY:-}" ] && [ -z "$${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ "$${ARG_ENABLE_AI_GATEWAY}" = "false" ]; then
-    echo "Note: No authentication configured (anthropic_api_key, claude_code_oauth_token, enable_ai_gateway), skipping onboarding bypass"
+  if [ -z "$${ANTHROPIC_API_KEY:-}" ] && [ -z "$${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ "$${ARG_ENABLE_AI_GATEWAY}" = "false" ] && [ -z "$${ARG_API_KEY_HELPER_SCRIPT}" ]; then
+    echo "Note: No authentication configured (anthropic_api_key, claude_code_oauth_token, enable_ai_gateway, api_key_helper), skipping onboarding bypass"
     return
   fi
 
@@ -214,4 +245,5 @@ EOF
 install_claude_code_cli
 setup_claude_configurations
 write_managed_settings
+setup_api_key_helper
 configure_standalone_mode

--- a/registry/coder/modules/claude-code/scripts/install.sh.tftpl
+++ b/registry/coder/modules/claude-code/scripts/install.sh.tftpl
@@ -21,6 +21,7 @@ ARG_MANAGED_SETTINGS_JSON=$(echo -n '${ARG_MANAGED_SETTINGS_JSON}' | base64 -d)
 ARG_USE_BEDROCK='${ARG_USE_BEDROCK}'
 ARG_USE_VERTEX='${ARG_USE_VERTEX}'
 ARG_ANTHROPIC_BASE_URL='${ARG_ANTHROPIC_BASE_URL}'
+ARG_API_KEY_HELPER_SCRIPT=$(echo -n '${ARG_API_KEY_HELPER_SCRIPT}' | base64 -d)
 
 export PATH="$${ARG_CLAUDE_BINARY_PATH}:$PATH"
 
@@ -37,6 +38,7 @@ printf "ARG_MANAGED_SETTINGS_JSON: %s\n" "$${ARG_MANAGED_SETTINGS_JSON}"
 printf "ARG_USE_BEDROCK: %s\n" "$${ARG_USE_BEDROCK}"
 printf "ARG_USE_VERTEX: %s\n" "$${ARG_USE_VERTEX}"
 printf "ARG_ANTHROPIC_BASE_URL: %s\n" "$${ARG_ANTHROPIC_BASE_URL}"
+printf "ARG_API_KEY_HELPER_SCRIPT: %s\n" "$${ARG_API_KEY_HELPER_SCRIPT:+(set)}"
 
 echo "--------------------------------"
 
@@ -178,6 +180,35 @@ function write_managed_settings() {
   echo "Wrote Claude Code managed settings to $${target}"
 }
 
+function setup_api_key_helper() {
+  if [ -z "$${ARG_API_KEY_HELPER_SCRIPT}" ]; then
+    return
+  fi
+
+  echo "Configuring api_key_helper for short-lived credentials..."
+
+  mkdir -p "$HOME/.claude"
+  local helper_path="$HOME/.claude/coder-api-key-helper.sh"
+  printf '%s' "$${ARG_API_KEY_HELPER_SCRIPT}" > "$${helper_path}"
+  chmod 0700 "$${helper_path}"
+
+  local dropin_dir="/etc/claude-code/managed-settings.d"
+  local target="$${dropin_dir}/20-coder-apikeyhelper.json"
+  if command_exists sudo; then
+    sudo mkdir -p "$${dropin_dir}"
+    printf '{"apiKeyHelper":"%s"}\n' "$${helper_path}" | sudo tee "$${target}" > /dev/null
+    sudo chmod 0644 "$${target}"
+  elif mkdir -p "$${dropin_dir}" 2> /dev/null; then
+    printf '{"apiKeyHelper":"%s"}\n' "$${helper_path}" > "$${target}"
+    chmod 0644 "$${target}"
+  else
+    echo "Warning: cannot write to $${dropin_dir} (no sudo and not writable); api_key_helper will not be registered"
+    return
+  fi
+
+  echo "Wrote api_key_helper script to $${helper_path} and registered via $${target}"
+}
+
 function configure_standalone_mode() {
   echo "Configuring Claude Code for standalone mode..."
 
@@ -193,10 +224,13 @@ function configure_standalone_mode() {
   elif [ -n "$${ARG_ANTHROPIC_BASE_URL}" ]; then
     echo "Using custom ANTHROPIC_BASE_URL ($${ARG_ANTHROPIC_BASE_URL}); Anthropic API key not required."
     have_auth="true"
+  elif [ -n "$${ARG_API_KEY_HELPER_SCRIPT}" ]; then
+    echo "Using api_key_helper for short-lived credentials; Anthropic API key not required."
+    have_auth="true"
   fi
 
   if [ "$${have_auth}" = "false" ]; then
-    echo "Note: No authentication configured (anthropic_api_key, claude_code_oauth_token, enable_ai_gateway, use_bedrock, use_vertex, anthropic_base_url), skipping onboarding bypass"
+    echo "Note: No authentication configured (anthropic_api_key, claude_code_oauth_token, enable_ai_gateway, use_bedrock, use_vertex, anthropic_base_url, api_key_helper), skipping onboarding bypass"
     return
   fi
 
@@ -234,4 +268,5 @@ EOF
 install_claude_code_cli
 setup_claude_configurations
 write_managed_settings
+setup_api_key_helper
 configure_standalone_mode


### PR DESCRIPTION
## Problem

The module currently treats the Anthropic API key as a static, long-lived secret:

- `claude_api_key` is not marked `sensitive`, so it can appear in plain text in Terraform plan output and CI logs (only `claude_code_oauth_token` had the flag).
- `install.sh` writes the key to `~/.claude.json` as `primaryApiKey`. The CLI already reads the key from the `ANTHROPIC_API_KEY` / `CLAUDE_API_KEY` environment variable that this module sets via `coder_env`, so the disk write is redundant and leaves a credential at rest in a user-readable file.
- There is no first-class way to use short-lived credentials. Customers who source keys from Vault, AWS Secrets Manager, or cloud IAM today have to wrap the module with a `pre_install_script` and still end up with a static value in TF state.

## Changes

- New `api_key_helper` input (`{ script, ttl_ms }`). The script is written to `~/.claude/coder-api-key-helper.sh` (mode 0700) and registered via the Claude Code [`apiKeyHelper`](https://docs.anthropic.com/en/docs/claude-code/settings#available-settings) setting at `/etc/claude-code/managed-settings.d/20-coder-apikeyhelper.json`. Claude invokes the helper whenever it needs a key and caches the result for `ttl_ms` (default 5 minutes), so the credential never lands in TF state, the agent environment, or `~/.claude.json`.
- `coder_env` for `CLAUDE_CODE_API_KEY_HELPER_TTL_MS` when `api_key_helper` is set.
- `claude_api_key` now has `sensitive = true` and an updated description.
- `install.sh` no longer writes `primaryApiKey` to `~/.claude.json`. Onboarding-bypass keys (`hasCompletedOnboarding`, `hasTrustDialogAccepted`, etc.) are kept so the CLI still starts non-interactively. The early-return guard is widened so onboarding bypass also runs when `api_key_helper` is the auth source.
- Validation: `api_key_helper` is mutually exclusive with `claude_api_key`, `claude_code_oauth_token`, and `enable_aibridge`.
- README: new "Short-lived credentials via api_key_helper" section with Vault and AWS Secrets Manager examples.

This is install-time configuration only, so it composes cleanly with the direction in #861.

## Validation

- `terraform fmt` clean
- `terraform validate` clean
- `terraform test`: 23/23 pass (4 new: `test_api_key_helper`, `test_api_key_helper_default_ttl`, `test_api_key_helper_validation_with_api_key`, `test_api_key_helper_validation_with_aibridge`)
- `bun test`: 2 new tests pass (`api-key-helper`, `claude-api-key-not-written-to-claude-json`); existing suite untouched
- `shellcheck --severity=warning scripts/install.sh` clean

## Disclosure

I work at Anthropic on the Claude Code team. This change is part of a small batch of upstream contributions based on what we have seen enterprise customers ask for; happy to adjust scope or split further if that helps review.

