### PR TITLE
chore(coder-utils): centralize script paths under agent-scoped utils directory

### DIFF
--- a/registry/coder/modules/coder-utils/main.tf
+++ b/registry/coder/modules/coder-utils/main.tf
@@ -113,7 +113,7 @@ resource "coder_script" "pre_install_script" {
     set -o errexit
     set -o pipefail
 
-    mkdir -p ${var.module_directory}
+    mkdir -p ${local.utils_script_path}
     mkdir -p ${local.log_directory}
 
     trap 'coder exp sync complete ${local.pre_install_script_name}' EXIT
@@ -136,7 +136,7 @@ resource "coder_script" "install_script" {
     set -o errexit
     set -o pipefail
 
-    mkdir -p ${var.module_directory}
+    mkdir -p ${local.utils_script_path}
     mkdir -p ${local.log_directory}
 
     trap 'coder exp sync complete ${local.install_script_name}' EXIT

--- a/registry/coder/modules/coder-utils/main.tf
+++ b/registry/coder/modules/coder-utils/main.tf
@@ -77,10 +77,12 @@ locals {
   post_install_script_name = "${var.agent_name}-post_install_script"
   start_script_name        = "${var.agent_name}-start_script"
 
-  pre_install_path  = "${var.module_directory}/pre_install.sh"
-  install_path      = "${var.module_directory}/install.sh"
-  post_install_path = "${var.module_directory}/post_install.sh"
-  start_path        = "${var.module_directory}/start.sh"
+  utils_script_path = "${var.module_directory}/${var.agent_name}-utils"
+
+  pre_install_path  = "${local.utils_script_path}/pre_install.sh"
+  install_path      = "${local.utils_script_path}/install.sh"
+  post_install_path = "${local.utils_script_path}/post_install.sh"
+  start_path        = "${local.utils_script_path}/start.sh"
 
   pre_install_log_path  = "${local.log_directory}/pre_install.log"
   install_log_path      = "${local.log_directory}/install.log"

--- a/registry/coder/modules/coder-utils/main.tftest.hcl
+++ b/registry/coder/modules/coder-utils/main.tftest.hcl
@@ -578,3 +578,95 @@ run "test_logs_nested_under_module_directory" {
     error_message = "install script must mkdir -p the logs/ sub-path"
   }
 }
+
+# Scripts are written to ${module_directory}/${agent_name}-utils/ so the
+# wrapper must mkdir that directory and all script paths must nest under it.
+run "test_scripts_nested_under_utils_directory" {
+  command = plan
+
+  variables {
+    agent_id            = "test-agent-id"
+    agent_name          = "test-agent"
+    module_directory    = ".test-module"
+    pre_install_script  = "echo pre"
+    install_script      = "echo install"
+    post_install_script = "echo post"
+    start_script        = "echo start"
+  }
+
+  # pre_install and install create the utils directory.
+  assert {
+    condition     = can(regex("mkdir -p .test-module/test-agent-utils", coder_script.pre_install_script[0].script))
+    error_message = "pre_install script must mkdir -p the utils directory"
+  }
+
+  assert {
+    condition     = can(regex("mkdir -p .test-module/test-agent-utils", coder_script.install_script.script))
+    error_message = "install script must mkdir -p the utils directory"
+  }
+
+  # Every script writes its file under the utils directory.
+  assert {
+    condition     = can(regex("base64 -d > .test-module/test-agent-utils/pre_install.sh", coder_script.pre_install_script[0].script))
+    error_message = "pre_install script must write to the utils directory"
+  }
+
+  assert {
+    condition     = can(regex("base64 -d > .test-module/test-agent-utils/install.sh", coder_script.install_script.script))
+    error_message = "install script must write to the utils directory"
+  }
+
+  assert {
+    condition     = can(regex("base64 -d > .test-module/test-agent-utils/post_install.sh", coder_script.post_install_script[0].script))
+    error_message = "post_install script must write to the utils directory"
+  }
+
+  assert {
+    condition     = can(regex("base64 -d > .test-module/test-agent-utils/start.sh", coder_script.start_script[0].script))
+    error_message = "start script must write to the utils directory"
+  }
+
+  # Every script executes from the utils directory.
+  assert {
+    condition     = can(regex(".test-module/test-agent-utils/pre_install.sh 2>&1", coder_script.pre_install_script[0].script))
+    error_message = "pre_install script must execute from the utils directory"
+  }
+
+  assert {
+    condition     = can(regex(".test-module/test-agent-utils/install.sh 2>&1", coder_script.install_script.script))
+    error_message = "install script must execute from the utils directory"
+  }
+
+  assert {
+    condition     = can(regex(".test-module/test-agent-utils/post_install.sh 2>&1", coder_script.post_install_script[0].script))
+    error_message = "post_install script must execute from the utils directory"
+  }
+
+  assert {
+    condition     = can(regex(".test-module/test-agent-utils/start.sh 2>&1", coder_script.start_script[0].script))
+    error_message = "start script must execute from the utils directory"
+  }
+}
+
+# The utils directory name includes agent_name so multiple modules sharing
+# the same module_directory do not collide.
+run "test_utils_directory_uses_agent_name" {
+  command = plan
+
+  variables {
+    agent_id         = "test-agent-id"
+    agent_name       = "custom-name"
+    module_directory = ".test-module"
+    install_script   = "echo install"
+  }
+
+  assert {
+    condition     = can(regex("mkdir -p .test-module/custom-name-utils", coder_script.install_script.script))
+    error_message = "utils directory must include agent_name"
+  }
+
+  assert {
+    condition     = can(regex("base64 -d > .test-module/custom-name-utils/install.sh", coder_script.install_script.script))
+    error_message = "install script must be written under agent-name-specific utils directory"
+  }
+}


### PR DESCRIPTION
## Description

Moves lifecycle scripts from `${module_directory}/` into `${module_directory}/${agent_name}-utils/` so multiple modules sharing the same base directory no longer collide on script filenames.

## Type of Change

- [x] Feature/enhancement

## Module Information

**Path:** `registry/coder/modules/coder-utils`
**Breaking change:** [x] Yes (script paths change for existing consumers)

## What changed

### `main.tf`
- New `utils_script_path` local: `${var.module_directory}/${var.agent_name}-utils`.
- `pre_install_path`, `install_path`, `post_install_path`, `start_path` now nest under `utils_script_path`.
- `mkdir -p` in pre_install and install wrappers updated to create the utils directory (previously only created `module_directory`, which would leave the new intermediate directory missing at runtime).

### `main.tftest.hcl`
- `test_scripts_nested_under_utils_directory`: verifies mkdir, base64 write targets, and execution paths all reference the `${agent_name}-utils/` subdirectory for all four script types.
- `test_utils_directory_uses_agent_name`: verifies a custom `agent_name` produces a distinct utils directory, preventing collisions.

## Testing & Validation

- [x] Tests pass (`terraform test`: 17 passed, 0 failed)
- [x] Tests pass (`bun test`: 5 passed, 0 failed)
- [x] Changes tested locally

## Related Issues

Closes #873

🤖 Generated with [Coder Agents](https://coder.com)