### PR TITLE
fix(registry/coder-labs/modules/codex): align variable names with claude-code v5

### DIFF
--- a/registry/coder-labs/modules/codex/README.md
+++ b/registry/coder-labs/modules/codex/README.md
@@ -101,7 +101,7 @@ module "codex" {
     preferred_auth_method = "apikey"
   EOT
 
-  additional_mcp_servers = <<-EOT
+  mcp = <<-EOT
     [mcp_servers.GitHub]
     command = "npx"
     args = ["-y", "@modelcontextprotocol/server-github"]

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -246,7 +246,7 @@ describe("codex", async () => {
     ].join("\n");
     const { id, scripts } = await setup({
       moduleVariables: {
-        additional_mcp_servers: additional,
+        mcp: additional,
       },
     });
     await runScripts(id, scripts);

--- a/registry/coder-labs/modules/codex/main.tf
+++ b/registry/coder-labs/modules/codex/main.tf
@@ -50,8 +50,8 @@ variable "install_codex" {
 
 variable "codex_version" {
   type        = string
-  description = "The version of Codex to install. Empty string installs the latest available version."
-  default     = ""
+  description = "The version of Codex to install."
+  default     = "latest"
 }
 
 variable "openai_api_key" {
@@ -75,16 +75,16 @@ variable "base_config_toml" {
       trust_level = "trusted"
 
     When non-empty, the value is written verbatim as the base of config.toml;
-    additional_mcp_servers and AI Gateway sections are still appended after it.
+    mcp and AI Gateway sections are still appended after it.
     Note: model_reasoning_effort and workdir trust are only applied in the
     default config. Include them in your custom config if needed.
   EOT
   default     = ""
 }
 
-variable "additional_mcp_servers" {
+variable "mcp" {
   type        = string
-  description = "Additional MCP servers configuration in TOML format."
+  description = "MCP server configurations in TOML format. When set, servers are appended to the Codex config.toml."
   default     = ""
 }
 
@@ -140,7 +140,7 @@ locals {
     ARG_CODEX_VERSION          = var.codex_version != "" ? base64encode(var.codex_version) : ""
     ARG_WORKDIR                = local.workdir != "" ? base64encode(local.workdir) : ""
     ARG_BASE_CONFIG_TOML       = var.base_config_toml != "" ? base64encode(var.base_config_toml) : ""
-    ARG_ADDITIONAL_MCP_SERVERS = var.additional_mcp_servers != "" ? base64encode(var.additional_mcp_servers) : ""
+    ARG_MCP                    = var.mcp != "" ? base64encode(var.mcp) : ""
     ARG_ENABLE_AI_GATEWAY      = tostring(var.enable_ai_gateway)
     ARG_AIBRIDGE_CONFIG        = var.enable_ai_gateway ? base64encode(local.aibridge_config) : ""
     ARG_MODEL_REASONING_EFFORT = var.model_reasoning_effort

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -12,7 +12,7 @@ ARG_INSTALL='${ARG_INSTALL}'
 ARG_CODEX_VERSION=$(echo -n '${ARG_CODEX_VERSION}' | base64 -d)
 ARG_WORKDIR=$(echo -n '${ARG_WORKDIR}' | base64 -d)
 ARG_BASE_CONFIG_TOML=$(echo -n '${ARG_BASE_CONFIG_TOML}' | base64 -d)
-ARG_ADDITIONAL_MCP_SERVERS=$(echo -n '${ARG_ADDITIONAL_MCP_SERVERS}' | base64 -d)
+ARG_MCP=$(echo -n '${ARG_MCP}' | base64 -d)
 ARG_ENABLE_AI_GATEWAY='${ARG_ENABLE_AI_GATEWAY}'
 ARG_AIBRIDGE_CONFIG=$(echo -n '${ARG_AIBRIDGE_CONFIG}' | base64 -d)
 ARG_MODEL_REASONING_EFFORT='${ARG_MODEL_REASONING_EFFORT}'
@@ -150,9 +150,9 @@ function populate_config_toml() {
     write_minimal_default_config "$${config_path}"
   fi
 
-  if [ -n "$${ARG_ADDITIONAL_MCP_SERVERS}" ]; then
-    printf "Adding additional MCP servers\n"
-    echo "$${ARG_ADDITIONAL_MCP_SERVERS}" >> "$${config_path}"
+  if [ -n "$${ARG_MCP}" ]; then
+    printf "Adding MCP servers\n"
+    echo "$${ARG_MCP}" >> "$${config_path}"
   fi
 
   if [ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ] && [ -n "$${ARG_AIBRIDGE_CONFIG}" ]; then


### PR DESCRIPTION
Aligns codex module variable names with the claude-code v5 conventions established in #861 and #879.

- Rename `additional_mcp_servers` to `mcp` to match claude-code's variable name.
- Change `codex_version` default from `""` to `"latest"` to match `claude_code_version`.

## Type of Change

- [ ] New module
- [ ] New template
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder-labs/modules/codex`
**Breaking change:** [x] Yes [ ] No

> [!WARNING]
> Breaking change for anyone referencing `additional_mcp_servers` by name. Since v5.0.0 was released and deleted on the same day (#879), this should have zero downstream impact.

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun fmt`)
- [x] Changes tested locally

## Related Issues

- Follow-up to #879
- Filed #886 to track adding `mcp_config_remote_path` support to codex

---
*This PR was authored by Coder Agents.*