### PR TITLE
refactor(vault-cli): use default = null instead of default = "" for vault_token

### DIFF
--- a/registry/coder/modules/vault-cli/README.md
+++ b/registry/coder/modules/vault-cli/README.md
@@ -13,7 +13,7 @@ Installs the [Vault](https://www.vaultproject.io/) CLI and optionally configures
 ```tf
 module "vault_cli" {
   source     = "registry.coder.com/coder/vault-cli/coder"
-  version = "1.1.2"
+  version    = "1.1.2"
   agent_id   = coder_agent.example.id
   vault_addr = "https://vault.example.com"
 }
@@ -34,7 +34,7 @@ If you have a Vault token, you can provide it to automatically configure authent
 ```tf
 module "vault_cli" {
   source      = "registry.coder.com/coder/vault-cli/coder"
-  version = "1.1.2"
+  version     = "1.1.2"
   agent_id    = coder_agent.example.id
   vault_addr  = "https://vault.example.com"
   vault_token = var.vault_token # Optional
@@ -50,7 +50,7 @@ Install the Vault CLI without any authentication:
 ```tf
 module "vault_cli" {
   source     = "registry.coder.com/coder/vault-cli/coder"
-  version = "1.1.2"
+  version    = "1.1.2"
   agent_id   = coder_agent.example.id
   vault_addr = "https://vault.example.com"
 }
@@ -61,7 +61,7 @@ module "vault_cli" {
 ```tf
 module "vault_cli" {
   source            = "registry.coder.com/coder/vault-cli/coder"
-  version = "1.1.2"
+  version           = "1.1.2"
   agent_id          = coder_agent.example.id
   vault_addr        = "https://vault.example.com"
   vault_cli_version = "1.15.0"
@@ -73,7 +73,7 @@ module "vault_cli" {
 ```tf
 module "vault_cli" {
   source      = "registry.coder.com/coder/vault-cli/coder"
-  version = "1.1.2"
+  version     = "1.1.2"
   agent_id    = coder_agent.example.id
   vault_addr  = "https://vault.example.com"
   install_dir = "/home/coder/bin"
@@ -87,7 +87,7 @@ For Vault Enterprise users who need to specify a namespace:
 ```tf
 module "vault_cli" {
   source          = "registry.coder.com/coder/vault-cli/coder"
-  version = "1.1.2"
+  version         = "1.1.2"
   agent_id        = coder_agent.example.id
   vault_addr      = "https://vault.example.com"
   vault_token     = var.vault_token
@@ -102,7 +102,7 @@ Install the Vault Enterprise binary. This is required if using SAML authenticati
 ```tf
 module "vault_cli" {
   source     = "registry.coder.com/coder/vault-cli/coder"
-  version = "1.1.2"
+  version    = "1.1.2"
   agent_id   = coder_agent.example.id
   vault_addr = "https://vault.example.com"
   enterprise = true

--- a/registry/coder/modules/vault-cli/README.md
+++ b/registry/coder/modules/vault-cli/README.md
@@ -13,7 +13,7 @@ Installs the [Vault](https://www.vaultproject.io/) CLI and optionally configures
 ```tf
 module "vault_cli" {
   source     = "registry.coder.com/coder/vault-cli/coder"
-  version    = "1.1.1"
+  version = "1.1.2"
   agent_id   = coder_agent.example.id
   vault_addr = "https://vault.example.com"
 }
@@ -34,7 +34,7 @@ If you have a Vault token, you can provide it to automatically configure authent
 ```tf
 module "vault_cli" {
   source      = "registry.coder.com/coder/vault-cli/coder"
-  version     = "1.1.1"
+  version = "1.1.2"
   agent_id    = coder_agent.example.id
   vault_addr  = "https://vault.example.com"
   vault_token = var.vault_token # Optional
@@ -50,7 +50,7 @@ Install the Vault CLI without any authentication:
 ```tf
 module "vault_cli" {
   source     = "registry.coder.com/coder/vault-cli/coder"
-  version    = "1.1.1"
+  version = "1.1.2"
   agent_id   = coder_agent.example.id
   vault_addr = "https://vault.example.com"
 }
@@ -61,7 +61,7 @@ module "vault_cli" {
 ```tf
 module "vault_cli" {
   source            = "registry.coder.com/coder/vault-cli/coder"
-  version           = "1.1.1"
+  version = "1.1.2"
   agent_id          = coder_agent.example.id
   vault_addr        = "https://vault.example.com"
   vault_cli_version = "1.15.0"
@@ -73,7 +73,7 @@ module "vault_cli" {
 ```tf
 module "vault_cli" {
   source      = "registry.coder.com/coder/vault-cli/coder"
-  version     = "1.1.1"
+  version = "1.1.2"
   agent_id    = coder_agent.example.id
   vault_addr  = "https://vault.example.com"
   install_dir = "/home/coder/bin"
@@ -87,7 +87,7 @@ For Vault Enterprise users who need to specify a namespace:
 ```tf
 module "vault_cli" {
   source          = "registry.coder.com/coder/vault-cli/coder"
-  version         = "1.1.1"
+  version = "1.1.2"
   agent_id        = coder_agent.example.id
   vault_addr      = "https://vault.example.com"
   vault_token     = var.vault_token
@@ -102,7 +102,7 @@ Install the Vault Enterprise binary. This is required if using SAML authenticati
 ```tf
 module "vault_cli" {
   source     = "registry.coder.com/coder/vault-cli/coder"
-  version    = "1.1.1"
+  version = "1.1.2"
   agent_id   = coder_agent.example.id
   vault_addr = "https://vault.example.com"
   enterprise = true

--- a/registry/coder/modules/vault-cli/main.tf
+++ b/registry/coder/modules/vault-cli/main.tf
@@ -22,7 +22,7 @@ variable "vault_addr" {
 variable "vault_token" {
   type        = string
   description = "The Vault token to use for authentication. If not provided, only the CLI will be installed."
-  default     = ""
+  default     = null
   sensitive   = true
 }
 
@@ -62,7 +62,7 @@ resource "coder_script" "vault_cli" {
   icon         = "/icon/vault.svg"
   script = templatefile("${path.module}/run.sh", {
     VAULT_ADDR        = var.vault_addr
-    VAULT_TOKEN       = var.vault_token
+    VAULT_TOKEN       = var.vault_token != null ? var.vault_token : ""
     INSTALL_DIR       = var.install_dir
     VAULT_CLI_VERSION = var.vault_cli_version
     ENTERPRISE        = var.enterprise
@@ -78,7 +78,7 @@ resource "coder_env" "vault_addr" {
 }
 
 resource "coder_env" "vault_token" {
-  count    = var.vault_token != "" ? 1 : 0
+  count    = var.vault_token != null ? 1 : 0
   agent_id = var.agent_id
   name     = "VAULT_TOKEN"
   value    = var.vault_token


### PR DESCRIPTION
## Summary

Replace `default = ""` with `default = null` for the `vault_token` variable in the vault-cli module, addressing part of #755.

Using `null` instead of `""` is better Terraform practice — it semantically means "not provided" rather than "provided but empty". This also aligns `vault_token` with the existing `vault_namespace` variable in the same module, which already uses `default = null`.

## Changes

- `vault_token` default: `""` → `null`
- `templatefile` call: added null guard (`var.vault_token != null ? var.vault_token : ""`) to safely pass to shell template
- `coder_env.vault_token` count: changed condition from `!= ""` to `!= null`

## Testing

All 10 existing Terraform tests pass without modification:

```
$ terraform test -verbose
  run "test_vault_cli_without_token"... pass
  run "test_vault_cli_with_token"... pass
  run "test_vault_cli_custom_version"... pass
  run "test_vault_cli_custom_install_dir"... pass
  run "test_vault_cli_invalid_version"... pass
  run "test_vault_cli_valid_semver"... pass
  run "test_vault_cli_rejects_v_prefix"... pass
  run "test_vault_cli_with_namespace"... pass
  run "test_vault_cli_with_token_and_namespace"... pass
  run "test_vault_cli_enterprise"... pass

Success! 10 passed, 0 failed.
```

## Notes

This is a scoped first step toward #755. If the approach is acceptable, I'm happy to submit follow-up PRs for other modules.