### PR TITLE
fix(git-clone): propagate pre/post-clone script failures

### DIFF
--- a/registry/coder/modules/git-clone/README.md
+++ b/registry/coder/modules/git-clone/README.md
@@ -14,7 +14,7 @@ This module allows you to automatically clone a repository by URL and skip if it
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "1.3.0"
+  version  = "1.3.1"
   agent_id = coder_agent.example.id
   url      = "https://github.com/coder/coder"
 }
@@ -28,7 +28,7 @@ module "git-clone" {
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "1.3.0"
+  version  = "1.3.1"
   agent_id = coder_agent.example.id
   url      = "https://github.com/coder/coder"
   base_dir = "~/projects/coder"
@@ -43,7 +43,7 @@ To use with [Git Authentication](https://coder.com/docs/v2/latest/admin/git-prov
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "1.3.0"
+  version  = "1.3.1"
   agent_id = coder_agent.example.id
   url      = "https://github.com/coder/coder"
 }
@@ -70,7 +70,7 @@ data "coder_parameter" "git_repo" {
 module "git_clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "1.3.0"
+  version  = "1.3.1"
   agent_id = coder_agent.example.id
   url      = data.coder_parameter.git_repo.value
 }
@@ -105,7 +105,7 @@ Configuring `git-clone` for a self-hosted GitHub Enterprise Server running at `g
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "1.3.0"
+  version  = "1.3.1"
   agent_id = coder_agent.example.id
   url      = "https://github.example.com/coder/coder/tree/feat/example"
   git_providers = {
@@ -125,7 +125,7 @@ To GitLab clone with a specific branch like `feat/example`
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "1.3.0"
+  version  = "1.3.1"
   agent_id = coder_agent.example.id
   url      = "https://gitlab.com/coder/coder/-/tree/feat/example"
 }
@@ -137,7 +137,7 @@ Configuring `git-clone` for a self-hosted GitLab running at `gitlab.example.com`
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "1.3.0"
+  version  = "1.3.1"
   agent_id = coder_agent.example.id
   url      = "https://gitlab.example.com/coder/coder/-/tree/feat/example"
   git_providers = {
@@ -159,7 +159,7 @@ For example, to clone the `feat/example` branch:
 module "git-clone" {
   count       = data.coder_workspace.me.start_count
   source      = "registry.coder.com/coder/git-clone/coder"
-  version     = "1.3.0"
+  version     = "1.3.1"
   agent_id    = coder_agent.example.id
   url         = "https://github.com/coder/coder"
   branch_name = "feat/example"
@@ -177,7 +177,7 @@ For example, this will clone into the `~/projects/coder/coder-dev` folder:
 module "git-clone" {
   count       = data.coder_workspace.me.start_count
   source      = "registry.coder.com/coder/git-clone/coder"
-  version     = "1.3.0"
+  version     = "1.3.1"
   agent_id    = coder_agent.example.id
   url         = "https://github.com/coder/coder"
   folder_name = "coder-dev"
@@ -196,7 +196,7 @@ If not defined, the default, `0`, performs a full clone.
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "1.3.0"
+  version  = "1.3.1"
   agent_id = coder_agent.example.id
   url      = "https://github.com/coder/coder"
   depth    = 1
@@ -212,7 +212,7 @@ This is useful for preparing the environment or validating prerequisites before 
 module "git-clone" {
   count            = data.coder_workspace.me.start_count
   source           = "registry.coder.com/coder/git-clone/coder"
-  version          = "1.3.0"
+  version          = "1.3.1"
   agent_id         = coder_agent.example.id
   url              = "https://github.com/coder/coder"
   pre_clone_script = <<-EOT
@@ -235,7 +235,7 @@ This is useful for running initialization tasks like installing dependencies or 
 module "git-clone" {
   count             = data.coder_workspace.me.start_count
   source            = "registry.coder.com/coder/git-clone/coder"
-  version           = "1.3.0"
+  version           = "1.3.1"
   agent_id          = coder_agent.example.id
   url               = "https://github.com/coder/coder"
   post_clone_script = <<-EOT

--- a/registry/coder/modules/git-clone/main.test.ts
+++ b/registry/coder/modules/git-clone/main.test.ts
@@ -250,13 +250,14 @@ describe("git-clone", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
       url: "fake-url",
+      base_dir: "/tmp",
       post_clone_script: "echo 'Post-clone script executed'",
     });
     const output = await executeScriptInContainer(
       state,
       "alpine/git",
       "sh",
-      "mkdir -p ~/fake-url && echo 'existing' > ~/fake-url/file.txt",
+      "mkdir -p /tmp/fake-url && echo 'existing' > /tmp/fake-url/file.txt",
     );
     expect(output.stdout).toContain("Running post-clone script...");
     expect(output.stdout).toContain("Post-clone script executed");
@@ -272,5 +273,36 @@ describe("git-clone", async () => {
     expect(output.stdout).toContain("Running pre-clone script...");
     expect(output.stdout).toContain("Pre-clone script executed");
     expect(output.stdout).toContain("Cloning fake-url to ~/fake-url...");
+  });
+
+  it("fails when pre-clone script fails", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      url: "fake-url",
+      pre_clone_script: "echo 'Pre-clone script failed'; exit 42",
+    });
+    const output = await executeScriptInContainer(state, "alpine/git");
+    expect(output.exitCode).toBe(42);
+    expect(output.stdout).toContain("Running pre-clone script...");
+    expect(output.stdout).toContain("Pre-clone script failed");
+    expect(output.stdout).not.toContain("Cloning fake-url to ~/fake-url...");
+  });
+
+  it("fails when post-clone script fails", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      url: "fake-url",
+      base_dir: "/tmp",
+      post_clone_script: "echo 'Post-clone script failed'; exit 43",
+    });
+    const output = await executeScriptInContainer(
+      state,
+      "alpine/git",
+      "sh",
+      "mkdir -p /tmp/fake-url && echo 'existing' > /tmp/fake-url/file.txt",
+    );
+    expect(output.exitCode).toBe(43);
+    expect(output.stdout).toContain("Running post-clone script...");
+    expect(output.stdout).toContain("Post-clone script failed");
   });
 });

--- a/registry/coder/modules/git-clone/run.sh
+++ b/registry/coder/modules/git-clone/run.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 REPO_URL="${REPO_URL}"
 CLONE_PATH="${CLONE_PATH}"
 BRANCH_NAME="${BRANCH_NAME}"


### PR DESCRIPTION
## Description

Fix git-clone module to fail fast when `pre_clone_script` or `post_clone_script` returns a non-zero exit code. Previously, both scripts were executed but their exit codes were never checked — a failing pre-clone hook (e.g., a prerequisite check that calls `exit 1`) was silently ignored and cloning continued. This broke the advertised "validate prerequisites before cloning" behavior and could leave workspaces starting with unmet preconditions.

## Type of Change

- [ ] New module
- [ ] New template
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder/modules/git-clone`  
**New version:** `v1.3.1`  
**Breaking change:** [ ] Yes [x] No

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun fmt`)
- [x] Changes tested locally

## Related Issues

- https://github.com/coder/registry/pull/887#issuecomment-4413765491
- https://github.com/coder/registry/issues/60
- https://github.com/coder/registry/issues/86
