### PR TITLE
fix(coder-labs/modules/codex): prevent config.toml overwrite on restart

### DIFF
--- a/registry/coder-labs/modules/codex/README.md
+++ b/registry/coder-labs/modules/codex/README.md
@@ -143,7 +143,26 @@ resource "coder_script" "post_codex" {
 When no custom `base_config_toml` is provided, the module uses a minimal default with `preferred_auth_method = "apikey"`. For advanced options, see [Codex config docs](https://developers.openai.com/codex/config-advanced).
 
 > [!NOTE]
-> Content you add outside the managed block is preserved across workspace restarts. `[section]` headers you place below `# <<< coder-managed: codex module <<<` must not duplicate a table name already defined inside the managed block. Duplicate table definitions are invalid per the TOML spec and will cause Codex to reject the config.
+> Content you add outside the managed block is preserved across workspace restarts. The module structures the file as:
+>
+> ```toml
+> # bare keys you add above the managed block (root scope)
+> my_flag = true
+>
+> # >>> coder-managed: codex module >>>
+> preferred_auth_method = "apikey"
+> # ... module-managed content ...
+> # <<< coder-managed: codex module <<<
+>
+> # [sections] you add below the managed block
+> [mcp_servers.my_tool]
+> command = "my-tool"
+> ```
+>
+> Two constraints to keep the TOML valid:
+>
+> - Bare keys you place **above** the managed block must not duplicate keys already inside it (duplicate keys are a TOML error).
+> - `[section]` headers you place **below** the managed block must not duplicate a table name already defined inside it (same reason). Bare keys placed after the managed block will fall under whatever `[section]` preceded them — place bare keys above the block to keep them at root scope.
 
 ## Troubleshooting
 

--- a/registry/coder-labs/modules/codex/README.md
+++ b/registry/coder-labs/modules/codex/README.md
@@ -142,6 +142,9 @@ resource "coder_script" "post_codex" {
 
 When no custom `base_config_toml` is provided, the module uses a minimal default with `preferred_auth_method = "apikey"`. For advanced options, see [Codex config docs](https://developers.openai.com/codex/config-advanced).
 
+> [!NOTE]
+> Content you add outside the managed block is preserved across workspace restarts. `[section]` headers you place below `# <<< coder-managed: codex module <<<` must not duplicate a table name already defined inside the managed block. Duplicate table definitions are invalid per the TOML spec and will cause Codex to reject the config.
+
 ## Troubleshooting
 
 Check the log files in `~/.coder-modules/coder-labs/codex/logs/` for detailed information.

--- a/registry/coder-labs/modules/codex/README.md
+++ b/registry/coder-labs/modules/codex/README.md
@@ -13,7 +13,7 @@ Install and configure the [Codex CLI](https://github.com/openai/codex) in your w
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.1.1"
+  version        = "5.2.0"
   agent_id       = coder_agent.main.id
   openai_api_key = var.openai_api_key
 }
@@ -33,7 +33,7 @@ locals {
 
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.1.1"
+  version        = "5.2.0"
   agent_id       = coder_agent.main.id
   workdir        = local.codex_workdir
   openai_api_key = var.openai_api_key
@@ -64,7 +64,7 @@ resource "coder_app" "codex" {
 ```tf
 module "codex" {
   source            = "registry.coder.com/coder-labs/codex/coder"
-  version           = "5.1.1"
+  version           = "5.2.0"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   enable_ai_gateway = true
@@ -88,7 +88,7 @@ When `enable_ai_gateway = true`, the module configures Codex to use the `aigatew
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.1.1"
+  version        = "5.2.0"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   openai_api_key = var.openai_api_key
@@ -117,7 +117,7 @@ The module exposes the `scripts` output: an ordered list of `coder exp sync` nam
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.1.1"
+  version        = "5.2.0"
   agent_id       = coder_agent.main.id
   openai_api_key = var.openai_api_key
 }

--- a/registry/coder-labs/modules/codex/README.md
+++ b/registry/coder-labs/modules/codex/README.md
@@ -13,7 +13,7 @@ Install and configure the [Codex CLI](https://github.com/openai/codex) in your w
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.0.0"
+  version        = "5.0.1"
   agent_id       = coder_agent.main.id
   openai_api_key = var.openai_api_key
 }
@@ -33,7 +33,7 @@ locals {
 
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.0.0"
+  version        = "5.0.1"
   agent_id       = coder_agent.main.id
   workdir        = local.codex_workdir
   openai_api_key = var.openai_api_key
@@ -64,7 +64,7 @@ resource "coder_app" "codex" {
 ```tf
 module "codex" {
   source            = "registry.coder.com/coder-labs/codex/coder"
-  version           = "5.0.0"
+  version           = "5.0.1"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   enable_ai_gateway = true
@@ -88,7 +88,7 @@ When `enable_ai_gateway = true`, the module configures Codex to use the `aigatew
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.0.0"
+  version        = "5.0.1"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   openai_api_key = var.openai_api_key
@@ -117,7 +117,7 @@ The module exposes the `scripts` output: an ordered list of `coder exp sync` nam
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.0.0"
+  version        = "5.0.1"
   agent_id       = coder_agent.main.id
   openai_api_key = var.openai_api_key
 }

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -425,6 +425,309 @@ describe("codex", async () => {
     expect(installLog).toContain("Installed Codex CLI");
   });
 
+  test("idempotent-defaults-preserve-user-edits", async () => {
+    const { id, scripts } = await setup();
+    await runScripts(id, scripts);
+
+    // User edits the config between restarts
+    await execContainer(id, [
+      "bash",
+      "-c",
+      `cat > /home/coder/.codex/config.toml << 'EOF'
+preferred_auth_method = "login"
+custom_user_key = "my_value"
+
+[projects."/home/coder/project"]
+trust_level = "trusted"
+EOF`,
+    ]);
+
+    // Second run: user edits must survive
+    await runScripts(id, scripts);
+    const config = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    // User's overridden value preserved (not reset to "apikey")
+    expect(config).toMatch(/preferred_auth_method\s*=\s*['"]login['"]/);
+    // User's custom key preserved
+    expect(config).toMatch(/custom_user_key\s*=\s*['"]my_value['"]/);
+  });
+
+  test("idempotent-mcp-deep-merge", async () => {
+    const mcpConfig = [
+      "[mcp_servers.github]",
+      'command = "npx"',
+      'args = ["-y", "@modelcontextprotocol/server-github"]',
+      'type = "stdio"',
+      "",
+      "[mcp_servers.filesystem]",
+      'command = "npx"',
+      'args = ["-y", "@modelcontextprotocol/server-filesystem"]',
+      'type = "stdio"',
+    ].join("\n");
+    const { id, scripts } = await setup({
+      moduleVariables: { mcp: mcpConfig },
+    });
+    await runScripts(id, scripts);
+
+    // User customizes the github MCP server between restarts
+    await execContainer(id, [
+      "bash",
+      "-c",
+      [
+        "CONFIG=/home/coder/.codex/config.toml",
+        // Replace the github command the user has customized
+        "sed -i \"s/command = .npx./command = 'my-custom-npx'/\" $CONFIG",
+      ].join(" && "),
+    ]);
+
+    // Second run
+    await runScripts(id, scripts);
+    const config = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    // User's customized github command preserved
+    expect(config).toMatch(/command\s*=\s*['"]my-custom-npx['"]/);
+    // filesystem server still present (not lost by shallow merge)
+    expect(config).toContain("mcp_servers");
+    expect(config).toContain("filesystem");
+  });
+
+  test("idempotent-base-config-preserves-user-edits", async () => {
+    const baseConfig = [
+      'sandbox_mode = "danger-full-access"',
+      'preferred_auth_method = "apikey"',
+    ].join("\n");
+    const { id, scripts } = await setup({
+      moduleVariables: { base_config_toml: baseConfig },
+    });
+    await runScripts(id, scripts);
+
+    // User changes sandbox_mode
+    await execContainer(id, [
+      "bash",
+      "-c",
+      "sed -i 's/danger-full-access/sandbox/' /home/coder/.codex/config.toml",
+    ]);
+
+    // Second run
+    await runScripts(id, scripts);
+    const config = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    // User's change preserved
+    expect(config).toMatch(/sandbox_mode\s*=\s*['"]sandbox['"]/);
+    // Original key from base config still present
+    expect(config).toContain("preferred_auth_method");
+  });
+
+  test("idempotent-run-twice-no-change", async () => {
+    const { id, scripts } = await setup();
+    await runScripts(id, scripts);
+    const configAfterFirst = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+
+    // Second run without any user edits
+    await runScripts(id, scripts);
+    const configAfterSecond = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+
+    // Config should still contain the same keys
+    expect(configAfterSecond).toContain("preferred_auth_method");
+    // The values must match (quotes may change on roundtrip, compare via JSON)
+    const toJson = async (toml: string) => {
+      const resp = await execContainer(id, [
+        "bash",
+        "-c",
+        `echo '${toml.replace(/'/g, "'\\''")}' | dasel -i toml -o json`,
+      ]);
+      return JSON.parse(resp.stdout);
+    };
+    expect(await toJson(configAfterSecond)).toEqual(
+      await toJson(configAfterFirst),
+    );
+  });
+
+  test("idempotent-mcp-new-servers-added-existing-kept", async () => {
+    // First run: one MCP server
+    const mcpRun1 = [
+      "[mcp_servers.github]",
+      'command = "npx"',
+      'args = ["-y", "@modelcontextprotocol/server-github"]',
+      'type = "stdio"',
+    ].join("\n");
+    const { id, scripts } = await setup({
+      moduleVariables: { mcp: mcpRun1 },
+    });
+    await runScripts(id, scripts);
+
+    // User adds their own MCP server manually
+    await execContainer(id, [
+      "bash",
+      "-c",
+      `cat >> /home/coder/.codex/config.toml << 'EOF'
+
+[mcp_servers.custom]
+command = "my-tool"
+args = ["--serve"]
+type = "stdio"
+EOF`,
+    ]);
+
+    // Second run: same module config
+    await runScripts(id, scripts);
+    const config = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    // Module's github server still present
+    expect(config).toContain("github");
+    // User's manually-added custom server preserved
+    expect(config).toMatch(/command\s*=\s*['"]my-tool['"]/);
+  });
+
+  test("idempotent-ai-gateway-preserves-user-provider", async () => {
+    const { id, coderEnvVars, scripts } = await setup({
+      moduleVariables: {
+        enable_ai_gateway: "true",
+      },
+    });
+    await runScripts(id, scripts, coderEnvVars);
+
+    // User changes model_provider
+    await execContainer(id, [
+      "bash",
+      "-c",
+      "sed -i 's/model_provider = .*/model_provider = \"custom_provider\"/' /home/coder/.codex/config.toml",
+    ]);
+
+    // Second run
+    await runScripts(id, scripts, coderEnvVars);
+    const config = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    // User's custom provider survives
+    expect(config).toMatch(/model_provider\s*=\s*['"]custom_provider['"]/);
+  });
+
+  test("base-config-plus-mcp-combined", async () => {
+    const baseConfig = [
+      'sandbox_mode = "danger-full-access"',
+      'preferred_auth_method = "apikey"',
+    ].join("\n");
+    const mcpConfig = [
+      "[mcp_servers.github]",
+      'command = "npx"',
+      'args = ["-y", "@modelcontextprotocol/server-github"]',
+      'type = "stdio"',
+    ].join("\n");
+    const { id, scripts } = await setup({
+      moduleVariables: {
+        base_config_toml: baseConfig,
+        mcp: mcpConfig,
+      },
+    });
+    await runScripts(id, scripts);
+    const config = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    // Base config keys present
+    expect(config).toContain("sandbox_mode");
+    expect(config).toContain("preferred_auth_method");
+    // MCP server present
+    expect(config).toContain("mcp_servers");
+    expect(config).toContain("github");
+  });
+
+  test("all-config-sources-combined", async () => {
+    const baseConfig = [
+      'sandbox_mode = "danger-full-access"',
+      'preferred_auth_method = "apikey"',
+    ].join("\n");
+    const mcpConfig = [
+      "[mcp_servers.github]",
+      'command = "npx"',
+      'args = ["-y", "@modelcontextprotocol/server-github"]',
+      'type = "stdio"',
+    ].join("\n");
+    const { id, coderEnvVars, scripts } = await setup({
+      moduleVariables: {
+        enable_ai_gateway: "true",
+        base_config_toml: baseConfig,
+        mcp: mcpConfig,
+      },
+    });
+    await runScripts(id, scripts, coderEnvVars);
+    const config = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    // Base config
+    expect(config).toContain("sandbox_mode");
+    expect(config).toContain("preferred_auth_method");
+    // MCP
+    expect(config).toContain("github");
+    // AI gateway
+    expect(config).toContain("model_providers");
+  });
+
+  test("idempotent-all-sources-user-edits-survive", async () => {
+    const baseConfig = [
+      'sandbox_mode = "danger-full-access"',
+      'preferred_auth_method = "apikey"',
+    ].join("\n");
+    const mcpConfig = [
+      "[mcp_servers.github]",
+      'command = "npx"',
+      'args = ["-y", "@modelcontextprotocol/server-github"]',
+      'type = "stdio"',
+    ].join("\n");
+    const { id, coderEnvVars, scripts } = await setup({
+      moduleVariables: {
+        enable_ai_gateway: "true",
+        base_config_toml: baseConfig,
+        mcp: mcpConfig,
+      },
+    });
+    await runScripts(id, scripts, coderEnvVars);
+
+    // User edits multiple things
+    await execContainer(id, [
+      "bash",
+      "-c",
+      [
+        "CONFIG=/home/coder/.codex/config.toml",
+        // Change auth method
+        "sed -i \"s/preferred_auth_method.*/preferred_auth_method = 'oauth'/\" $CONFIG",
+        // Add a custom top-level key
+        "echo 'user_note = \"do not touch\"' >> $CONFIG",
+      ].join(" && "),
+    ]);
+
+    // Second run
+    await runScripts(id, scripts, coderEnvVars);
+    const config = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    // User edits survived
+    expect(config).toMatch(/preferred_auth_method\s*=\s*['"]oauth['"]/);
+    expect(config).toContain("user_note");
+    // Module config still present
+    expect(config).toContain("sandbox_mode");
+    expect(config).toContain("github");
+    expect(config).toContain("model_providers");
+  });
+
   test("custom-config-drops-reasoning-effort", async () => {
     const baseConfig = [
       'sandbox_mode = "danger-full-access"',

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -527,26 +527,26 @@ EOF`,
   test("idempotent-run-twice-no-change", async () => {
     const { id, scripts } = await setup();
 
-    // Convert the container config file to JSON for comparison
-    const configToJson = async () => {
-      const resp = await execContainer(id, [
-        "bash",
-        "-c",
-        "dasel -i toml -o json < /home/coder/.codex/config.toml",
-      ]);
-      return JSON.parse(resp.stdout);
-    };
-
     // First run
     await runScripts(id, scripts);
-    const jsonAfterFirst = await configToJson();
 
-    // Second run without any user edits
+    // Second run triggers a dasel roundtrip (quotes may change)
     await runScripts(id, scripts);
-    const jsonAfterSecond = await configToJson();
+    const configAfterSecond = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
 
-    // Data must be identical (quotes may differ, so compare JSON not strings)
-    expect(jsonAfterSecond).toEqual(jsonAfterFirst);
+    // Third run: if idempotent, output must be identical to second run
+    await runScripts(id, scripts);
+    const configAfterThird = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+
+    // After the first roundtrip the serialization is stable, so a byte
+    // comparison is valid from the second run onward.
+    expect(configAfterThird).toEqual(configAfterSecond);
   });
 
   test("idempotent-mcp-new-servers-added-existing-kept", async () => {

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -541,6 +541,10 @@ EOF`,
     // User section preserved
     expect(config).toContain("[mcp_servers.user_tool]");
     expect(config).toMatch(/command\s*=\s*"my-tool"/);
+    // User section must appear after the managed block, not inside or before it.
+    const endIdx = config.indexOf(MANAGED_END);
+    const sectionIdx = config.indexOf("[mcp_servers.user_tool]");
+    expect(sectionIdx).toBeGreaterThan(endIdx);
   });
 
   test("idempotent-user-bare-keys-stay-at-root-scope", async () => {
@@ -746,6 +750,14 @@ EOF`,
     // Legacy section preserved after managed block
     const endIdx = config.indexOf(MANAGED_END);
     expect(config.indexOf("[mcp_servers.legacy]")).toBeGreaterThan(endIdx);
+
+    // Second run: the migrated file must be stable (no double-hoisting, no duplicate markers).
+    await runScripts(id, scripts);
+    const configAfterSecond = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    expect(configAfterSecond).toEqual(config);
   });
 
   test("idempotent-all-sources-user-content-survives", async () => {

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -551,14 +551,13 @@ EOF`,
     const { id, scripts } = await setup();
     await runScripts(id, scripts);
 
-    // User adds bare keys AND a section after the managed block.
+    // User prepends bare keys before the managed block and appends a section after it.
     await execContainer(id, [
       "bash",
       "-c",
-      `cat >> /home/coder/.codex/config.toml << 'EOF'
-
-my_custom_key = "hello"
-sandbox_mode = "full"
+      `config=/home/coder/.codex/config.toml
+{ printf 'my_custom_key = "hello"\\nsandbox_mode = "full"\\n\\n'; cat "$config"; } > /tmp/codex_c.toml && mv /tmp/codex_c.toml "$config"
+cat >> "$config" << 'EOF'
 
 [mcp_servers.user_tool]
 command = "my-tool"
@@ -572,8 +571,7 @@ EOF`,
       "/home/coder/.codex/config.toml",
     );
 
-    // User bare keys must appear BEFORE the managed block start marker
-    // so they remain at TOML root scope.
+    // Bare keys placed before the managed block must remain before MANAGED_START.
     const startIdx = config.indexOf(MANAGED_START);
     const customKeyIdx = config.indexOf('my_custom_key = "hello"');
     const sandboxIdx = config.indexOf('sandbox_mode = "full"');
@@ -582,7 +580,7 @@ EOF`,
     expect(customKeyIdx).toBeLessThan(startIdx);
     expect(sandboxIdx).toBeLessThan(startIdx);
 
-    // User section preserved after managed block
+    // Section appended after the managed block must remain after MANAGED_END.
     const endIdx = config.indexOf(MANAGED_END);
     const sectionIdx = config.indexOf("[mcp_servers.user_tool]");
     expect(sectionIdx).toBeGreaterThan(endIdx);
@@ -648,7 +646,7 @@ EOF`,
       id,
       "/home/coder/.codex/config.toml",
     );
-    // Bare-key comment hoisted above managed block
+    // Bare-key comment preserved in output
     expect(config).toContain("# My personal top-level setting");
     // Section comments preserved below managed block
     expect(config).toContain("# My personal MCP server");

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -346,9 +346,7 @@ describe("codex", async () => {
       id,
       "/home/coder/.codex/config.toml",
     );
-    expect(configToml).toMatch(
-      new RegExp(`projects.*${workdir.replace(/\//g, "\\/")}.*`),
-    );
+    expect(configToml).toMatch(new RegExp(`\\[projects\\..*${workdir}.*\\]`));
     expect(configToml).toMatch(/trust_level\s*=\s*['"]trusted['"]/);
   });
 
@@ -473,14 +471,14 @@ EOF`,
     });
     await runScripts(id, scripts);
 
-    // User customizes the github MCP server between restarts
+    // User customizes ONLY the github MCP server between restarts
     await execContainer(id, [
       "bash",
       "-c",
       [
         "CONFIG=/home/coder/.codex/config.toml",
-        // Replace the github command the user has customized
-        "sed -i \"s/command = .npx./command = 'my-custom-npx'/\" $CONFIG",
+        // Use sed address range to only replace command under github section
+        "sed -i '/github/,/^$/{ s/command = .*/command = '\"'\"'my-custom-npx'\"'\"'/; }' $CONFIG",
       ].join(" && "),
     ]);
 
@@ -492,9 +490,9 @@ EOF`,
     );
     // User's customized github command preserved
     expect(config).toMatch(/command\s*=\s*['"]my-custom-npx['"]/);
-    // filesystem server still present (not lost by shallow merge)
-    expect(config).toContain("mcp_servers");
+    // filesystem server still present with original command
     expect(config).toContain("filesystem");
+    expect(config).toMatch(/command\s*=\s*['"]npx['"]/);
   });
 
   test("idempotent-base-config-preserves-user-edits", async () => {
@@ -526,7 +524,7 @@ EOF`,
     expect(config).toContain("preferred_auth_method");
   });
 
-  test("idempotent-run-twice-no-change", async () => {
+  test("idempotent-stable-after-roundtrip", async () => {
     const { id, scripts } = await setup();
 
     // First run
@@ -637,11 +635,11 @@ EOF`,
       "/home/coder/.codex/config.toml",
     );
     // Base config keys present
-    expect(config).toContain("sandbox_mode");
-    expect(config).toContain("preferred_auth_method");
+    expect(config).toMatch(/sandbox_mode\s*=\s*['"]danger-full-access['"]/);
+    expect(config).toMatch(/preferred_auth_method\s*=\s*['"]apikey['"]/);
     // MCP server present
     expect(config).toContain("mcp_servers");
-    expect(config).toContain("github");
+    expect(config).toMatch(/command\s*=\s*['"]npx['"]/);
   });
 
   test("all-config-sources-combined", async () => {
@@ -668,12 +666,12 @@ EOF`,
       "/home/coder/.codex/config.toml",
     );
     // Base config
-    expect(config).toContain("sandbox_mode");
-    expect(config).toContain("preferred_auth_method");
+    expect(config).toMatch(/sandbox_mode\s*=\s*['"]danger-full-access['"]/);
+    expect(config).toMatch(/preferred_auth_method\s*=\s*['"]apikey['"]/);
     // MCP
-    expect(config).toContain("github");
+    expect(config).toMatch(/command\s*=\s*['"]npx['"]/);
     // AI gateway
-    expect(config).toContain("model_providers");
+    expect(config).toContain("[model_providers.aigateway]");
   });
 
   test("idempotent-all-sources-user-edits-survive", async () => {
@@ -717,11 +715,11 @@ EOF`,
     );
     // User edits survived
     expect(config).toMatch(/preferred_auth_method\s*=\s*['"]oauth['"]/);
-    expect(config).toContain("user_note");
+    expect(config).toMatch(/user_note\s*=\s*['"]do not touch['"]/);
     // Module config still present
-    expect(config).toContain("sandbox_mode");
+    expect(config).toMatch(/sandbox_mode\s*=\s*['"]danger-full-access['"]/);
     expect(config).toContain("github");
-    expect(config).toContain("model_providers");
+    expect(config).toContain("[model_providers.aigateway]");
   });
 
   test("custom-config-drops-reasoning-effort", async () => {

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -711,7 +711,7 @@ EOF`,
     expect(config).toMatch(/command\s*=\s*"my-tool"/);
   });
 
-  test("idempotent-no-markers-overwrites", async () => {
+  test("idempotent-no-markers-preserves-user-config", async () => {
     const { id, scripts } = await setup();
 
     // Simulate a legacy config without markers (pre-upgrade).
@@ -721,22 +721,31 @@ EOF`,
       `mkdir -p /home/coder/.codex && cat > /home/coder/.codex/config.toml << 'EOF'
 preferred_auth_method = "login"
 legacy_key = "old_value"
+
+[mcp_servers.legacy]
+command = "legacy-tool"
+type = "stdio"
 EOF`,
     ]);
 
-    // First run with marker-block code: no markers found, overwrites.
+    // First run with marker-block code: no markers found, entire file is user content.
     await runScripts(id, scripts);
     const config = await readFileContainer(
       id,
       "/home/coder/.codex/config.toml",
     );
-    // New managed block is written
+    // Managed block is written
     expect(config).toContain(MANAGED_START);
     expect(config).toContain(MANAGED_END);
-    expect(config).toMatch(/preferred_auth_method\s*=\s*"apikey"/);
-    // Legacy content is gone (no markers to preserve it)
-    expect(config).not.toContain("legacy_key");
-    expect(config).not.toContain("old_value");
+    // Legacy bare keys hoisted above managed block at root scope
+    const startIdx = config.indexOf(MANAGED_START);
+    expect(config.indexOf('preferred_auth_method = "login"')).toBeLessThan(
+      startIdx,
+    );
+    expect(config.indexOf('legacy_key = "old_value"')).toBeLessThan(startIdx);
+    // Legacy section preserved after managed block
+    const endIdx = config.indexOf(MANAGED_END);
+    expect(config.indexOf("[mcp_servers.legacy]")).toBeGreaterThan(endIdx);
   });
 
   test("idempotent-all-sources-user-content-survives", async () => {

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -543,6 +543,47 @@ EOF`,
     expect(config).toMatch(/command\s*=\s*"my-tool"/);
   });
 
+  test("idempotent-user-bare-keys-stay-at-root-scope", async () => {
+    const { id, scripts } = await setup();
+    await runScripts(id, scripts);
+
+    // User adds bare keys AND a section after the managed block.
+    await execContainer(id, [
+      "bash",
+      "-c",
+      `cat >> /home/coder/.codex/config.toml << 'EOF'
+
+my_custom_key = "hello"
+sandbox_mode = "full"
+
+[mcp_servers.user_tool]
+command = "my-tool"
+EOF`,
+    ]);
+
+    // Second run
+    await runScripts(id, scripts);
+    const config = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+
+    // User bare keys must appear BEFORE the managed block start marker
+    // so they remain at TOML root scope.
+    const startIdx = config.indexOf(MANAGED_START);
+    const customKeyIdx = config.indexOf('my_custom_key = "hello"');
+    const sandboxIdx = config.indexOf('sandbox_mode = "full"');
+    expect(customKeyIdx).toBeGreaterThan(-1);
+    expect(sandboxIdx).toBeGreaterThan(-1);
+    expect(customKeyIdx).toBeLessThan(startIdx);
+    expect(sandboxIdx).toBeLessThan(startIdx);
+
+    // User section preserved after managed block
+    const endIdx = config.indexOf(MANAGED_END);
+    const sectionIdx = config.indexOf("[mcp_servers.user_tool]");
+    expect(sectionIdx).toBeGreaterThan(endIdx);
+  });
+
   test("idempotent-managed-block-regenerated", async () => {
     const { id, scripts } = await setup({
       moduleVariables: {
@@ -580,13 +621,16 @@ EOF`,
     const { id, scripts } = await setup();
     await runScripts(id, scripts);
 
-    // User adds comments and a section after the managed block.
+    // User adds a bare-key comment, a bare key, then a section with comments.
     await execContainer(id, [
       "bash",
       "-c",
       `cat >> /home/coder/.codex/config.toml << 'EOF'
 
-# My personal settings for local development
+# My personal top-level setting
+my_flag = true
+
+# My personal MCP server
 [mcp_servers.notes]
 command = "notes-server"
 # This server is for my personal notes
@@ -600,8 +644,10 @@ EOF`,
       id,
       "/home/coder/.codex/config.toml",
     );
-    // User comments preserved
-    expect(config).toContain("# My personal settings for local development");
+    // Bare-key comment hoisted above managed block
+    expect(config).toContain("# My personal top-level setting");
+    // Section comments preserved below managed block
+    expect(config).toContain("# My personal MCP server");
     expect(config).toContain("# This server is for my personal notes");
     expect(config).toContain("[mcp_servers.notes]");
   });

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -659,21 +659,41 @@ EOF`,
   test("idempotent-stable-after-roundtrip", async () => {
     const { id, scripts } = await setup();
 
-    // First run
+    // First run: write the managed block.
     await runScripts(id, scripts);
-    const configAfterFirst = await readFileContainer(
-      id,
-      "/home/coder/.codex/config.toml",
-    );
 
-    // Second run: no format conversion, should be byte-identical.
+    // User appends content outside the managed block.
+    await execContainer(id, [
+      "bash",
+      "-c",
+      `cat >> /home/coder/.codex/config.toml << 'EOF'
+
+roundtrip_key = "present"
+
+# User's personal server
+[mcp_servers.roundtrip]
+command = "roundtrip-tool"
+type = "stdio"
+EOF`,
+    ]);
+
+    // Second run: managed block is regenerated with user content in place.
     await runScripts(id, scripts);
     const configAfterSecond = await readFileContainer(
       id,
       "/home/coder/.codex/config.toml",
     );
 
-    expect(configAfterSecond).toEqual(configAfterFirst);
+    // Third run: output must be byte-identical (no double-hoisting or newline drift).
+    await runScripts(id, scripts);
+    const configAfterThird = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+
+    expect(configAfterThird).toEqual(configAfterSecond);
+    expect(configAfterThird).toContain('roundtrip_key = "present"');
+    expect(configAfterThird).toContain("[mcp_servers.roundtrip]");
   });
 
   test("idempotent-mcp-new-servers-added-existing-kept", async () => {

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -231,8 +231,8 @@ describe("codex", async () => {
     });
     await runScripts(id, scripts);
     const resp = await readFileContainer(id, "/home/coder/.codex/config.toml");
-    expect(resp).toContain('sandbox_mode = "danger-full-access"');
-    expect(resp).toContain('preferred_auth_method = "apikey"');
+    expect(resp).toMatch(/sandbox_mode\s*=\s*['"]danger-full-access['"]/);
+    expect(resp).toMatch(/preferred_auth_method\s*=\s*['"]apikey['"]/);
     expect(resp).toContain("[custom_section]");
   });
 
@@ -259,7 +259,7 @@ describe("codex", async () => {
     const { id, scripts } = await setup();
     await runScripts(id, scripts);
     const resp = await readFileContainer(id, "/home/coder/.codex/config.toml");
-    expect(resp).toContain('preferred_auth_method = "apikey"');
+    expect(resp).toMatch(/preferred_auth_method\s*=\s*['"]apikey['"]/);
     expect(resp).not.toContain("model_provider");
     expect(resp).not.toContain("[model_providers.");
     expect(resp).not.toContain("model_reasoning_effort");
@@ -330,7 +330,7 @@ describe("codex", async () => {
       id,
       "/home/coder/.codex/config.toml",
     );
-    expect(configToml).toContain('model_reasoning_effort = "high"');
+    expect(configToml).toMatch(/model_reasoning_effort\s*=\s*['"]high['"]/);
     expect(configToml).not.toContain("model_provider");
   });
 
@@ -346,8 +346,8 @@ describe("codex", async () => {
       id,
       "/home/coder/.codex/config.toml",
     );
-    expect(configToml).toContain(`[projects."${workdir}"]`);
-    expect(configToml).toContain('trust_level = "trusted"');
+    expect(configToml).toMatch(new RegExp(`projects.*${workdir.replace(/\//g, '\\/')}.*`));
+    expect(configToml).toMatch(/trust_level\s*=\s*['"]trusted['"]/);
   });
 
   test("no-workdir-no-project-section", async () => {
@@ -738,7 +738,7 @@ EOF`,
       id,
       "/home/coder/.codex/config.toml",
     );
-    expect(configToml).toContain('sandbox_mode = "danger-full-access"');
+    expect(configToml).toMatch(/sandbox_mode\s*=\s*['"]danger-full-access['"]/);
     expect(configToml).not.toContain("model_reasoning_effort");
   });
 });

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -346,7 +346,9 @@ describe("codex", async () => {
       id,
       "/home/coder/.codex/config.toml",
     );
-    expect(configToml).toMatch(new RegExp(`projects.*${workdir.replace(/\//g, '\\/')}.*`));
+    expect(configToml).toMatch(
+      new RegExp(`projects.*${workdir.replace(/\//g, "\\/")}.*`),
+    );
     expect(configToml).toMatch(/trust_level\s*=\s*['"]trusted['"]/);
   });
 

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -715,7 +715,7 @@ EOF`,
     expect(config).toMatch(/command\s*=\s*"my-tool"/);
   });
 
-  test("idempotent-no-markers-preserves-user-config", async () => {
+  test("no-markers-first-run-overwrites", async () => {
     const { id, scripts } = await setup();
 
     // Simulate a legacy config without markers (pre-upgrade).
@@ -732,7 +732,7 @@ type = "stdio"
 EOF`,
     ]);
 
-    // First run with marker-block code: no markers found, entire file is user content.
+    // First run: no markers found, file is overwritten entirely by the managed block.
     await runScripts(id, scripts);
     const config = await readFileContainer(
       id,
@@ -741,17 +741,12 @@ EOF`,
     // Managed block is written
     expect(config).toContain(MANAGED_START);
     expect(config).toContain(MANAGED_END);
-    // Legacy bare keys hoisted above managed block at root scope
-    const startIdx = config.indexOf(MANAGED_START);
-    expect(config.indexOf('preferred_auth_method = "login"')).toBeLessThan(
-      startIdx,
-    );
-    expect(config.indexOf('legacy_key = "old_value"')).toBeLessThan(startIdx);
-    // Legacy section preserved after managed block
-    const endIdx = config.indexOf(MANAGED_END);
-    expect(config.indexOf("[mcp_servers.legacy]")).toBeGreaterThan(endIdx);
+    // Legacy content is gone
+    expect(config).not.toContain('preferred_auth_method = "login"');
+    expect(config).not.toContain('legacy_key = "old_value"');
+    expect(config).not.toContain("[mcp_servers.legacy]");
 
-    // Second run: the migrated file must be stable (no double-hoisting, no duplicate markers).
+    // Second run: output must be stable.
     await runScripts(id, scripts);
     const configAfterSecond = await readFileContainer(
       id,

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -171,6 +171,9 @@ const runScripts = async (
   }
 };
 
+const MANAGED_START = "# >>> coder-managed: codex module >>>";
+const MANAGED_END = "# <<< coder-managed: codex module <<<";
+
 setDefaultTimeout(60 * 1000);
 
 describe("codex", async () => {
@@ -231,8 +234,10 @@ describe("codex", async () => {
     });
     await runScripts(id, scripts);
     const resp = await readFileContainer(id, "/home/coder/.codex/config.toml");
-    expect(resp).toMatch(/sandbox_mode\s*=\s*['"]danger-full-access['"]/);
-    expect(resp).toMatch(/preferred_auth_method\s*=\s*['"]apikey['"]/);
+    expect(resp).toContain(MANAGED_START);
+    expect(resp).toContain(MANAGED_END);
+    expect(resp).toMatch(/sandbox_mode\s*=\s*"danger-full-access"/);
+    expect(resp).toMatch(/preferred_auth_method\s*=\s*"apikey"/);
     expect(resp).toContain("[custom_section]");
   });
 
@@ -259,7 +264,9 @@ describe("codex", async () => {
     const { id, scripts } = await setup();
     await runScripts(id, scripts);
     const resp = await readFileContainer(id, "/home/coder/.codex/config.toml");
-    expect(resp).toMatch(/preferred_auth_method\s*=\s*['"]apikey['"]/);
+    expect(resp).toContain(MANAGED_START);
+    expect(resp).toContain(MANAGED_END);
+    expect(resp).toMatch(/preferred_auth_method\s*=\s*"apikey"/);
     expect(resp).not.toContain("model_provider");
     expect(resp).not.toContain("[model_providers.");
     expect(resp).not.toContain("model_reasoning_effort");
@@ -314,8 +321,8 @@ describe("codex", async () => {
       id,
       "/home/coder/.codex/config.toml",
     );
-    expect(configToml).toMatch(/model_provider\s*=\s*['"]aigateway['"]/);
-    expect(configToml).toMatch(/model_reasoning_effort\s*=\s*['"]none['"]/);
+    expect(configToml).toMatch(/model_provider\s*=\s*"aigateway"/);
+    expect(configToml).toMatch(/model_reasoning_effort\s*=\s*"none"/);
     expect(configToml).toContain("[model_providers.aigateway]");
   });
 
@@ -330,7 +337,7 @@ describe("codex", async () => {
       id,
       "/home/coder/.codex/config.toml",
     );
-    expect(configToml).toMatch(/model_reasoning_effort\s*=\s*['"]high['"]/);
+    expect(configToml).toMatch(/model_reasoning_effort\s*=\s*"high"/);
     expect(configToml).not.toContain("model_provider");
   });
 
@@ -347,7 +354,7 @@ describe("codex", async () => {
       "/home/coder/.codex/config.toml",
     );
     expect(configToml).toMatch(new RegExp(`\\[projects\\..*${workdir}.*\\]`));
-    expect(configToml).toMatch(/trust_level\s*=\s*['"]trusted['"]/);
+    expect(configToml).toMatch(/trust_level\s*=\s*"trusted"/);
   });
 
   test("no-workdir-no-project-section", async () => {
@@ -380,7 +387,7 @@ describe("codex", async () => {
       id,
       "/home/coder/.codex/config.toml",
     );
-    expect(configToml).toMatch(/model_provider\s*=\s*['"]aigateway['"]/);
+    expect(configToml).toMatch(/model_provider\s*=\s*"aigateway"/);
     expect(configToml).toContain("[model_providers.aigateway]");
   });
 
@@ -425,193 +432,6 @@ describe("codex", async () => {
     expect(installLog).toContain("Installed Codex CLI");
   });
 
-  test("idempotent-defaults-preserve-user-edits", async () => {
-    const { id, scripts } = await setup();
-    await runScripts(id, scripts);
-
-    // User edits the config between restarts
-    await execContainer(id, [
-      "bash",
-      "-c",
-      `cat > /home/coder/.codex/config.toml << 'EOF'
-preferred_auth_method = "login"
-custom_user_key = "my_value"
-
-[projects."/home/coder/project"]
-trust_level = "trusted"
-EOF`,
-    ]);
-
-    // Second run: user edits must survive
-    await runScripts(id, scripts);
-    const config = await readFileContainer(
-      id,
-      "/home/coder/.codex/config.toml",
-    );
-    // User's overridden value preserved (not reset to "apikey")
-    expect(config).toMatch(/preferred_auth_method\s*=\s*['"]login['"]/);
-    // User's custom key preserved
-    expect(config).toMatch(/custom_user_key\s*=\s*['"]my_value['"]/);
-  });
-
-  test("idempotent-mcp-deep-merge", async () => {
-    const mcpConfig = [
-      "[mcp_servers.github]",
-      'command = "npx"',
-      'args = ["-y", "@modelcontextprotocol/server-github"]',
-      'type = "stdio"',
-      "",
-      "[mcp_servers.filesystem]",
-      'command = "npx"',
-      'args = ["-y", "@modelcontextprotocol/server-filesystem"]',
-      'type = "stdio"',
-    ].join("\n");
-    const { id, scripts } = await setup({
-      moduleVariables: { mcp: mcpConfig },
-    });
-    await runScripts(id, scripts);
-
-    // User customizes ONLY the github MCP server between restarts
-    await execContainer(id, [
-      "bash",
-      "-c",
-      [
-        "CONFIG=/home/coder/.codex/config.toml",
-        // Use sed address range to only replace command under github section
-        "sed -i '/github/,/^$/{ s/command = .*/command = '\"'\"'my-custom-npx'\"'\"'/; }' $CONFIG",
-      ].join(" && "),
-    ]);
-
-    // Second run
-    await runScripts(id, scripts);
-    const config = await readFileContainer(
-      id,
-      "/home/coder/.codex/config.toml",
-    );
-    // User's customized github command preserved
-    expect(config).toMatch(/command\s*=\s*['"]my-custom-npx['"]/);
-    // filesystem server still present with original command
-    expect(config).toContain("filesystem");
-    expect(config).toMatch(/command\s*=\s*['"]npx['"]/);
-  });
-
-  test("idempotent-base-config-preserves-user-edits", async () => {
-    const baseConfig = [
-      'sandbox_mode = "danger-full-access"',
-      'preferred_auth_method = "apikey"',
-    ].join("\n");
-    const { id, scripts } = await setup({
-      moduleVariables: { base_config_toml: baseConfig },
-    });
-    await runScripts(id, scripts);
-
-    // User changes sandbox_mode
-    await execContainer(id, [
-      "bash",
-      "-c",
-      "sed -i 's/danger-full-access/sandbox/' /home/coder/.codex/config.toml",
-    ]);
-
-    // Second run
-    await runScripts(id, scripts);
-    const config = await readFileContainer(
-      id,
-      "/home/coder/.codex/config.toml",
-    );
-    // User's change preserved
-    expect(config).toMatch(/sandbox_mode\s*=\s*['"]sandbox['"]/);
-    // Original key from base config still present
-    expect(config).toContain("preferred_auth_method");
-  });
-
-  test("idempotent-stable-after-roundtrip", async () => {
-    const { id, scripts } = await setup();
-
-    // First run
-    await runScripts(id, scripts);
-
-    // Second run triggers a dasel roundtrip (quotes may change)
-    await runScripts(id, scripts);
-    const configAfterSecond = await readFileContainer(
-      id,
-      "/home/coder/.codex/config.toml",
-    );
-
-    // Third run: if idempotent, output must be identical to second run
-    await runScripts(id, scripts);
-    const configAfterThird = await readFileContainer(
-      id,
-      "/home/coder/.codex/config.toml",
-    );
-
-    // After the first roundtrip the serialization is stable, so a byte
-    // comparison is valid from the second run onward.
-    expect(configAfterThird).toEqual(configAfterSecond);
-  });
-
-  test("idempotent-mcp-new-servers-added-existing-kept", async () => {
-    // First run: one MCP server
-    const mcpRun1 = [
-      "[mcp_servers.github]",
-      'command = "npx"',
-      'args = ["-y", "@modelcontextprotocol/server-github"]',
-      'type = "stdio"',
-    ].join("\n");
-    const { id, scripts } = await setup({
-      moduleVariables: { mcp: mcpRun1 },
-    });
-    await runScripts(id, scripts);
-
-    // User adds their own MCP server manually
-    await execContainer(id, [
-      "bash",
-      "-c",
-      `cat >> /home/coder/.codex/config.toml << 'EOF'
-
-[mcp_servers.custom]
-command = "my-tool"
-args = ["--serve"]
-type = "stdio"
-EOF`,
-    ]);
-
-    // Second run: same module config
-    await runScripts(id, scripts);
-    const config = await readFileContainer(
-      id,
-      "/home/coder/.codex/config.toml",
-    );
-    // Module's github server still present
-    expect(config).toContain("github");
-    // User's manually-added custom server preserved
-    expect(config).toMatch(/command\s*=\s*['"]my-tool['"]/);
-  });
-
-  test("idempotent-ai-gateway-preserves-user-provider", async () => {
-    const { id, coderEnvVars, scripts } = await setup({
-      moduleVariables: {
-        enable_ai_gateway: "true",
-      },
-    });
-    await runScripts(id, scripts, coderEnvVars);
-
-    // User changes model_provider
-    await execContainer(id, [
-      "bash",
-      "-c",
-      "sed -i 's/model_provider = .*/model_provider = \"custom_provider\"/' /home/coder/.codex/config.toml",
-    ]);
-
-    // Second run
-    await runScripts(id, scripts, coderEnvVars);
-    const config = await readFileContainer(
-      id,
-      "/home/coder/.codex/config.toml",
-    );
-    // User's custom provider survives
-    expect(config).toMatch(/model_provider\s*=\s*['"]custom_provider['"]/);
-  });
-
   test("base-config-plus-mcp-combined", async () => {
     const baseConfig = [
       'sandbox_mode = "danger-full-access"',
@@ -634,12 +454,10 @@ EOF`,
       id,
       "/home/coder/.codex/config.toml",
     );
-    // Base config keys present
-    expect(config).toMatch(/sandbox_mode\s*=\s*['"]danger-full-access['"]/);
-    expect(config).toMatch(/preferred_auth_method\s*=\s*['"]apikey['"]/);
-    // MCP server present
+    expect(config).toMatch(/sandbox_mode\s*=\s*"danger-full-access"/);
+    expect(config).toMatch(/preferred_auth_method\s*=\s*"apikey"/);
     expect(config).toContain("mcp_servers");
-    expect(config).toMatch(/command\s*=\s*['"]npx['"]/);
+    expect(config).toMatch(/command\s*=\s*"npx"/);
   });
 
   test("all-config-sources-combined", async () => {
@@ -665,60 +483,9 @@ EOF`,
       id,
       "/home/coder/.codex/config.toml",
     );
-    // Base config
-    expect(config).toMatch(/sandbox_mode\s*=\s*['"]danger-full-access['"]/);
-    expect(config).toMatch(/preferred_auth_method\s*=\s*['"]apikey['"]/);
-    // MCP
-    expect(config).toMatch(/command\s*=\s*['"]npx['"]/);
-    // AI gateway
-    expect(config).toContain("[model_providers.aigateway]");
-  });
-
-  test("idempotent-all-sources-user-edits-survive", async () => {
-    const baseConfig = [
-      'sandbox_mode = "danger-full-access"',
-      'preferred_auth_method = "apikey"',
-    ].join("\n");
-    const mcpConfig = [
-      "[mcp_servers.github]",
-      'command = "npx"',
-      'args = ["-y", "@modelcontextprotocol/server-github"]',
-      'type = "stdio"',
-    ].join("\n");
-    const { id, coderEnvVars, scripts } = await setup({
-      moduleVariables: {
-        enable_ai_gateway: "true",
-        base_config_toml: baseConfig,
-        mcp: mcpConfig,
-      },
-    });
-    await runScripts(id, scripts, coderEnvVars);
-
-    // User edits multiple things
-    await execContainer(id, [
-      "bash",
-      "-c",
-      [
-        "CONFIG=/home/coder/.codex/config.toml",
-        // Change auth method
-        "sed -i \"s/preferred_auth_method.*/preferred_auth_method = 'oauth'/\" $CONFIG",
-        // Add a custom top-level key
-        "echo 'user_note = \"do not touch\"' >> $CONFIG",
-      ].join(" && "),
-    ]);
-
-    // Second run
-    await runScripts(id, scripts, coderEnvVars);
-    const config = await readFileContainer(
-      id,
-      "/home/coder/.codex/config.toml",
-    );
-    // User edits survived
-    expect(config).toMatch(/preferred_auth_method\s*=\s*['"]oauth['"]/);
-    expect(config).toMatch(/user_note\s*=\s*['"]do not touch['"]/);
-    // Module config still present
-    expect(config).toMatch(/sandbox_mode\s*=\s*['"]danger-full-access['"]/);
-    expect(config).toContain("github");
+    expect(config).toMatch(/sandbox_mode\s*=\s*"danger-full-access"/);
+    expect(config).toMatch(/preferred_auth_method\s*=\s*"apikey"/);
+    expect(config).toMatch(/command\s*=\s*"npx"/);
     expect(config).toContain("[model_providers.aigateway]");
   });
 
@@ -738,7 +505,286 @@ EOF`,
       id,
       "/home/coder/.codex/config.toml",
     );
-    expect(configToml).toMatch(/sandbox_mode\s*=\s*['"]danger-full-access['"]/);
+    expect(configToml).toMatch(/sandbox_mode\s*=\s*"danger-full-access"/);
     expect(configToml).not.toContain("model_reasoning_effort");
+  });
+
+  // --- idempotency tests: marker-block semantics ---
+
+  test("idempotent-user-section-survives-restart", async () => {
+    const { id, scripts } = await setup();
+    await runScripts(id, scripts);
+
+    // User adds a custom section after the managed block.
+    await execContainer(id, [
+      "bash",
+      "-c",
+      `cat >> /home/coder/.codex/config.toml << 'EOF'
+
+[mcp_servers.user_tool]
+command = "my-tool"
+args = ["--serve"]
+type = "stdio"
+EOF`,
+    ]);
+
+    // Second run: managed block is regenerated, user section survives.
+    await runScripts(id, scripts);
+    const config = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    // Managed content still present
+    expect(config).toMatch(/preferred_auth_method\s*=\s*"apikey"/);
+    expect(config).toContain(MANAGED_START);
+    expect(config).toContain(MANAGED_END);
+    // User section preserved
+    expect(config).toContain("[mcp_servers.user_tool]");
+    expect(config).toMatch(/command\s*=\s*"my-tool"/);
+  });
+
+  test("idempotent-managed-block-regenerated", async () => {
+    const { id, scripts } = await setup({
+      moduleVariables: {
+        model_reasoning_effort: "high",
+      },
+    });
+    await runScripts(id, scripts);
+
+    // User modifies a value inside the managed block.
+    await execContainer(id, [
+      "bash",
+      "-c",
+      "sed -i 's/model_reasoning_effort.*/model_reasoning_effort = \"low\"/' /home/coder/.codex/config.toml",
+    ]);
+
+    // Verify user edit took effect.
+    const edited = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    expect(edited).toMatch(/model_reasoning_effort\s*=\s*"low"/);
+
+    // Second run: managed block is regenerated with original values.
+    await runScripts(id, scripts);
+    const config = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    // Original managed value restored
+    expect(config).toMatch(/model_reasoning_effort\s*=\s*"high"/);
+    expect(config).not.toMatch(/model_reasoning_effort\s*=\s*"low"/);
+  });
+
+  test("idempotent-user-comments-preserved", async () => {
+    const { id, scripts } = await setup();
+    await runScripts(id, scripts);
+
+    // User adds comments and a section after the managed block.
+    await execContainer(id, [
+      "bash",
+      "-c",
+      `cat >> /home/coder/.codex/config.toml << 'EOF'
+
+# My personal settings for local development
+[mcp_servers.notes]
+command = "notes-server"
+# This server is for my personal notes
+type = "stdio"
+EOF`,
+    ]);
+
+    // Second run
+    await runScripts(id, scripts);
+    const config = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    // User comments preserved
+    expect(config).toContain("# My personal settings for local development");
+    expect(config).toContain("# This server is for my personal notes");
+    expect(config).toContain("[mcp_servers.notes]");
+  });
+
+  test("idempotent-stable-after-roundtrip", async () => {
+    const { id, scripts } = await setup();
+
+    // First run
+    await runScripts(id, scripts);
+    const configAfterFirst = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+
+    // Second run: no format conversion, should be byte-identical.
+    await runScripts(id, scripts);
+    const configAfterSecond = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+
+    expect(configAfterSecond).toEqual(configAfterFirst);
+  });
+
+  test("idempotent-mcp-new-servers-added-existing-kept", async () => {
+    const mcpConfig = [
+      "[mcp_servers.github]",
+      'command = "npx"',
+      'args = ["-y", "@modelcontextprotocol/server-github"]',
+      'type = "stdio"',
+    ].join("\n");
+    const { id, scripts } = await setup({
+      moduleVariables: { mcp: mcpConfig },
+    });
+    await runScripts(id, scripts);
+
+    // User adds their own MCP server after the managed block.
+    await execContainer(id, [
+      "bash",
+      "-c",
+      `cat >> /home/coder/.codex/config.toml << 'EOF'
+
+[mcp_servers.custom]
+command = "my-tool"
+args = ["--serve"]
+type = "stdio"
+EOF`,
+    ]);
+
+    // Second run
+    await runScripts(id, scripts);
+    const config = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    // Module's github server still present (in managed block)
+    expect(config).toContain("[mcp_servers.github]");
+    expect(config).toMatch(/command\s*=\s*"npx"/);
+    // User's custom server preserved (outside managed block)
+    expect(config).toContain("[mcp_servers.custom]");
+    expect(config).toMatch(/command\s*=\s*"my-tool"/);
+  });
+
+  test("idempotent-no-markers-overwrites", async () => {
+    const { id, scripts } = await setup();
+
+    // Simulate a legacy config without markers (pre-upgrade).
+    await execContainer(id, [
+      "bash",
+      "-c",
+      `mkdir -p /home/coder/.codex && cat > /home/coder/.codex/config.toml << 'EOF'
+preferred_auth_method = "login"
+legacy_key = "old_value"
+EOF`,
+    ]);
+
+    // First run with marker-block code: no markers found, overwrites.
+    await runScripts(id, scripts);
+    const config = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    // New managed block is written
+    expect(config).toContain(MANAGED_START);
+    expect(config).toContain(MANAGED_END);
+    expect(config).toMatch(/preferred_auth_method\s*=\s*"apikey"/);
+    // Legacy content is gone (no markers to preserve it)
+    expect(config).not.toContain("legacy_key");
+    expect(config).not.toContain("old_value");
+  });
+
+  test("idempotent-all-sources-user-content-survives", async () => {
+    const baseConfig = [
+      'sandbox_mode = "danger-full-access"',
+      'preferred_auth_method = "apikey"',
+    ].join("\n");
+    const mcpConfig = [
+      "[mcp_servers.github]",
+      'command = "npx"',
+      'args = ["-y", "@modelcontextprotocol/server-github"]',
+      'type = "stdio"',
+    ].join("\n");
+    const { id, coderEnvVars, scripts } = await setup({
+      moduleVariables: {
+        enable_ai_gateway: "true",
+        base_config_toml: baseConfig,
+        mcp: mcpConfig,
+      },
+    });
+    await runScripts(id, scripts, coderEnvVars);
+
+    // User adds content outside the managed block.
+    await execContainer(id, [
+      "bash",
+      "-c",
+      `cat >> /home/coder/.codex/config.toml << 'EOF'
+
+# User's personal MCP server
+[mcp_servers.personal]
+command = "personal-server"
+type = "stdio"
+EOF`,
+    ]);
+
+    // Second run
+    await runScripts(id, scripts, coderEnvVars);
+    const config = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+    // All managed content correct
+    expect(config).toMatch(/sandbox_mode\s*=\s*"danger-full-access"/);
+    expect(config).toMatch(/preferred_auth_method\s*=\s*"apikey"/);
+    expect(config).toContain("[mcp_servers.github]");
+    expect(config).toContain("[model_providers.aigateway]");
+    // User content preserved
+    expect(config).toContain("# User's personal MCP server");
+    expect(config).toContain("[mcp_servers.personal]");
+    expect(config).toMatch(/command\s*=\s*"personal-server"/);
+  });
+
+  test("idempotent-multiple-restarts-user-content-stable", async () => {
+    const mcpConfig = [
+      "[mcp_servers.github]",
+      'command = "npx"',
+      'args = ["-y", "@modelcontextprotocol/server-github"]',
+      'type = "stdio"',
+    ].join("\n");
+    const { id, scripts } = await setup({
+      moduleVariables: { mcp: mcpConfig },
+    });
+    await runScripts(id, scripts);
+
+    // User adds content outside managed block.
+    await execContainer(id, [
+      "bash",
+      "-c",
+      `cat >> /home/coder/.codex/config.toml << 'EOF'
+
+# User customizations
+[mcp_servers.custom]
+command = "custom-tool"
+type = "stdio"
+EOF`,
+    ]);
+
+    // Run 2
+    await runScripts(id, scripts);
+    const configAfterSecond = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+
+    // Run 3: should be byte-identical to run 2
+    await runScripts(id, scripts);
+    const configAfterThird = await readFileContainer(
+      id,
+      "/home/coder/.codex/config.toml",
+    );
+
+    expect(configAfterThird).toEqual(configAfterSecond);
+    // User content still present
+    expect(configAfterThird).toContain("# User customizations");
+    expect(configAfterThird).toContain("[mcp_servers.custom]");
   });
 });

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -314,8 +314,8 @@ describe("codex", async () => {
       id,
       "/home/coder/.codex/config.toml",
     );
-    expect(configToml).toContain('model_provider = "aigateway"');
-    expect(configToml).toContain('model_reasoning_effort = "none"');
+    expect(configToml).toMatch(/model_provider\s*=\s*['"]aigateway['"]/);
+    expect(configToml).toMatch(/model_reasoning_effort\s*=\s*['"]none['"]/);
     expect(configToml).toContain("[model_providers.aigateway]");
   });
 
@@ -380,7 +380,7 @@ describe("codex", async () => {
       id,
       "/home/coder/.codex/config.toml",
     );
-    expect(configToml).toContain('model_provider = "aigateway"');
+    expect(configToml).toMatch(/model_provider\s*=\s*['"]aigateway['"]/);
     expect(configToml).toContain("[model_providers.aigateway]");
   });
 
@@ -526,33 +526,27 @@ EOF`,
 
   test("idempotent-run-twice-no-change", async () => {
     const { id, scripts } = await setup();
-    await runScripts(id, scripts);
-    const configAfterFirst = await readFileContainer(
-      id,
-      "/home/coder/.codex/config.toml",
-    );
 
-    // Second run without any user edits
-    await runScripts(id, scripts);
-    const configAfterSecond = await readFileContainer(
-      id,
-      "/home/coder/.codex/config.toml",
-    );
-
-    // Config should still contain the same keys
-    expect(configAfterSecond).toContain("preferred_auth_method");
-    // The values must match (quotes may change on roundtrip, compare via JSON)
-    const toJson = async (toml: string) => {
+    // Convert the container config file to JSON for comparison
+    const configToJson = async () => {
       const resp = await execContainer(id, [
         "bash",
         "-c",
-        `echo '${toml.replace(/'/g, "'\\''")}' | dasel -i toml -o json`,
+        "dasel -i toml -o json < /home/coder/.codex/config.toml",
       ]);
       return JSON.parse(resp.stdout);
     };
-    expect(await toJson(configAfterSecond)).toEqual(
-      await toJson(configAfterFirst),
-    );
+
+    // First run
+    await runScripts(id, scripts);
+    const jsonAfterFirst = await configToJson();
+
+    // Second run without any user edits
+    await runScripts(id, scripts);
+    const jsonAfterSecond = await configToJson();
+
+    // Data must be identical (quotes may differ, so compare JSON not strings)
+    expect(jsonAfterSecond).toEqual(jsonAfterFirst);
   });
 
   test("idempotent-mcp-new-servers-added-existing-kept", async () => {

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -26,7 +26,6 @@ printf "install_codex: %s\n" "$${ARG_INSTALL}"
 printf "model_reasoning_effort: %s\n" "$${ARG_MODEL_REASONING_EFFORT}"
 echo "--------------------------------"
 
-
 function install_dasel() {
   if command_exists dasel; then
     return 0
@@ -58,7 +57,6 @@ function install_dasel() {
     return 1
   fi
 }
-
 
 function add_path_to_shell_profiles() {
   local path_dir="$1"
@@ -146,7 +144,7 @@ function install_codex() {
 }
 
 # Builds the minimal default config as a JSON string on stdout.
-function write_minimal_default_config() {
+function build_minimal_default_config() {
   local json
   json=$(jq -n '{preferred_auth_method: "apikey"}')
 
@@ -177,7 +175,7 @@ function populate_config_toml() {
     new_json=$(echo "$${ARG_BASE_CONFIG_TOML}" | dasel -i toml -o json)
   else
     printf "Using minimal default configuration\n"
-    new_json=$(write_minimal_default_config)
+    new_json=$(build_minimal_default_config)
   fi
 
   if [ -n "$${ARG_MCP}" ]; then
@@ -197,13 +195,19 @@ function populate_config_toml() {
   # Deep-merge with existing config (existing user values win).
   if [ -s "$${config_path}" ]; then
     local existing_json
-    existing_json=$(dasel -i toml -o json < "$${config_path}")
+    if ! existing_json=$(dasel -i toml -o json < "$${config_path}" 2>/dev/null); then
+      printf "Error: existing %s contains invalid TOML, cannot merge\n" "$${config_path}" >&2
+      exit 1
+    fi
     new_json=$(echo "$${new_json}" "$${existing_json}" | jq -s '.[0] * .[1]')
   fi
 
-  # Single conversion: JSON to TOML.
-  echo "$${new_json}" | dasel -i json -o toml > "$${config_path}"
+  # Single conversion: JSON to TOML (atomic via temp file).
+  local tmp
+  tmp=$(mktemp "$${config_path}.XXXXXX")
+  echo "$${new_json}" | dasel -i json -o toml > "$${tmp}" && mv "$${tmp}" "$${config_path}"
 }
+
 function setup_workdir() {
   if [ -n "$${ARG_WORKDIR}" ] && [ ! -d "$${ARG_WORKDIR}" ]; then
     echo "Creating workdir: $${ARG_WORKDIR}"
@@ -230,6 +234,10 @@ EOF
 
 install_codex
 install_dasel
+if ! command_exists jq; then
+  printf "Error: jq is required but not installed.\n" >&2
+  exit 1
+fi
 populate_config_toml
 setup_workdir
 add_auth_json

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -173,8 +173,9 @@ function write_minimal_default_config() {
 function populate_config_toml() {
   local config_path="$HOME/.codex/config.toml"
   mkdir -p "$(dirname "$${config_path}")"
+  touch "$${config_path}"
 
-  if [ ! -f "$${config_path}" ]; then
+  if [ ! -s "$${config_path}" ]; then
     printf "Using minimal default configuration\n"
     write_minimal_default_config "$${config_path}"
   fi

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -139,8 +139,18 @@ function populate_config_toml() {
   local MANAGED_START="# >>> coder-managed: codex module >>>"
   local MANAGED_END="# <<< coder-managed: codex module <<<"
 
+  # Reject inputs that contain the managed-block markers to prevent embedding
+  # spurious markers that would corrupt the block structure on subsequent runs.
+  for _arg in "$${ARG_BASE_CONFIG_TOML}" "$${ARG_MCP}"; do
+    if [ -n "$${_arg}" ] && printf '%s' "$${_arg}" | grep -qF "$${MANAGED_START}"; then
+      printf 'Error: a codex module input contains a managed-block marker; aborting.\n' >&2
+      return 1
+    fi
+  done
+
   # Build managed-block content in a temp file.
-  local managed
+  local managed="" config_tmp=""
+  trap 'rm -f "$${managed:-}" "$${config_tmp:-}"' EXIT
   managed=$(mktemp)
 
   if [ -n "$${ARG_BASE_CONFIG_TOML}" ]; then
@@ -167,18 +177,21 @@ function populate_config_toml() {
 
   # Preserve user content from the existing config.
   # On the first run (no markers), the file is overwritten fresh.
-  local user_content=""
+  local existing_config="" user_content=""
   if [ -s "$${config_path}" ]; then
-    if grep -qF "$${MANAGED_START}" "$${config_path}"; then
-      if grep -qF "$${MANAGED_END}" "$${config_path}"; then
+    existing_config=$(cat "$${config_path}")
+  fi
+  if [ -n "$${existing_config}" ]; then
+    if printf '%s\n' "$${existing_config}" | grep -qF "$${MANAGED_START}"; then
+      if printf '%s\n' "$${existing_config}" | grep -qF "$${MANAGED_END}"; then
         # Strip the managed block; everything else is user content.
-        user_content=$(sed '/# >>> coder-managed: codex module >>>/,/# <<< coder-managed: codex module <<</d' "$${config_path}")
+        user_content=$(printf '%s\n' "$${existing_config}" | sed '/# >>> coder-managed: codex module >>>/,/# <<< coder-managed: codex module <<</d')
       else
         # Start marker present but end marker missing (file was truncated or hand-edited).
         # Treat the entire file as user content to avoid silently deleting everything
         # after the orphaned start marker.
         printf "Warning: codex config has managed-block start marker but no end marker; treating entire file as user content\n"
-        user_content=$(cat "$${config_path}")
+        user_content="$${existing_config}"
       fi
     fi
     # Trim leading blank lines.
@@ -188,13 +201,24 @@ function populate_config_toml() {
   # Split user content into bare keys (before any [section]) and sections.
   # Bare keys go above the managed block so they stay at TOML root scope;
   # sections go below it where each [header] resets scope naturally.
+  # Note: grep '^\[' may also match a bare '[' at the start of a multi-line array
+  # literal; this is low risk for Codex configs which do not use that syntax.
   local user_bare="" user_sections=""
   if [ -n "$${user_content}" ]; then
-    local first_section
-    first_section=$(printf '%s\n' "$${user_content}" | grep -n '^\[' | head -1 | cut -d: -f1)
-    if [ -n "$${first_section}" ]; then
-      user_bare=$(printf '%s\n' "$${user_content}" | head -n "$((first_section - 1))")
-      user_sections=$(printf '%s\n' "$${user_content}" | tail -n "+$${first_section}")
+    local first_section_lineno prev
+    first_section_lineno=$(printf '%s\n' "$${user_content}" | grep -n '^\[' | head -1 | cut -d: -f1)
+    if [ -n "$${first_section_lineno}" ]; then
+      # Walk backward past comment and blank lines so they stay
+      # attached to the section below rather than split into user_bare.
+      while [ "$${first_section_lineno}" -gt 1 ]; do
+        prev=$(printf '%s\n' "$${user_content}" | sed -n "$((first_section_lineno - 1))p")
+        case "$${prev}" in
+          '#'*|'') first_section_lineno=$((first_section_lineno - 1)) ;;
+          *) break ;;
+        esac
+      done
+      user_bare=$(printf '%s\n' "$${user_content}" | head -n "$((first_section_lineno - 1))")
+      user_sections=$(printf '%s\n' "$${user_content}" | tail -n "+$${first_section_lineno}")
       # Trim trailing blank lines from bare portion.
       user_bare=$(printf '%s' "$${user_bare}" | sed -e :x -e '/^\n*$/{ $d; N; bx; }')
     else
@@ -206,8 +230,7 @@ function populate_config_toml() {
   #   user bare keys  (root scope)
   #   managed block   (bare keys first, then [sections])
   #   user sections   (each [header] resets scope)
-  local tmp
-  tmp=$(mktemp "$${config_path}.XXXXXX")
+  config_tmp=$(mktemp "$${config_path}.XXXXXX")
   {
     if [ -n "$${user_bare}" ]; then
       printf '%s\n\n' "$${user_bare}"
@@ -218,7 +241,7 @@ function populate_config_toml() {
     if [ -n "$${user_sections}" ]; then
       printf '\n%s\n' "$${user_sections}"
     fi
-  } > "$${tmp}" && mv "$${tmp}" "$${config_path}"
+  } > "$${config_tmp}" && mv "$${config_tmp}" "$${config_path}"
   rm -f "$${managed}"
 }
 

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -166,6 +166,7 @@ function populate_config_toml() {
   fi
 
   # Preserve user content from the existing config.
+  # On the first run (no markers), the file is overwritten fresh.
   local user_content=""
   if [ -s "$${config_path}" ]; then
     if grep -qF "$${MANAGED_START}" "$${config_path}"; then
@@ -179,9 +180,6 @@ function populate_config_toml() {
         printf "Warning: codex config has managed-block start marker but no end marker; treating entire file as user content\n"
         user_content=$(cat "$${config_path}")
       fi
-    else
-      # No markers (pre-upgrade or hand-written config). Treat the whole file as user content.
-      user_content=$(cat "$${config_path}")
     fi
     # Trim leading blank lines.
     user_content=$(printf '%s' "$${user_content}" | sed '/./,$!d')
@@ -201,27 +199,6 @@ function populate_config_toml() {
       user_bare=$(printf '%s' "$${user_bare}" | sed -e :x -e '/^\n*$/{ $d; N; bx; }')
     else
       user_bare="$${user_content}"
-    fi
-  fi
-
-  # Drop user bare keys that also appear in the managed block to prevent TOML
-  # duplicate-key errors (the TOML spec forbids duplicate keys at the same scope).
-  # This occurs during pre-marker upgrades when the legacy config already contained
-  # a key the managed block emits (e.g. preferred_auth_method).
-  if [ -n "$${user_bare}" ]; then
-    local managed_keys
-    managed_keys=$(awk '/^\[/{exit} /^[a-zA-Z_]/{sub(/[[:space:]]*=.*/,""); print}' "$${managed}")
-    if [ -n "$${managed_keys}" ]; then
-      user_bare=$(printf '%s\n' "$${user_bare}" | while IFS= read -r line; do
-        local line_key
-        line_key=$(printf '%s' "$${line}" | sed -n 's/^[[:space:]]*\([a-zA-Z_][a-zA-Z0-9_-]*\)[[:space:]]*=.*/\1/p')
-        if [ -n "$${line_key}" ] && printf '%s\n' "$${managed_keys}" | grep -qxF "$${line_key}"; then
-          : # Key exists in the managed block; omit to avoid a duplicate-key error.
-        else
-          printf '%s\n' "$${line}"
-        fi
-      done)
-      user_bare=$(printf '%s' "$${user_bare}" | sed -e :x -e '/^\n*$/{ $d; N; bx; }')
     fi
   fi
 

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -176,70 +176,43 @@ function populate_config_toml() {
   fi
 
   # Preserve user content from the existing config.
-  # On the first run (no markers), the file is overwritten fresh.
-  local existing_config="" user_content=""
+  # user_before = everything before MANAGED_START
+  # user_after  = everything after MANAGED_END
+  # On the first run (no markers), both are empty and the file is written fresh.
+  local existing_config="" user_before="" user_after=""
   if [ -s "$${config_path}" ]; then
     existing_config=$(cat "$${config_path}")
   fi
   if [ -n "$${existing_config}" ]; then
     if printf '%s\n' "$${existing_config}" | grep -qF "$${MANAGED_START}"; then
       if printf '%s\n' "$${existing_config}" | grep -qF "$${MANAGED_END}"; then
-        # Strip the managed block; everything else is user content.
-        user_content=$(printf '%s\n' "$${existing_config}" | sed '/# >>> coder-managed: codex module >>>/,/# <<< coder-managed: codex module <<</d')
+        user_before=$(printf '%s\n' "$${existing_config}" | awk -v m="$${MANAGED_START}" '$0==m{exit} {print}')
+        user_after=$(printf '%s\n' "$${existing_config}" | awk -v m="$${MANAGED_END}" 'found{print} $0==m{found=1}')
+        user_before=$(printf '%s\n' "$${user_before}" | sed '/./,$!d')
+        user_after=$(printf '%s\n' "$${user_after}" | sed '/./,$!d')
       else
         # Start marker present but end marker missing (file was truncated or hand-edited).
-        # Treat the entire file as user content to avoid silently deleting everything
-        # after the orphaned start marker.
+        # Treat everything as user_before to avoid silently deleting data.
         printf "Warning: codex config has managed-block start marker but no end marker; treating entire file as user content\n"
-        user_content="$${existing_config}"
+        user_before="$${existing_config}"
       fi
-    fi
-    # Trim leading blank lines.
-    user_content=$(printf '%s' "$${user_content}" | sed '/./,$!d')
-  fi
-
-  # Split user content into bare keys (before any [section]) and sections.
-  # Bare keys go above the managed block so they stay at TOML root scope;
-  # sections go below it where each [header] resets scope naturally.
-  # Note: grep '^\[' may also match a bare '[' at the start of a multi-line array
-  # literal; this is low risk for Codex configs which do not use that syntax.
-  local user_bare="" user_sections=""
-  if [ -n "$${user_content}" ]; then
-    local first_section_lineno prev
-    first_section_lineno=$(printf '%s\n' "$${user_content}" | grep -n '^\[' | head -1 | cut -d: -f1)
-    if [ -n "$${first_section_lineno}" ]; then
-      # Walk backward past comment and blank lines so they stay
-      # attached to the section below rather than split into user_bare.
-      while [ "$${first_section_lineno}" -gt 1 ]; do
-        prev=$(printf '%s\n' "$${user_content}" | sed -n "$((first_section_lineno - 1))p")
-        case "$${prev}" in
-          '#'*) first_section_lineno=$((first_section_lineno - 1)) ;;
-          *) break ;;
-        esac
-      done
-      user_bare=$(printf '%s\n' "$${user_content}" | head -n "$((first_section_lineno - 1))")
-      user_sections=$(printf '%s\n' "$${user_content}" | tail -n "+$${first_section_lineno}")
-      # Trim trailing blank lines from bare portion.
-      user_bare=$(printf '%s' "$${user_bare}" | sed -e :x -e '/^\n*$/{ $d; N; bx; }')
-    else
-      user_bare="$${user_content}"
     fi
   fi
 
   # Assemble final config atomically:
-  #   user bare keys  (root scope)
-  #   managed block   (bare keys first, then [sections])
-  #   user sections   (each [header] resets scope)
+  #   user_before  (content that was before the managed block)
+  #   managed block
+  #   user_after   (content that was after the managed block)
   config_tmp=$(mktemp "$${config_path}.XXXXXX")
   {
-    if [ -n "$${user_bare}" ]; then
-      printf '%s\n\n' "$${user_bare}"
+    if [ -n "$${user_before}" ]; then
+      printf '%s\n\n' "$${user_before}"
     fi
     printf '%s\n' "$${MANAGED_START}"
     cat "$${managed}"
     printf '%s\n' "$${MANAGED_END}"
-    if [ -n "$${user_sections}" ]; then
-      printf '\n%s\n' "$${user_sections}"
+    if [ -n "$${user_after}" ]; then
+      printf '\n%s\n' "$${user_after}"
     fi
   } > "$${config_tmp}" && mv "$${config_tmp}" "$${config_path}"
   rm -f "$${managed}"

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -26,6 +26,40 @@ printf "install_codex: %s\n" "$${ARG_INSTALL}"
 printf "model_reasoning_effort: %s\n" "$${ARG_MODEL_REASONING_EFFORT}"
 echo "--------------------------------"
 
+
+function install_dasel() {
+  if command_exists dasel; then
+    return 0
+  fi
+
+  local os arch install_dir url
+  os=$$(uname -s | tr '[:upper:]' '[:lower:]')
+  arch=$$(uname -m)
+  case "$${arch}" in
+    x86_64)        arch="amd64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    *)
+      printf "Error: unsupported architecture %s\n" "$${arch}" >&2
+      return 1
+      ;;
+  esac
+
+  install_dir="$${CODER_SCRIPT_BIN_DIR:-$$HOME/.local/bin}"
+  mkdir -p "$${install_dir}"
+
+  url="https://github.com/TomWright/dasel/releases/download/v3.4.0/dasel_$${os}_$${arch}"
+  printf "Installing dasel from %s\n" "$${url}"
+  if curl -fsSL "$${url}" -o "$${install_dir}/dasel" && chmod +x "$${install_dir}/dasel"; then
+    export PATH="$${install_dir}:$$PATH"
+    printf "Installed %s\n" "$$(dasel --version)"
+  else
+    printf "Error: failed to download dasel\n" >&2
+    rm -f "$${install_dir}/dasel"
+    return 1
+  fi
+}
+
+
 function add_path_to_shell_profiles() {
   local path_dir="$1"
 
@@ -112,56 +146,63 @@ function install_codex() {
 }
 
 function write_minimal_default_config() {
-  local config_path="$1"
-  local optional_config=""
+  local config_path="$$1"
+  local optional_config='preferred_auth_method = "apikey"'
 
-  if [ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ]; then
-    optional_config='model_provider = "aigateway"'
+  if [[ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ]]; then
+    optional_config+=$$'\n''model_provider = "aigateway"'
   fi
 
-  if [ -n "$${ARG_MODEL_REASONING_EFFORT}" ]; then
-    optional_config+=$'\n'"model_reasoning_effort = \"$${ARG_MODEL_REASONING_EFFORT}\""
+  if [[ -n "$${ARG_MODEL_REASONING_EFFORT}" ]]; then
+    optional_config+=$$'\n'"model_reasoning_effort = \"$${ARG_MODEL_REASONING_EFFORT}\""
   fi
 
-  cat << EOF > "$${config_path}"
-preferred_auth_method = "apikey"
-$${optional_config}
-
-EOF
-
-  if [ -n "$${ARG_WORKDIR}" ]; then
-    cat << EOF >> "$${config_path}"
-[projects."$${ARG_WORKDIR}"]
-trust_level = "trusted"
-
-EOF
+  if [[ -n "$${ARG_WORKDIR}" ]]; then
+    optional_config+=$$'\n'"[projects.\"$${ARG_WORKDIR}\"]"
+    optional_config+=$$'\n''trust_level = "trusted"'
   fi
+
+  merge_tmp="$$(mktemp)"
+  echo "$${optional_config}" > "$${merge_tmp}"
+  dasel -i toml --root "merge(parse(\"toml\", readFile(\"$${merge_tmp}\")), \$root)" \
+    < "$${config_path}" > "$${config_path}.tmp" \
+    && mv "$${config_path}.tmp" "$${config_path}"
+  rm -f "$${merge_tmp}"
 }
 
 function populate_config_toml() {
   local config_path="$HOME/.codex/config.toml"
-  mkdir -p "$(dirname "$${config_path}")"
+  mkdir -p "$$(dirname "$${config_path}")"
 
-  if [ -n "$${ARG_BASE_CONFIG_TOML}" ]; then
-    printf "Using provided base configuration\n"
-    echo "$${ARG_BASE_CONFIG_TOML}" > "$${config_path}"
-  else
+  if [ ! -f "$${config_path}" ]; then
     printf "Using minimal default configuration\n"
     write_minimal_default_config "$${config_path}"
   fi
 
-  if [ -n "$${ARG_MCP}" ]; then
-    printf "Adding MCP servers\n"
-    echo "$${ARG_MCP}" >> "$${config_path}"
+  local merge_config=""
+
+  if [ -n "$${ARG_BASE_CONFIG_TOML}" ]; then
+    printf "Using provided base configuration\n"
+    merge_config+="$${ARG_BASE_CONFIG_TOML}"
   fi
 
-  if [ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ] && [ -n "$${ARG_AIBRIDGE_CONFIG}" ]; then
-    if ! grep -q '\[model_providers\.aigateway\]' "$${config_path}" 2>/dev/null; then
-      printf "Adding AI Gateway configuration\n"
-      echo -e "\n$${ARG_AIBRIDGE_CONFIG}" >> "$${config_path}"
-    else
-      printf "AI Gateway provider already defined in config, skipping append\n"
-    fi
+  if [ -n "$${ARG_MCP}" ]; then
+    printf "Adding MCP servers\n"
+    merge_config+=$$'\n'"$${ARG_MCP}"
+  fi
+
+  if [[ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ]] && [[ -n "$${ARG_AIBRIDGE_CONFIG}" ]]; then
+    printf "Adding AI Gateway configuration\n"
+    merge_config+=$$'\n'"$${ARG_AIBRIDGE_CONFIG}"
+  fi
+
+  if [ -n "$${merge_config}" ]; then
+    merge_tmp="$$(mktemp)"
+    echo "$${merge_config}" > "$${merge_tmp}"
+    dasel -i toml --root "merge(parse(\"toml\", readFile(\"$${merge_tmp}\")), \$root)" \
+      < "$${config_path}" > "$${config_path}.tmp" \
+      && mv "$${config_path}.tmp" "$${config_path}"
+    rm -f "$${merge_tmp}"
   fi
 }
 
@@ -190,6 +231,7 @@ EOF
 }
 
 install_codex
+install_dasel
 populate_config_toml
 setup_workdir
 add_auth_json

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -196,7 +196,7 @@ function populate_config_toml() {
       user_bare=$(printf '%s\n' "$${user_content}" | head -n "$((first_section - 1))")
       user_sections=$(printf '%s\n' "$${user_content}" | tail -n "+$${first_section}")
       # Trim trailing blank lines from bare portion.
-      user_bare=$(printf '%s' "$${user_bare}" | sed -e :a -e '/^\n*$/{ $d; N; ba; }')
+      user_bare=$(printf '%s' "$${user_bare}" | sed -e :x -e '/^\n*$/{ $d; N; bx; }')
     else
       user_bare="$${user_content}"
     fi

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -51,7 +51,7 @@ function install_dasel() {
   printf "Installing dasel from %s\n" "$${url}"
   if curl -fsSL "$${url}" -o "$${install_dir}/dasel" && chmod +x "$${install_dir}/dasel"; then
     export PATH="$${install_dir}:$PATH"
-    printf "Installed %s\n" "$(dasel --version)"
+    printf "Installed %s\n" "$(dasel version)"
   else
     printf "Error: failed to download dasel\n" >&2
     rm -f "$${install_dir}/dasel"
@@ -179,6 +179,8 @@ function write_minimal_default_config() {
     optional_config+=$'\n'"[projects.\"$${ARG_WORKDIR}\"]"
     optional_config+=$'\n''trust_level = "trusted"'
   fi
+
+  echo "OPTIONAL CONFIG: $${optional_config}"
 
   merge_toml_config "$${config_path}" "$${optional_config}"
 }

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -157,7 +157,7 @@ function merge_toml_config() {
   local merge_tmp
   merge_tmp="$(mktemp)"
   echo "$${content}" > "$${merge_tmp}"
-  dasel -i toml --root "merge(parse(\"toml\", readFile(\"$${merge_tmp}\")), \$root)" \
+  dasel -i toml -o toml "{parse(\"toml\", readFile(\"$${merge_tmp}\"))..., \$root...}" \
     < "$${config_path}" > "$${config_path}.tmp" \
     && mv "$${config_path}.tmp" "$${config_path}"
   rm -f "$${merge_tmp}"

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -169,8 +169,16 @@ function populate_config_toml() {
   local user_content=""
   if [ -s "$${config_path}" ]; then
     if grep -qF "$${MANAGED_START}" "$${config_path}"; then
-      # Strip the managed block; everything else is user content.
-      user_content=$(sed '/# >>> coder-managed: codex module >>>/,/# <<< coder-managed: codex module <<</d' "$${config_path}")
+      if grep -qF "$${MANAGED_END}" "$${config_path}"; then
+        # Strip the managed block; everything else is user content.
+        user_content=$(sed '/# >>> coder-managed: codex module >>>/,/# <<< coder-managed: codex module <<</d' "$${config_path}")
+      else
+        # Start marker present but end marker missing (file was truncated or hand-edited).
+        # Treat the entire file as user content to avoid silently deleting everything
+        # after the orphaned start marker.
+        printf "Warning: codex config has managed-block start marker but no end marker; treating entire file as user content\n"
+        user_content=$(cat "$${config_path}")
+      fi
     else
       # No markers (pre-upgrade or hand-written config). Treat the whole file as user content.
       user_content=$(cat "$${config_path}")
@@ -193,6 +201,27 @@ function populate_config_toml() {
       user_bare=$(printf '%s' "$${user_bare}" | sed -e :x -e '/^\n*$/{ $d; N; bx; }')
     else
       user_bare="$${user_content}"
+    fi
+  fi
+
+  # Drop user bare keys that also appear in the managed block to prevent TOML
+  # duplicate-key errors (the TOML spec forbids duplicate keys at the same scope).
+  # This occurs during pre-marker upgrades when the legacy config already contained
+  # a key the managed block emits (e.g. preferred_auth_method).
+  if [ -n "$${user_bare}" ]; then
+    local managed_keys
+    managed_keys=$(awk '/^\[/{exit} /^[a-zA-Z_]/{sub(/[[:space:]]*=.*/,""); print}' "$${managed}")
+    if [ -n "$${managed_keys}" ]; then
+      user_bare=$(printf '%s\n' "$${user_bare}" | while IFS= read -r line; do
+        local line_key
+        line_key=$(printf '%s' "$${line}" | sed -n 's/^[[:space:]]*\([a-zA-Z_][a-zA-Z0-9_-]*\)[[:space:]]*=.*/\1/p')
+        if [ -n "$${line_key}" ] && printf '%s\n' "$${managed_keys}" | grep -qxF "$${line_key}"; then
+          : # Key exists in the managed block; omit to avoid a duplicate-key error.
+        else
+          printf '%s\n' "$${line}"
+        fi
+      done)
+      user_bare=$(printf '%s' "$${user_bare}" | sed -e :x -e '/^\n*$/{ $d; N; bx; }')
     fi
   fi
 

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -213,7 +213,7 @@ function populate_config_toml() {
       while [ "$${first_section_lineno}" -gt 1 ]; do
         prev=$(printf '%s\n' "$${user_content}" | sed -n "$((first_section_lineno - 1))p")
         case "$${prev}" in
-          '#'*|'') first_section_lineno=$((first_section_lineno - 1)) ;;
+          '#'*) first_section_lineno=$((first_section_lineno - 1)) ;;
           *) break ;;
         esac
       done

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -33,8 +33,8 @@ function install_dasel() {
   fi
 
   local os arch install_dir url
-  os=$$(uname -s | tr '[:upper:]' '[:lower:]')
-  arch=$$(uname -m)
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  arch=$(uname -m)
   case "$${arch}" in
     x86_64)        arch="amd64" ;;
     aarch64|arm64) arch="arm64" ;;
@@ -44,14 +44,14 @@ function install_dasel() {
       ;;
   esac
 
-  install_dir="$${CODER_SCRIPT_BIN_DIR:-$$HOME/.local/bin}"
+  install_dir="$${CODER_SCRIPT_BIN_DIR:-$HOME/.local/bin}"
   mkdir -p "$${install_dir}"
 
   url="https://github.com/TomWright/dasel/releases/download/v3.4.0/dasel_$${os}_$${arch}"
   printf "Installing dasel from %s\n" "$${url}"
   if curl -fsSL "$${url}" -o "$${install_dir}/dasel" && chmod +x "$${install_dir}/dasel"; then
-    export PATH="$${install_dir}:$$PATH"
-    printf "Installed %s\n" "$$(dasel --version)"
+    export PATH="$${install_dir}:$PATH"
+    printf "Installed %s\n" "$(dasel --version)"
   else
     printf "Error: failed to download dasel\n" >&2
     rm -f "$${install_dir}/dasel"
@@ -146,23 +146,23 @@ function install_codex() {
 }
 
 function write_minimal_default_config() {
-  local config_path="$$1"
+  local config_path="$1"
   local optional_config='preferred_auth_method = "apikey"'
 
   if [[ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ]]; then
-    optional_config+=$$'\n''model_provider = "aigateway"'
+    optional_config+=$'\n''model_provider = "aigateway"'
   fi
 
   if [[ -n "$${ARG_MODEL_REASONING_EFFORT}" ]]; then
-    optional_config+=$$'\n'"model_reasoning_effort = \"$${ARG_MODEL_REASONING_EFFORT}\""
+    optional_config+=$'\n'"model_reasoning_effort = \"$${ARG_MODEL_REASONING_EFFORT}\""
   fi
 
   if [[ -n "$${ARG_WORKDIR}" ]]; then
-    optional_config+=$$'\n'"[projects.\"$${ARG_WORKDIR}\"]"
-    optional_config+=$$'\n''trust_level = "trusted"'
+    optional_config+=$'\n'"[projects.\"$${ARG_WORKDIR}\"]"
+    optional_config+=$'\n''trust_level = "trusted"'
   fi
 
-  merge_tmp="$$(mktemp)"
+  merge_tmp="$(mktemp)"
   echo "$${optional_config}" > "$${merge_tmp}"
   dasel -i toml --root "merge(parse(\"toml\", readFile(\"$${merge_tmp}\")), \$root)" \
     < "$${config_path}" > "$${config_path}.tmp" \
@@ -172,7 +172,7 @@ function write_minimal_default_config() {
 
 function populate_config_toml() {
   local config_path="$HOME/.codex/config.toml"
-  mkdir -p "$$(dirname "$${config_path}")"
+  mkdir -p "$(dirname "$${config_path}")"
 
   if [ ! -f "$${config_path}" ]; then
     printf "Using minimal default configuration\n"
@@ -188,16 +188,16 @@ function populate_config_toml() {
 
   if [ -n "$${ARG_MCP}" ]; then
     printf "Adding MCP servers\n"
-    merge_config+=$$'\n'"$${ARG_MCP}"
+    merge_config+=$'\n'"$${ARG_MCP}"
   fi
 
   if [[ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ]] && [[ -n "$${ARG_AIBRIDGE_CONFIG}" ]]; then
     printf "Adding AI Gateway configuration\n"
-    merge_config+=$$'\n'"$${ARG_AIBRIDGE_CONFIG}"
+    merge_config+=$'\n'"$${ARG_AIBRIDGE_CONFIG}"
   fi
 
   if [ -n "$${merge_config}" ]; then
-    merge_tmp="$$(mktemp)"
+    merge_tmp="$(mktemp)"
     echo "$${merge_config}" > "$${merge_tmp}"
     dasel -i toml --root "merge(parse(\"toml\", readFile(\"$${merge_tmp}\")), \$root)" \
       < "$${config_path}" > "$${config_path}.tmp" \

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -154,13 +154,19 @@ function merge_toml_config() {
     return
   fi
 
-  local merge_tmp
-  merge_tmp="$(mktemp)"
+  local merge_tmp existing_json new_json
+  merge_tmp=$(mktemp)
+  existing_json=$(mktemp)
+  new_json=$(mktemp)
   echo "$${content}" > "$${merge_tmp}"
-  dasel -i toml -o toml "{parse(\"toml\", readFile(\"$${merge_tmp}\"))..., \$root...}" \
-    < "$${config_path}" > "$${config_path}.tmp" \
+
+  dasel -i toml -o json < "$${config_path}" > "$${existing_json}"
+  dasel -i toml -o json < "$${merge_tmp}" > "$${new_json}"
+
+  jq -s '.[0] * .[1]' "$${new_json}" "$${existing_json}" \
+    | dasel -i json -o toml > "$${config_path}.tmp" \
     && mv "$${config_path}.tmp" "$${config_path}"
-  rm -f "$${merge_tmp}"
+  rm -f "$${merge_tmp}" "$${existing_json}" "$${new_json}"
 }
 
 function write_minimal_default_config() {

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -26,38 +26,6 @@ printf "install_codex: %s\n" "$${ARG_INSTALL}"
 printf "model_reasoning_effort: %s\n" "$${ARG_MODEL_REASONING_EFFORT}"
 echo "--------------------------------"
 
-function install_dasel() {
-  if command_exists dasel; then
-    return 0
-  fi
-
-  local os arch install_dir url
-  os=$(uname -s | tr '[:upper:]' '[:lower:]')
-  arch=$(uname -m)
-  case "$${arch}" in
-    x86_64)        arch="amd64" ;;
-    aarch64|arm64) arch="arm64" ;;
-    *)
-      printf "Error: unsupported architecture %s\n" "$${arch}" >&2
-      return 1
-      ;;
-  esac
-
-  install_dir="$${CODER_SCRIPT_BIN_DIR:-$HOME/.local/bin}"
-  mkdir -p "$${install_dir}"
-
-  url="https://github.com/TomWright/dasel/releases/download/v3.4.0/dasel_$${os}_$${arch}"
-  printf "Installing dasel from %s\n" "$${url}"
-  if curl -fsSL "$${url}" -o "$${install_dir}/dasel" && chmod +x "$${install_dir}/dasel"; then
-    export PATH="$${install_dir}:$PATH"
-    printf "Installed %s\n" "$(dasel version)"
-  else
-    printf "Error: failed to download dasel\n" >&2
-    rm -f "$${install_dir}/dasel"
-    return 1
-  fi
-}
-
 function add_path_to_shell_profiles() {
   local path_dir="$1"
 
@@ -143,69 +111,86 @@ function install_codex() {
   ensure_codex_in_path
 }
 
-# Builds the minimal default config as a JSON string on stdout.
-function build_minimal_default_config() {
-  local json
-  json=$(jq -n '{preferred_auth_method: "apikey"}')
+function write_minimal_default_config() {
+  local config_path="$1"
+  local optional_config=""
 
   if [ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ]; then
-    json=$(echo "$${json}" | jq '.model_provider = "aigateway"')
+    optional_config='model_provider = "aigateway"'
   fi
 
   if [ -n "$${ARG_MODEL_REASONING_EFFORT}" ]; then
-    json=$(echo "$${json}" | jq --arg v "$${ARG_MODEL_REASONING_EFFORT}" '.model_reasoning_effort = $v')
+    optional_config+=$'\n'"model_reasoning_effort = \"$${ARG_MODEL_REASONING_EFFORT}\""
   fi
+
+  cat << EOF > "$${config_path}"
+preferred_auth_method = "apikey"
+$${optional_config}
+
+EOF
 
   if [ -n "$${ARG_WORKDIR}" ]; then
-    json=$(echo "$${json}" | jq --arg w "$${ARG_WORKDIR}" '.projects[$w].trust_level = "trusted"')
-  fi
+    cat << EOF >> "$${config_path}"
+[projects."$${ARG_WORKDIR}"]
+trust_level = "trusted"
 
-  echo "$${json}"
+EOF
+  fi
 }
 
 function populate_config_toml() {
   local config_path="$HOME/.codex/config.toml"
   mkdir -p "$(dirname "$${config_path}")"
 
-  # Build the new config entirely in JSON.
-  local new_json
+  local MANAGED_START="# >>> coder-managed: codex module >>>"
+  local MANAGED_END="# <<< coder-managed: codex module <<<"
+
+  # Build managed-block content in a temp file.
+  local managed
+  managed=$(mktemp)
 
   if [ -n "$${ARG_BASE_CONFIG_TOML}" ]; then
     printf "Using provided base configuration\n"
-    new_json=$(echo "$${ARG_BASE_CONFIG_TOML}" | dasel -i toml -o json)
+    printf '%s\n' "$${ARG_BASE_CONFIG_TOML}" > "$${managed}"
   else
     printf "Using minimal default configuration\n"
-    new_json=$(build_minimal_default_config)
+    write_minimal_default_config "$${managed}"
   fi
 
   if [ -n "$${ARG_MCP}" ]; then
     printf "Adding MCP servers\n"
-    local mcp_json
-    mcp_json=$(echo "$${ARG_MCP}" | dasel -i toml -o json)
-    new_json=$(echo "$${mcp_json}" "$${new_json}" | jq -s '.[0] * .[1]')
+    printf '%s\n' "$${ARG_MCP}" >> "$${managed}"
   fi
 
   if [ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ] && [ -n "$${ARG_AIBRIDGE_CONFIG}" ]; then
-    printf "Adding AI Gateway configuration\n"
-    local aibridge_json
-    aibridge_json=$(echo "$${ARG_AIBRIDGE_CONFIG}" | dasel -i toml -o json)
-    new_json=$(echo "$${aibridge_json}" "$${new_json}" | jq -s '.[0] * .[1]')
-  fi
-
-  # Deep-merge with existing config (existing user values win).
-  if [ -s "$${config_path}" ]; then
-    local existing_json
-    if ! existing_json=$(dasel -i toml -o json < "$${config_path}" 2>/dev/null); then
-      printf "Error: existing %s contains invalid TOML, cannot merge\n" "$${config_path}" >&2
-      exit 1
+    if ! grep -q '\[model_providers\.aigateway\]' "$${managed}" 2>/dev/null; then
+      printf "Adding AI Gateway configuration\n"
+      printf '\n%s\n' "$${ARG_AIBRIDGE_CONFIG}" >> "$${managed}"
+    else
+      printf "AI Gateway provider already defined in config, skipping append\n"
     fi
-    new_json=$(echo "$${new_json}" "$${existing_json}" | jq -s '.[0] * .[1]')
   fi
 
-  # Single conversion: JSON to TOML (atomic via temp file).
+  # Preserve user content outside the managed block from the existing config.
+  local user_content=""
+  if [ -s "$${config_path}" ] && grep -qF "$${MANAGED_START}" "$${config_path}"; then
+    user_content=$(sed '/# >>> coder-managed: codex module >>>/,/# <<< coder-managed: codex module <<</d' "$${config_path}")
+    # Trim leading blank lines.
+    user_content=$(printf '%s' "$${user_content}" | sed '/./,$!d')
+  fi
+
+  # Assemble final config atomically: managed block, then user content.
   local tmp
   tmp=$(mktemp "$${config_path}.XXXXXX")
-  echo "$${new_json}" | dasel -i json -o toml > "$${tmp}" && mv "$${tmp}" "$${config_path}"
+  {
+    printf '%s\n' "$${MANAGED_START}"
+    cat "$${managed}"
+    printf '%s\n' "$${MANAGED_END}"
+    if [ -n "$${user_content}" ]; then
+      printf '\n%s\n' "$${user_content}"
+    fi
+  } > "$${tmp}" && mv "$${tmp}" "$${config_path}"
+  rm -f "$${managed}"
 }
 
 function setup_workdir() {
@@ -233,11 +218,6 @@ EOF
 }
 
 install_codex
-install_dasel
-if ! command_exists jq; then
-  printf "Error: jq is required but not installed.\n" >&2
-  exit 1
-fi
 populate_config_toml
 setup_workdir
 add_auth_json

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -145,78 +145,64 @@ function install_codex() {
   ensure_codex_in_path
 }
 
-function merge_toml_config() {
-  local config_path="$1"
-  local content="$2"
-
-  if [ ! -s "$${config_path}" ]; then
-    echo "$${content}" > "$${config_path}"
-    return
-  fi
-
-  local merge_tmp existing_json new_json
-  merge_tmp=$(mktemp)
-  existing_json=$(mktemp)
-  new_json=$(mktemp)
-  echo "$${content}" > "$${merge_tmp}"
-
-  dasel -i toml -o json < "$${config_path}" > "$${existing_json}"
-  dasel -i toml -o json < "$${merge_tmp}" > "$${new_json}"
-
-  jq -s '.[0] * .[1]' "$${new_json}" "$${existing_json}" \
-    | dasel -i json -o toml > "$${config_path}.tmp" \
-    && mv "$${config_path}.tmp" "$${config_path}"
-  rm -f "$${merge_tmp}" "$${existing_json}" "$${new_json}"
-}
-
+# Builds the minimal default config as a JSON string on stdout.
 function write_minimal_default_config() {
-  local config_path="$1"
-  local optional_config='preferred_auth_method = "apikey"'
+  local json
+  json=$(jq -n '{preferred_auth_method: "apikey"}')
 
-  if [[ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ]]; then
-    optional_config+=$'\n''model_provider = "aigateway"'
+  if [ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ]; then
+    json=$(echo "$${json}" | jq '.model_provider = "aigateway"')
   fi
 
-  if [[ -n "$${ARG_MODEL_REASONING_EFFORT}" ]]; then
-    optional_config+=$'\n'"model_reasoning_effort = \"$${ARG_MODEL_REASONING_EFFORT}\""
+  if [ -n "$${ARG_MODEL_REASONING_EFFORT}" ]; then
+    json=$(echo "$${json}" | jq --arg v "$${ARG_MODEL_REASONING_EFFORT}" '.model_reasoning_effort = $v')
   fi
 
-  if [[ -n "$${ARG_WORKDIR}" ]]; then
-    optional_config+=$'\n'"[projects.\"$${ARG_WORKDIR}\"]"
-    optional_config+=$'\n''trust_level = "trusted"'
+  if [ -n "$${ARG_WORKDIR}" ]; then
+    json=$(echo "$${json}" | jq --arg w "$${ARG_WORKDIR}" '.projects[$w].trust_level = "trusted"')
   fi
 
-  merge_toml_config "$${config_path}" "$${optional_config}"
+  echo "$${json}"
 }
 
 function populate_config_toml() {
   local config_path="$HOME/.codex/config.toml"
   mkdir -p "$(dirname "$${config_path}")"
-  touch "$${config_path}"
+
+  # Build the new config entirely in JSON.
+  local new_json
 
   if [ -n "$${ARG_BASE_CONFIG_TOML}" ]; then
     printf "Using provided base configuration\n"
-    merge_toml_config "$${config_path}" "$${ARG_BASE_CONFIG_TOML}"
+    new_json=$(echo "$${ARG_BASE_CONFIG_TOML}" | dasel -i toml -o json)
   else
     printf "Using minimal default configuration\n"
-    write_minimal_default_config "$${config_path}"
+    new_json=$(write_minimal_default_config)
   fi
-
-  local merge_config=""
 
   if [ -n "$${ARG_MCP}" ]; then
     printf "Adding MCP servers\n"
-    merge_config+="$${ARG_MCP}"
+    local mcp_json
+    mcp_json=$(echo "$${ARG_MCP}" | dasel -i toml -o json)
+    new_json=$(echo "$${mcp_json}" "$${new_json}" | jq -s '.[0] * .[1]')
   fi
 
-  if [[ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ]] && [[ -n "$${ARG_AIBRIDGE_CONFIG}" ]]; then
+  if [ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ] && [ -n "$${ARG_AIBRIDGE_CONFIG}" ]; then
     printf "Adding AI Gateway configuration\n"
-    merge_config+=$'\n'"$${ARG_AIBRIDGE_CONFIG}"
+    local aibridge_json
+    aibridge_json=$(echo "$${ARG_AIBRIDGE_CONFIG}" | dasel -i toml -o json)
+    new_json=$(echo "$${aibridge_json}" "$${new_json}" | jq -s '.[0] * .[1]')
   fi
 
-  if [ -n "$${merge_config}" ]; then
-    merge_toml_config "$${config_path}" "$${merge_config}"
+  # Deep-merge with existing config (existing user values win).
+  if [ -s "$${config_path}" ]; then
+    local existing_json
+    existing_json=$(dasel -i toml -o json < "$${config_path}")
+    new_json=$(echo "$${new_json}" "$${existing_json}" | jq -s '.[0] * .[1]')
   fi
+
+  # Single conversion: JSON to TOML.
+  echo "$${new_json}" | dasel -i json -o toml > "$${config_path}"
 }
 function setup_workdir() {
   if [ -n "$${ARG_WORKDIR}" ] && [ ! -d "$${ARG_WORKDIR}" ]; then

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -179,15 +179,38 @@ function populate_config_toml() {
     user_content=$(printf '%s' "$${user_content}" | sed '/./,$!d')
   fi
 
-  # Assemble final config atomically: managed block, then user content.
+  # Split user content into bare keys (before any [section]) and sections.
+  # Bare keys go above the managed block so they stay at TOML root scope;
+  # sections go below it where each [header] resets scope naturally.
+  local user_bare="" user_sections=""
+  if [ -n "$${user_content}" ]; then
+    local first_section
+    first_section=$(printf '%s\n' "$${user_content}" | grep -n '^\[' | head -1 | cut -d: -f1)
+    if [ -n "$${first_section}" ]; then
+      user_bare=$(printf '%s\n' "$${user_content}" | head -n "$((first_section - 1))")
+      user_sections=$(printf '%s\n' "$${user_content}" | tail -n "+$${first_section}")
+      # Trim trailing blank lines from bare portion.
+      user_bare=$(printf '%s' "$${user_bare}" | sed -e :a -e '/^\n*$/{ $d; N; ba; }')
+    else
+      user_bare="$${user_content}"
+    fi
+  fi
+
+  # Assemble final config atomically:
+  #   user bare keys  (root scope)
+  #   managed block   (bare keys first, then [sections])
+  #   user sections   (each [header] resets scope)
   local tmp
   tmp=$(mktemp "$${config_path}.XXXXXX")
   {
+    if [ -n "$${user_bare}" ]; then
+      printf '%s\n\n' "$${user_bare}"
+    fi
     printf '%s\n' "$${MANAGED_START}"
     cat "$${managed}"
     printf '%s\n' "$${MANAGED_END}"
-    if [ -n "$${user_content}" ]; then
-      printf '\n%s\n' "$${user_content}"
+    if [ -n "$${user_sections}" ]; then
+      printf '\n%s\n' "$${user_sections}"
     fi
   } > "$${tmp}" && mv "$${tmp}" "$${config_path}"
   rm -f "$${managed}"

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -142,7 +142,7 @@ function populate_config_toml() {
   # Reject inputs that contain the managed-block markers to prevent embedding
   # spurious markers that would corrupt the block structure on subsequent runs.
   for _arg in "$${ARG_BASE_CONFIG_TOML}" "$${ARG_MCP}"; do
-    if [ -n "$${_arg}" ] && printf '%s' "$${_arg}" | grep -qF "$${MANAGED_START}"; then
+    if [ -n "$${_arg}" ] && printf '%s' "$${_arg}" | grep -qF -e "$${MANAGED_START}" -e "$${MANAGED_END}"; then
       printf 'Error: a codex module input contains a managed-block marker; aborting.\n' >&2
       return 1
     fi

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -171,10 +171,16 @@ function populate_config_toml() {
     fi
   fi
 
-  # Preserve user content outside the managed block from the existing config.
+  # Preserve user content from the existing config.
   local user_content=""
-  if [ -s "$${config_path}" ] && grep -qF "$${MANAGED_START}" "$${config_path}"; then
-    user_content=$(sed '/# >>> coder-managed: codex module >>>/,/# <<< coder-managed: codex module <<</d' "$${config_path}")
+  if [ -s "$${config_path}" ]; then
+    if grep -qF "$${MANAGED_START}" "$${config_path}"; then
+      # Strip the managed block; everything else is user content.
+      user_content=$(sed '/# >>> coder-managed: codex module >>>/,/# <<< coder-managed: codex module <<</d' "$${config_path}")
+    else
+      # No markers (pre-upgrade or hand-written config). Treat the whole file as user content.
+      user_content=$(cat "$${config_path}")
+    fi
     # Trim leading blank lines.
     user_content=$(printf '%s' "$${user_content}" | sed '/./,$!d')
   fi

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -145,6 +145,24 @@ function install_codex() {
   ensure_codex_in_path
 }
 
+function merge_toml_config() {
+  local config_path="$1"
+  local content="$2"
+
+  if [ ! -s "$${config_path}" ]; then
+    echo "$${content}" > "$${config_path}"
+    return
+  fi
+
+  local merge_tmp
+  merge_tmp="$(mktemp)"
+  echo "$${content}" > "$${merge_tmp}"
+  dasel -i toml --root "merge(parse(\"toml\", readFile(\"$${merge_tmp}\")), \$root)" \
+    < "$${config_path}" > "$${config_path}.tmp" \
+    && mv "$${config_path}.tmp" "$${config_path}"
+  rm -f "$${merge_tmp}"
+}
+
 function write_minimal_default_config() {
   local config_path="$1"
   local optional_config='preferred_auth_method = "apikey"'
@@ -162,12 +180,7 @@ function write_minimal_default_config() {
     optional_config+=$'\n''trust_level = "trusted"'
   fi
 
-  merge_tmp="$(mktemp)"
-  echo "$${optional_config}" > "$${merge_tmp}"
-  dasel -i toml --root "merge(parse(\"toml\", readFile(\"$${merge_tmp}\")), \$root)" \
-    < "$${config_path}" > "$${config_path}.tmp" \
-    && mv "$${config_path}.tmp" "$${config_path}"
-  rm -f "$${merge_tmp}"
+  merge_toml_config "$${config_path}" "$${optional_config}"
 }
 
 function populate_config_toml() {
@@ -175,21 +188,19 @@ function populate_config_toml() {
   mkdir -p "$(dirname "$${config_path}")"
   touch "$${config_path}"
 
-  if [ ! -s "$${config_path}" ]; then
+  if [ -n "$${ARG_BASE_CONFIG_TOML}" ]; then
+    printf "Using provided base configuration\n"
+    merge_toml_config "$${config_path}" "$${ARG_BASE_CONFIG_TOML}"
+  else
     printf "Using minimal default configuration\n"
     write_minimal_default_config "$${config_path}"
   fi
 
   local merge_config=""
 
-  if [ -n "$${ARG_BASE_CONFIG_TOML}" ]; then
-    printf "Using provided base configuration\n"
-    merge_config+="$${ARG_BASE_CONFIG_TOML}"
-  fi
-
   if [ -n "$${ARG_MCP}" ]; then
     printf "Adding MCP servers\n"
-    merge_config+=$'\n'"$${ARG_MCP}"
+    merge_config+="$${ARG_MCP}"
   fi
 
   if [[ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ]] && [[ -n "$${ARG_AIBRIDGE_CONFIG}" ]]; then
@@ -198,15 +209,9 @@ function populate_config_toml() {
   fi
 
   if [ -n "$${merge_config}" ]; then
-    merge_tmp="$(mktemp)"
-    echo "$${merge_config}" > "$${merge_tmp}"
-    dasel -i toml --root "merge(parse(\"toml\", readFile(\"$${merge_tmp}\")), \$root)" \
-      < "$${config_path}" > "$${config_path}.tmp" \
-      && mv "$${config_path}.tmp" "$${config_path}"
-    rm -f "$${merge_tmp}"
+    merge_toml_config "$${config_path}" "$${merge_config}"
   fi
 }
-
 function setup_workdir() {
   if [ -n "$${ARG_WORKDIR}" ] && [ ! -d "$${ARG_WORKDIR}" ]; then
     echo "Creating workdir: $${ARG_WORKDIR}"

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -186,8 +186,6 @@ function write_minimal_default_config() {
     optional_config+=$'\n''trust_level = "trusted"'
   fi
 
-  echo "OPTIONAL CONFIG: $${optional_config}"
-
   merge_toml_config "$${config_path}" "$${optional_config}"
 }
 


### PR DESCRIPTION
## Description

Replace the destructive overwrite of `~/.codex/config.toml` with a marker-block merge. The module owns a fenced region of the file; everything outside the markers is user-owned and preserved across restarts.

```toml
# >>> coder-managed: codex module >>>
preferred_auth_method = "apikey"
[mcp_servers.github]
command = "npx"
# <<< coder-managed: codex module <<<
```

Sample Template: https://dev.coder.com/templates/product/codex-pr-896/docs


## Type of Change
- [ ] New module
- [ ] New template
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information
Path: `registry/coder-labs/modules/codex`
New version: v5.1.1

Breaking change: [ ] Yes [x] No

## Testing & Validation
- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun fmt`)
- [x] Changes tested locally

Closes: [REG-11](https://linear.app/codercom/issue/REG-11)