### PR TITLE
fix(coder-labs/codex): use dasel for idempotent config.toml writes

### DIFF
--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -111,52 +111,86 @@ function install_codex() {
   ensure_codex_in_path
 }
 
+function install_dasel() {
+  if command_exists dasel; then
+    return 0
+  fi
+
+  local os arch install_dir
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  arch=$(uname -m)
+  case "$${arch}" in
+    x86_64)        arch="amd64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    armv7l|armv6l) arch="arm32" ;;
+    i386|i686)     arch="386"   ;;
+    *)
+      printf "Error: unsupported architecture %s\n" "$${arch}" >&2
+      return 1
+      ;;
+  esac
+
+  install_dir="$${CODER_SCRIPT_BIN_DIR:-$HOME/.local/bin}"
+  mkdir -p "$${install_dir}"
+
+  local url="https://github.com/TomWright/dasel/releases/download/v2.8.1/dasel_$${os}_$${arch}"
+  printf "Installing dasel from %s\n" "$${url}"
+  if curl -fsSL "$${url}" -o "$${install_dir}/dasel" && chmod +x "$${install_dir}/dasel"; then
+    export PATH="$${install_dir}:$PATH"
+    printf "Installed %s\n" "$(dasel --version)"
+  else
+    printf "Error: failed to download dasel\n" >&2
+    rm -f "$${install_dir}/dasel"
+    return 1
+  fi
+}
+
 function write_minimal_default_config() {
   local config_path="$1"
-  local optional_config=""
+
+  dasel -f "$${config_path}" 'preferred_auth_method' > /dev/null 2>&1 || \
+    dasel put -f "$${config_path}" -t string -v 'apikey' 'preferred_auth_method'
 
   if [ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ]; then
-    optional_config='model_provider = "aigateway"'
+    dasel -f "$${config_path}" 'model_provider' > /dev/null 2>&1 || \
+      dasel put -f "$${config_path}" -t string -v 'aigateway' 'model_provider'
   fi
 
   if [ -n "$${ARG_MODEL_REASONING_EFFORT}" ]; then
-    optional_config+=$'\n'"model_reasoning_effort = \"$${ARG_MODEL_REASONING_EFFORT}\""
+    dasel -f "$${config_path}" 'model_reasoning_effort' > /dev/null 2>&1 || \
+      dasel put -f "$${config_path}" -t string -v "$${ARG_MODEL_REASONING_EFFORT}" 'model_reasoning_effort'
   fi
 
-  cat << EOF > "$${config_path}"
-preferred_auth_method = "apikey"
-$${optional_config}
-
-EOF
-
   if [ -n "$${ARG_WORKDIR}" ]; then
-    cat << EOF >> "$${config_path}"
-[projects."$${ARG_WORKDIR}"]
-trust_level = "trusted"
-
-EOF
+    dasel -f "$${config_path}" "projects.$${ARG_WORKDIR}.trust_level" > /dev/null 2>&1 || \
+      dasel put -f "$${config_path}" -t string -v 'trusted' "projects.$${ARG_WORKDIR}.trust_level"
   fi
 }
 
 function populate_config_toml() {
   local config_path="$HOME/.codex/config.toml"
   mkdir -p "$(dirname "$${config_path}")"
+  touch "$${config_path}"
 
   if [ -n "$${ARG_BASE_CONFIG_TOML}" ]; then
-    printf "Using provided base configuration\n"
-    echo "$${ARG_BASE_CONFIG_TOML}" > "$${config_path}"
+    if ! grep -qF "$${ARG_BASE_CONFIG_TOML%%$'\n'*}" "$${config_path}" 2>/dev/null; then
+      printf "Using provided base configuration\n"
+      printf '%s\n' "$${ARG_BASE_CONFIG_TOML}" >> "$${config_path}"
+    fi
   else
     printf "Using minimal default configuration\n"
     write_minimal_default_config "$${config_path}"
   fi
 
   if [ -n "$${ARG_MCP}" ]; then
-    printf "Adding MCP servers\n"
-    echo "$${ARG_MCP}" >> "$${config_path}"
+    if ! grep -qF "$${ARG_MCP%%$'\n'*}" "$${config_path}" 2>/dev/null; then
+      printf "Adding MCP servers\n"
+      echo "$${ARG_MCP}" >> "$${config_path}"
+    fi
   fi
 
   if [ "$${ARG_ENABLE_AI_GATEWAY}" = "true" ] && [ -n "$${ARG_AIBRIDGE_CONFIG}" ]; then
-    if ! grep -q '\[model_providers\.aigateway\]' "$${config_path}" 2>/dev/null; then
+    if ! dasel -f "$${config_path}" 'model_providers.aigateway' > /dev/null 2>&1; then
       printf "Adding AI Gateway configuration\n"
       echo -e "\n$${ARG_AIBRIDGE_CONFIG}" >> "$${config_path}"
     else
@@ -190,6 +224,7 @@ EOF
 }
 
 install_codex
+install_dasel
 populate_config_toml
 setup_workdir
 add_auth_json


### PR DESCRIPTION
## Problem

`~/.codex/config.toml` was unconditionally overwritten/appended on every workspace restart, wiping user edits to keys like `model_reasoning_effort`.

## Solution

Install **dasel v2.8.1** at startup and use it for all structured TOML key checks and writes.

### What changed

- **`install_dasel()`** — downloads `dasel_${os}_${arch}` from the v2.8.1 GitHub release, installs to `$CODER_SCRIPT_BIN_DIR` (or `~/.local/bin`), and exports to `$PATH`. Skips if already present. Supports linux/darwin × amd64/arm64/arm32/386.
- **`write_minimal_default_config()`** — replaces the grep-then-prepend approach with:
  ```bash
  dasel -f "$config_path" 'key' >/dev/null 2>&1 || dasel put -f "$config_path" -t string -v 'value' 'key'
  ```
  Each key is only written if absent, including the nested `projects.$WORKDIR.trust_level` table entry.
- **`populate_config_toml()`** — adds `touch` to ensure the file exists before dasel runs (dasel v2 requires the file to exist), and replaces the `grep -q '\[model_providers\.aigateway\]'` check with `dasel -f ... 'model_providers.aigateway'`.
- `ARG_BASE_CONFIG_TOML` and `ARG_MCP` blocks (arbitrary user TOML) continue to use a grep first-line check since their key structure is not known in advance.

### Why dasel v2, not v3

Dasel v3 (released Dec 2025) changed to a query-only language with no write support for new keys. v2.8.1 is the last release with `dasel put`.

<details>
<summary>Implementation plan / decision log</summary>

- Pinned to v2.8.1 to avoid the broken v3 API (`latest` now resolves to v3).
- Used `dasel select` exit-code pattern (exits 1 when key missing) as idempotency guard.
- Dasel v2 reformats TOML with sorted keys and single-quoted strings on first write — both are valid TOML; subsequent restarts do not re-write.
- `ARG_AIBRIDGE_CONFIG` raw block is still appended via `echo` since extracting individual values from the multi-line string would be fragile; dasel is used only for the existence check.

> Generated by Coder Agents
</details>