### PR TITLE
feat: add Windows RDP keepalive monitor

### DIFF
--- a/registry/coder/modules/windows-rdp/README.md
+++ b/registry/coder/modules/windows-rdp/README.md
@@ -59,3 +59,21 @@ module "windows_rdp" {
   devolutions_gateway_version = "2025.2.2" # Specify a specific version
 }
 ```
+
+### RDP Keepalive
+
+The module keeps the workspace active while an RDP session is connected by
+checking for established local RDP connections and extending the workspace
+deadline with the agent token.
+
+```tf
+module "windows_rdp" {
+  count                       = data.coder_workspace.me.start_count
+  source                      = "registry.coder.com/coder/windows-rdp/coder"
+  version                     = "1.3.0"
+  agent_id                    = coder_agent.main.id
+  keepalive_enabled           = true
+  keepalive_interval_seconds  = 60
+  keepalive_extension_minutes = 30
+}
+```

--- a/registry/coder/modules/windows-rdp/main.test.ts
+++ b/registry/coder/modules/windows-rdp/main.test.ts
@@ -11,6 +11,7 @@ type TestVariables = Readonly<{
   share?: string;
   admin_username?: string;
   admin_password?: string;
+  keepalive_interval_seconds?: number;
 }>;
 
 function findWindowsRdpScript(state: TerraformState): string | null {
@@ -127,5 +128,20 @@ describe("Web RDP", async () => {
 
     expect(customResultsGroup.username).toBe(customAdminUsername);
     expect(customResultsGroup.password).toBe(customAdminPassword);
+  });
+
+  it("Can install an RDP keepalive monitor", async () => {
+    const state = await runTerraformApply<TestVariables>(import.meta.dir, {
+      agent_id: "foo",
+      keepalive_interval_seconds: 30,
+    });
+
+    const rdpScript = findWindowsRdpScript(state);
+    expect(rdpScript).toBeString();
+    expect(rdpScript).toContain("Install-RDPKeepaliveMonitor");
+    expect(rdpScript).toContain("$keepaliveIntervalSeconds = 30");
+    expect(rdpScript).toContain("Get-NetTCPConnection");
+    expect(rdpScript).toContain("Invoke-CoderAgentActivity");
+    expect(rdpScript).toContain("CoderRdpKeepalive");
   });
 });

--- a/registry/coder/modules/windows-rdp/main.tf
+++ b/registry/coder/modules/windows-rdp/main.tf
@@ -70,6 +70,36 @@ variable "devolutions_gateway_version" {
   description = "Version of Devolutions Gateway to install. Use 'latest' for the most recent version, or specify a version like '2025.3.2'."
 }
 
+variable "keepalive_enabled" {
+  type        = bool
+  default     = true
+  description = "Whether to extend the workspace deadline while an RDP session is connected."
+}
+
+variable "keepalive_interval_seconds" {
+  type        = number
+  default     = 60
+  description = "How often to check for active RDP sessions."
+
+  validation {
+    condition     = var.keepalive_interval_seconds >= 10
+    error_message = "keepalive_interval_seconds must be at least 10 seconds."
+  }
+}
+
+variable "keepalive_extension_minutes" {
+  type        = number
+  default     = 30
+  description = "How far into the future to extend the workspace deadline when RDP is active."
+
+  validation {
+    condition     = var.keepalive_extension_minutes >= 1
+    error_message = "keepalive_extension_minutes must be at least 1 minute."
+  }
+}
+
+data "coder_workspace" "me" {}
+
 resource "coder_script" "windows-rdp" {
   agent_id     = var.agent_id
   display_name = "windows-rdp"
@@ -79,6 +109,10 @@ resource "coder_script" "windows-rdp" {
     admin_username              = var.admin_username
     admin_password              = var.admin_password
     devolutions_gateway_version = var.devolutions_gateway_version
+    keepalive_enabled           = var.keepalive_enabled
+    keepalive_interval_seconds  = var.keepalive_interval_seconds
+    keepalive_extension_minutes = var.keepalive_extension_minutes
+    workspace_id                = data.coder_workspace.me.id
 
     # Wanted to have this be in the powershell template file, but Terraform
     # doesn't allow recursive calls to the templatefile function. Have to feed

--- a/registry/coder/modules/windows-rdp/powershell-installation-script.tftpl
+++ b/registry/coder/modules/windows-rdp/powershell-installation-script.tftpl
@@ -125,7 +125,94 @@ if ($isPatched -eq $null) {
 }
 }
 
+function Install-RDPKeepaliveMonitor {
+$keepaliveEnabled = [System.Convert]::ToBoolean("${keepalive_enabled}")
+$keepaliveIntervalSeconds = ${keepalive_interval_seconds}
+$keepaliveExtensionMinutes = ${keepalive_extension_minutes}
+$workspaceId = "${workspace_id}"
+
+if (-not $keepaliveEnabled) {
+    return
+}
+
+$scriptDir = "C:\coder"
+$scriptPath = Join-Path $scriptDir "rdp-keepalive.ps1"
+$logPath = Join-Path $scriptDir "rdp-keepalive.log"
+
+New-Item -ItemType Directory -Path $scriptDir -Force | Out-Null
+
+@"
+`$ErrorActionPreference = "Continue"
+`$workspaceId = "$workspaceId"
+`$intervalSeconds = $keepaliveIntervalSeconds
+`$extensionMinutes = $keepaliveExtensionMinutes
+`$logPath = "$logPath"
+
+function Write-KeepaliveLog {
+    param ([string]`$message)
+    `$timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    "`$timestamp `$message" | Add-Content -Path `$logPath
+}
+
+function Test-RDPConnectionActive {
+    try {
+        `$connections = @(Get-NetTCPConnection -LocalPort 3389 -State Established -ErrorAction Stop)
+        return `$connections.Count -gt 0
+    }
+    catch {
+        Write-KeepaliveLog "Unable to inspect RDP connections: `$(`$_.Exception.Message)"
+        return `$false
+    }
+}
+
+function Invoke-CoderAgentActivity {
+    if ([string]::IsNullOrWhiteSpace(`$env:CODER_AGENT_TOKEN) -or [string]::IsNullOrWhiteSpace(`$env:CODER_AGENT_URL)) {
+        Write-KeepaliveLog "CODER_AGENT_TOKEN or CODER_AGENT_URL is not available"
+        return
+    }
+
+    `$deadline = (Get-Date).ToUniversalTime().AddMinutes(`$extensionMinutes).ToString("yyyy-MM-ddTHH:mm:ssZ")
+    `$uri = "`$env:CODER_AGENT_URL/api/v2/workspaces/`$workspaceId/extend"
+    `$headers = @{
+        "Coder-Session-Token" = `$env:CODER_AGENT_TOKEN
+        "Content-Type" = "application/json"
+    }
+    `$body = @{ deadline = `$deadline } | ConvertTo-Json -Compress
+
+    try {
+        Invoke-RestMethod -Method Put -Uri `$uri -Headers `$headers -Body `$body | Out-Null
+        Write-KeepaliveLog "Extended workspace deadline to `$deadline"
+    }
+    catch {
+        Write-KeepaliveLog "Unable to extend workspace deadline: `$(`$_.Exception.Message)"
+    }
+}
+
+while (`$true) {
+    if (Test-RDPConnectionActive) {
+        Invoke-CoderAgentActivity
+    }
+
+    Start-Sleep -Seconds `$intervalSeconds
+}
+"@ | Set-Content -Path $scriptPath -Encoding UTF8
+
+Get-CimInstance Win32_Process -Filter "name = 'powershell.exe'" |
+    Where-Object { $_.CommandLine -like "*CoderRdpKeepalive*" } |
+    ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+
+$keepaliveCommand = "& { `$env:CODER_RDP_KEEPALIVE = 'CoderRdpKeepalive'; & '$scriptPath' }"
+Start-Process powershell.exe -WindowStyle Hidden -ArgumentList @(
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command",
+    $keepaliveCommand
+)
+}
+
 Set-AdminPassword -adminPassword "${admin_password}"
 Configure-RDP
 Install-DevolutionsGateway
 Patch-Devolutions-HTML
+Install-RDPKeepaliveMonitor


### PR DESCRIPTION
## Summary
- add opt-in keepalive settings to the `windows-rdp` module
- install a background PowerShell monitor that detects established RDP sessions
- extend the workspace deadline through the documented workspace API while RDP is active
- document the keepalive knobs and cover the rendered script output

## Testing
- `PATH=/tmp/coder-test-bin:/tmp/terraform-bin:$PATH npm exec --yes --package=bun@latest -- bun test registry/coder/modules/windows-rdp/main.test.ts`
- `/tmp/terraform-bin/terraform fmt -check -diff /tmp/coder-registry/registry/coder/modules/windows-rdp/main.tf`
- `/tmp/terraform-bin/terraform -chdir=/tmp/coder-registry/registry/coder/modules/windows-rdp validate`
- `npx prettier --check registry/coder/modules/windows-rdp/README.md registry/coder/modules/windows-rdp/main.test.ts`
- `git diff --check`

Fixes #200

/claim #200