### PR TITLE
feat(registry/coder/skills): register modules and templates skills

### DIFF
--- a/registry/coder/skills/README.md
+++ b/registry/coder/skills/README.md
@@ -7,6 +7,14 @@ sources:
         display_name: Coder Setup
         icon: ../../../.icons/coder.svg
         tags: [coder, deployment, configuration]
+      modules:
+        display_name: Coder Modules
+        icon: ../../../.icons/coder-modules.svg
+        tags: [coder, terraform, modules]
+      templates:
+        display_name: Coder Templates
+        icon: ../../../.icons/coder-templates.svg
+        tags: [coder, terraform, templates]
 ---
 
 # Coder Skills
@@ -20,6 +28,8 @@ and served through the registry's API, MCP tools, and
 
 ## Available Skills
 
-| Skill                                                        | Description                                                                                                                                                                                   |
-| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Coder Setup](https://registry.coder.com/skills/coder/setup) | Install, deploy, or bootstrap a new Coder deployment end-to-end. Covers Docker, Kubernetes/Helm, VM, cloud, HTTPS/domain setup, first admin creation, starter templates, and first workspace. |
+| Skill                                                                | Description                                                                                                                                                                                   |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Coder Setup](https://registry.coder.com/skills/coder/setup)         | Install, deploy, or bootstrap a new Coder deployment end-to-end. Covers Docker, Kubernetes/Helm, VM, cloud, HTTPS/domain setup, first admin creation, starter templates, and first workspace. |
+| [Coder Modules](https://registry.coder.com/skills/coder/modules)     | Add or update Coder modules (from registry.coder.com/modules) inside an existing Coder template. Covers IDEs, AI agents, secrets, dev environment tools, and cloud regions.                   |
+| [Coder Templates](https://registry.coder.com/skills/coder/templates) | Author, edit, push, or version a Coder template. Covers starter selection, template anatomy, parameters, validation, push, and first-workspace verification.                                  |


### PR DESCRIPTION
## Summary

Adds two new catalogue entries to `registry/coder/skills/README.md`:

- `coder/modules` with `coder-modules.svg`
- `coder/templates` with `coder-templates.svg`

Both pull from `coder/skills@main` alongside the existing `setup` skill. Tag sets are scoped so the registry-server filter facets pick them up (`[coder, terraform, modules]` and `[coder, terraform, templates]`).

## Verified locally

```
go run ./cmd/readmevalidation
processing skills README files  num_files=1
processed all skills README files  num_files=1
```

No other validator output changed (23 contributor profiles, 79 modules, 33 templates still parse cleanly).

## Source repo content

The skill content (SKILL.md plus per-skill metadata) lives in coder/skills#2. Until that PR merges, this catalogue change is effectively a no-op: the registry-server build pipeline iterates over skills it discovers in the source repo, and looks up catalogue overrides per skill. Catalogue entries for skills that do not yet exist in the source repo are silently ignored.

That means these two PRs can land in either order without breaking anything. Both have to be merged before the new skills appear on registry.coder.com.

## Related

- coder/skills#2 (source repo content for `modules` and `templates`)
- coder/registry-server#442 (build pipeline, API, MCP, frontend)
- coder/registry#884 (catalogue format)

This PR was created with help from Coder Agents.