### PR TITLE
fix(coder-labs/gemini): base64-encode task prompt to handle special characters

### DIFF
--- a/registry/coder-labs/modules/gemini/README.md
+++ b/registry/coder-labs/modules/gemini/README.md
@@ -13,7 +13,7 @@ Run [Gemini CLI](https://github.com/google-gemini/gemini-cli) in your workspace 
 ```tf
 module "gemini" {
   source   = "registry.coder.com/coder-labs/gemini/coder"
-  version  = "3.0.1"
+  version  = "3.0.2"
   agent_id = coder_agent.main.id
   folder   = "/home/coder/project"
 }
@@ -46,7 +46,7 @@ variable "gemini_api_key" {
 
 module "gemini" {
   source         = "registry.coder.com/coder-labs/gemini/coder"
-  version        = "3.0.1"
+  version        = "3.0.2"
   agent_id       = coder_agent.main.id
   gemini_api_key = var.gemini_api_key
   folder         = "/home/coder/project"
@@ -94,7 +94,7 @@ data "coder_parameter" "ai_prompt" {
 module "gemini" {
   count                = data.coder_workspace.me.start_count
   source               = "registry.coder.com/coder-labs/gemini/coder"
-  version              = "3.0.1"
+  version              = "3.0.2"
   agent_id             = coder_agent.main.id
   gemini_api_key       = var.gemini_api_key
   gemini_model         = "gemini-2.5-flash"
@@ -134,7 +134,7 @@ For enterprise users who prefer Google's Vertex AI platform:
 ```tf
 module "gemini" {
   source         = "registry.coder.com/coder-labs/gemini/coder"
-  version        = "3.0.1"
+  version        = "3.0.2"
   agent_id       = coder_agent.main.id
   gemini_api_key = var.gemini_api_key
   folder         = "/home/coder/project"

--- a/registry/coder-labs/modules/gemini/main.test.ts
+++ b/registry/coder-labs/modules/gemini/main.test.ts
@@ -263,6 +263,34 @@ describe("gemini", async () => {
     expect(resp).toContain("Running automated task:");
   });
 
+  test("task-prompt-with-special-characters", async () => {
+    // A single quote in the prompt previously broke shell quoting in the start
+    // script. The prompt must be passed through verbatim and never interpreted
+    // by the shell.
+    const taskPrompt = `dummy prompt' ; touch /tmp/task-prompt-marker ; echo '`;
+    const { id } = await setup({
+      moduleVariables: {
+        task_prompt: taskPrompt,
+      },
+    });
+    await execModuleScript(id);
+
+    // No part of the prompt should be executed by the shell.
+    const marker = await execContainer(id, [
+      "bash",
+      "-c",
+      "test -e /tmp/task-prompt-marker && echo CREATED || echo SAFE",
+    ]);
+    expect(marker.stdout).toContain("SAFE");
+
+    // The prompt must be passed through verbatim, including the single quotes.
+    const promptFile = await readFileContainer(
+      id,
+      "/home/coder/.gemini-module/prompt.txt",
+    );
+    expect(promptFile).toContain(taskPrompt);
+  });
+
   test("start-without-prompt", async () => {
     const { id } = await setup();
     await execModuleScript(id);

--- a/registry/coder-labs/modules/gemini/main.tf
+++ b/registry/coder-labs/modules/gemini/main.tf
@@ -216,7 +216,7 @@ module "agentapi" {
      GEMINI_YOLO_MODE='${var.enable_yolo_mode}' \
      GEMINI_MODEL='${var.gemini_model}' \
      GEMINI_START_DIRECTORY='${var.folder}' \
-     GEMINI_TASK_PROMPT='${var.task_prompt}' \
+     GEMINI_TASK_PROMPT='${base64encode(var.task_prompt)}' \
      /tmp/start.sh
    EOT
 }

--- a/registry/coder-labs/modules/gemini/scripts/start.sh
+++ b/registry/coder-labs/modules/gemini/scripts/start.sh
@@ -44,6 +44,13 @@ else
   }
 fi
 
+# The task prompt is base64-encoded in main.tf so prompts containing single
+# quotes or other shell metacharacters do not break the start script. Decode
+# it before use.
+if [ -n "${GEMINI_TASK_PROMPT:-}" ]; then
+  GEMINI_TASK_PROMPT=$(echo -n "$GEMINI_TASK_PROMPT" | base64 -d)
+fi
+
 if [ -n "$GEMINI_TASK_PROMPT" ]; then
   printf "Running automated task: %s\n" "$GEMINI_TASK_PROMPT"
   PROMPT="Every step of the way, report tasks to Coder with proper descriptions and statuses. Your task at hand: $GEMINI_TASK_PROMPT"


### PR DESCRIPTION
Encodes the Gemini module's `task_prompt` before passing it into the start script and decodes it in `start.sh`, matching how `gemini_system_prompt` is already handled. Prompts containing single quotes or other shell metacharacters are now passed through correctly instead of breaking the start script.

## Type of Change

- [x] Bug fix

## Module Information

**Path:** `registry/coder-labs/modules/gemini`  
**New version:** `v3.0.2`  
**Breaking change:** No

## Testing & Validation

- [x] Tests pass (`bun test main.test.ts`) — added a regression test for prompts containing special characters
- [x] Code formatted (`bun fmt`)
- [x] Changes tested locally

## Related Issues

None

---
<sub>Generated by Coder Agents on behalf of @jdomeracki-coder.</sub>