### PR TITLE
feat: migrate codex installation to use official install script

### DIFF
--- a/registry/coder-labs/modules/codex/README.md
+++ b/registry/coder-labs/modules/codex/README.md
@@ -20,7 +20,7 @@ module "codex" {
 ```
 
 > [!WARNING]
-> If upgrading from v4.x.x of this module: v5 is a major refactor that drops support for [Coder Tasks](https://coder.com/docs/ai-coder/tasks) and [Boundary](https://coder.com/docs/ai-coder/agent-firewall). v5 also assumes npm is pre-installed; it no longer bootstraps Node.js. Keep using v4.x.x if you depend on them. See the [PR description](https://github.com/coder/registry/pull/879) for a full migration guide.
+> If upgrading from v4.x.x of this module: v5 is a major refactor that drops support for [Coder Tasks](https://coder.com/docs/ai-coder/tasks) and [Boundary](https://coder.com/docs/ai-coder/agent-firewall). Keep using v4.x.x if you depend on them. See the [PR description](https://github.com/coder/registry/pull/879) for a full migration guide.
 
 ## Examples
 

--- a/registry/coder-labs/modules/codex/README.md
+++ b/registry/coder-labs/modules/codex/README.md
@@ -13,7 +13,7 @@ Install and configure the [Codex CLI](https://github.com/openai/codex) in your w
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.0.0"
+  version        = "5.1.0"
   agent_id       = coder_agent.main.id
   openai_api_key = var.openai_api_key
 }
@@ -33,7 +33,7 @@ locals {
 
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.0.0"
+  version        = "5.1.0"
   agent_id       = coder_agent.main.id
   workdir        = local.codex_workdir
   openai_api_key = var.openai_api_key
@@ -64,7 +64,7 @@ resource "coder_app" "codex" {
 ```tf
 module "codex" {
   source            = "registry.coder.com/coder-labs/codex/coder"
-  version           = "5.0.0"
+  version           = "5.1.0"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   enable_ai_gateway = true
@@ -88,7 +88,7 @@ When `enable_ai_gateway = true`, the module configures Codex to use the `aigatew
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.0.0"
+  version        = "5.1.0"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   openai_api_key = var.openai_api_key
@@ -117,7 +117,7 @@ The module exposes the `scripts` output: an ordered list of `coder exp sync` nam
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.0.0"
+  version        = "5.1.0"
   agent_id       = coder_agent.main.id
   openai_api_key = var.openai_api_key
 }

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -189,7 +189,7 @@ describe("codex", async () => {
   });
 
   test("install-codex-version", async () => {
-    const version = "0.10.0";
+    const version = "0.134.0";
     const { id, coderEnvVars, scripts } = await setup({
       skipCodexMock: true,
       moduleVariables: {

--- a/registry/coder-labs/modules/codex/main.tf
+++ b/registry/coder-labs/modules/codex/main.tf
@@ -50,7 +50,7 @@ variable "install_codex" {
 
 variable "codex_version" {
   type        = string
-  description = "The version of Codex to install. Accepts 'latest' or a semver like '0.10.0'."
+  description = "The version of Codex to install."
   default     = "latest"
 }
 

--- a/registry/coder-labs/modules/codex/main.tf
+++ b/registry/coder-labs/modules/codex/main.tf
@@ -50,7 +50,7 @@ variable "install_codex" {
 
 variable "codex_version" {
   type        = string
-  description = "The version of Codex to install."
+  description = "The version of Codex to install. Accepts 'latest' or a semver like '0.10.0'."
   default     = "latest"
 }
 
@@ -137,7 +137,7 @@ locals {
   EOF
   install_script = templatefile("${path.module}/scripts/install.sh.tftpl", {
     ARG_INSTALL                = tostring(var.install_codex)
-    ARG_CODEX_VERSION          = var.codex_version != "" ? base64encode(var.codex_version) : ""
+    ARG_CODEX_VERSION          = var.codex_version
     ARG_WORKDIR                = local.workdir != "" ? base64encode(local.workdir) : ""
     ARG_BASE_CONFIG_TOML       = var.base_config_toml != "" ? base64encode(var.base_config_toml) : ""
     ARG_MCP                    = var.mcp != "" ? base64encode(var.mcp) : ""

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -78,6 +78,7 @@ function install_codex() {
 
   printf "%s Installing Codex CLI\n" "$${BOLD}"
   curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_RELEASE="$${ARG_CODEX_VERSION}" CODEX_NON_INTERACTIVE=1 sh
+  export PATH="$HOME/.local/bin:$PATH"
   printf "%s Installed Codex CLI: %s\n" "$${BOLD}" "$(codex --version)"
   ensure_codex_in_path
 }

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -9,7 +9,7 @@ command_exists() {
 }
 
 ARG_INSTALL='${ARG_INSTALL}'
-ARG_CODEX_VERSION=$(echo -n '${ARG_CODEX_VERSION}' | base64 -d)
+ARG_CODEX_VERSION='${ARG_CODEX_VERSION}'
 ARG_WORKDIR=$(echo -n '${ARG_WORKDIR}' | base64 -d)
 ARG_BASE_CONFIG_TOML=$(echo -n '${ARG_BASE_CONFIG_TOML}' | base64 -d)
 ARG_MCP=$(echo -n '${ARG_MCP}' | base64 -d)
@@ -51,8 +51,6 @@ function ensure_codex_in_path() {
   local CODEX_BIN=""
   if command -v codex > /dev/null 2>&1; then
     CODEX_BIN=$(command -v codex)
-  elif [ -x "$HOME/.npm-global/bin/codex" ]; then
-    CODEX_BIN="$HOME/.npm-global/bin/codex"
   fi
 
   if [ -z "$${CODEX_BIN}" ] || [ ! -x "$${CODEX_BIN}" ]; then
@@ -78,35 +76,8 @@ function install_codex() {
     return
   fi
 
-  if [ -s "$HOME/.nvm/nvm.sh" ]; then
-    export NVM_DIR="$HOME/.nvm"
-    . "$NVM_DIR/nvm.sh"
-  fi
-
-  # Detect a package manager for global installs.
-  if command_exists npm; then
-    PKG_INSTALL="npm install -g"
-    if ! command_exists nvm; then
-      mkdir -p "$HOME/.npm-global"
-      npm config set prefix "$HOME/.npm-global"
-      export PATH="$HOME/.npm-global/bin:$PATH"
-    fi
-  elif command_exists pnpm; then
-    PKG_INSTALL="pnpm add -g"
-  elif command_exists bun; then
-    PKG_INSTALL="bun add -g"
-  else
-    echo "Error: npm, pnpm, or bun is required to install Codex. Install one of them first or set install_codex = false."
-    exit 1
-  fi
-
   printf "%s Installing Codex CLI\n" "$${BOLD}"
-
-  if [ -n "$${ARG_CODEX_VERSION}" ]; then
-    $PKG_INSTALL "@openai/codex@$${ARG_CODEX_VERSION}"
-  else
-    $PKG_INSTALL "@openai/codex"
-  fi
+  curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_RELEASE="$${ARG_CODEX_VERSION}" CODEX_NON_INTERACTIVE=1 sh
   printf "%s Installed Codex CLI: %s\n" "$${BOLD}" "$(codex --version)"
   ensure_codex_in_path
 }


### PR DESCRIPTION
## Description

* migrate codex installation to use official install script
* remove npm installation

## Type of Change

- [ ] New module
- [ ] New template
- [ ] Bug fix
- [X] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder-labs/modules/codex`  <br>**New version:** `v5.1.0`  <br>**Breaking change:** \[x\] Yes \[ \] No

## Testing & Validation

- [X] Tests pass (`bun test`)
- [X] Code formatted (`bun fmt`)
- [X] Changes tested locally

## Related Issues

Closes: coder/registry#905