### PR TITLE
fix: update coder provider version constraint from >= 0.23 to >= 2.0

### DIFF
--- a/registry/coder/modules/coder-login/main.tf
+++ b/registry/coder/modules/coder-login/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.23"
+      version = ">= 2.0"
     }
   }
 }

--- a/registry/coder/modules/git-config/main.tf
+++ b/registry/coder/modules/git-config/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.23"
+      version = ">= 2.0"
     }
   }
 }

--- a/registry/coder/modules/github-upload-public-key/main.tf
+++ b/registry/coder/modules/github-upload-public-key/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.23"
+      version = ">= 2.0"
     }
   }
 }

--- a/registry/coder/modules/jfrog-oauth/main.tf
+++ b/registry/coder/modules/jfrog-oauth/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.23"
+      version = ">= 2.0"
     }
   }
 }

--- a/registry/coder/modules/jfrog-token/main.tf
+++ b/registry/coder/modules/jfrog-token/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = ">= 0.23"
+      version = ">= 2.0"
     }
     artifactory = {
       source  = "registry.terraform.io/jfrog/artifactory"


### PR DESCRIPTION
## Summary

The old version constraint `>= 0.23` causes terraform init to fail when combined with modules that require `>= 2.x` (e.g., code-server v1.5.0 requires `>= 2.5.0`):

```
Error: Failed to query available provider packages
Could not retrieve the list of available versions for provider coder/coder:
no available releases match the given constraints ~> 0.23, >= 2.5.0
```

## Changes

Updated 5 modules to use `>= 2.0`:
- coder-login
- git-config
- github-upload-public-key
- jfrog-oauth
- jfrog-token