### PR TITLE
fix: update coder provider version in cloud-dev template

### DIFF
--- a/registry/nboyers/templates/cloud-dev/main.tf
+++ b/registry/nboyers/templates/cloud-dev/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "~> 0.23"
+      version = ">= 2.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## Summary

The cloud-dev template has `version = "~> 0.23"` for the coder provider, which is incompatible with modules requiring `>= 2.x` (e.g., code-server requires `>= 2.5.0`).

This causes terraform init to fail:
```
Error: Failed to query available provider packages
Could not retrieve the list of available versions for provider coder/coder:
no available releases match the given constraints ~> 0.23, >= 2.5.0
```

## Changes

Updated `registry/nboyers/templates/cloud-dev/main.tf` from `~> 0.23` to `>= 2.0`.