### PR TITLE
feat(coder-labs/modules/codex): migrate to gh release installation

### DIFF
--- a/registry/coder-labs/modules/codex/README.md
+++ b/registry/coder-labs/modules/codex/README.md
@@ -13,7 +13,7 @@ Install and configure the [Codex CLI](https://github.com/openai/codex) in your w
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.1.0"
+  version        = "5.1.1"
   agent_id       = coder_agent.main.id
   openai_api_key = var.openai_api_key
 }
@@ -33,7 +33,7 @@ locals {
 
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.1.0"
+  version        = "5.1.1"
   agent_id       = coder_agent.main.id
   workdir        = local.codex_workdir
   openai_api_key = var.openai_api_key
@@ -64,7 +64,7 @@ resource "coder_app" "codex" {
 ```tf
 module "codex" {
   source            = "registry.coder.com/coder-labs/codex/coder"
-  version           = "5.1.0"
+  version           = "5.1.1"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   enable_ai_gateway = true
@@ -88,7 +88,7 @@ When `enable_ai_gateway = true`, the module configures Codex to use the `aigatew
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.1.0"
+  version        = "5.1.1"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   openai_api_key = var.openai_api_key
@@ -117,7 +117,7 @@ The module exposes the `scripts` output: an ordered list of `coder exp sync` nam
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.1.0"
+  version        = "5.1.1"
   agent_id       = coder_agent.main.id
   openai_api_key = var.openai_api_key
 }

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -77,7 +77,29 @@ function install_codex() {
   fi
 
   printf "%s Installing Codex CLI\n" "$${BOLD}"
-  curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_RELEASE="$${ARG_CODEX_VERSION}" CODEX_NON_INTERACTIVE=1 sh
+
+  local arch
+  arch=$(uname -m)
+  local target="$${arch}-unknown-linux-musl"
+  local version="$${ARG_CODEX_VERSION}"
+
+  local url="https://github.com/openai/codex/releases/download/rust-v$${version}/codex-$${target}.tar.gz"
+
+  if [ "$${version}" = "latest" ]; then
+    url="https://github.com/openai/codex/releases/latest/download/codex-$${target}.tar.gz"
+  fi
+
+  printf "Downloading %s\n" "$${url}"
+  local tmp_dir
+  tmp_dir=$(mktemp -d)
+  curl -fsL -o "$${tmp_dir}/codex.tar.gz" "$${url}"
+
+  tar -xzf "$${tmp_dir}/codex.tar.gz" -C "$${tmp_dir}"
+  mkdir -p "$HOME/.local/bin"
+  mv "$${tmp_dir}/codex-$${target}" "$HOME/.local/bin/codex"
+  chmod +x "$HOME/.local/bin/codex"
+  rm -rf "$${tmp_dir}"
+
   export PATH="$HOME/.local/bin:$PATH"
   printf "%s Installed Codex CLI: %s\n" "$${BOLD}" "$(codex --version)"
   ensure_codex_in_path

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -92,7 +92,7 @@ function install_codex() {
   printf "Downloading %s\n" "$${url}"
   local tmp_dir
   tmp_dir=$(mktemp -d)
-  curl -fsL -o "$${tmp_dir}/codex.tar.gz" "$${url}"
+  curl -fsSL -o "$${tmp_dir}/codex.tar.gz" "$${url}"
 
   tar -xzf "$${tmp_dir}/codex.tar.gz" -C "$${tmp_dir}"
   mkdir -p "$HOME/.local/bin"


### PR DESCRIPTION
## Description
- migrate to gh release installation from official installation script, upstream bug in official install.sh

## Type of Change

- [ ] New module
- [ ] New template
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

<!-- Delete this section if not applicable -->

**Path:** `registry/coder-labs/modules/codex`  
**New version:** `v5.1.1`  
**Breaking change:** [ ] Yes [x] No

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun fmt`)
- [x] Changes tested locally

## Related Issues

Closes: #917
