### PR TITLE
fix(vscode-web): point app healthcheck at /version instead of /healthz

### DIFF
--- a/registry/coder/modules/vscode-web/README.md
+++ b/registry/coder/modules/vscode-web/README.md
@@ -14,7 +14,7 @@ Automatically install [Visual Studio Code Server](https://code.visualstudio.com/
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/vscode-web/coder"
-  version        = "1.5.0"
+  version        = "1.5.1"
   agent_id       = coder_agent.example.id
   accept_license = true
 }
@@ -30,7 +30,7 @@ module "vscode-web" {
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/vscode-web/coder"
-  version        = "1.5.0"
+  version        = "1.5.1"
   agent_id       = coder_agent.example.id
   install_prefix = "/home/coder/.vscode-web"
   folder         = "/home/coder"
@@ -44,7 +44,7 @@ module "vscode-web" {
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/vscode-web/coder"
-  version        = "1.5.0"
+  version        = "1.5.1"
   agent_id       = coder_agent.example.id
   extensions     = ["github.copilot", "ms-python.python", "ms-toolsai.jupyter"]
   accept_license = true
@@ -59,7 +59,7 @@ Configure VS Code's [Machine settings.json](https://code.visualstudio.com/docs/g
 module "vscode-web" {
   count      = data.coder_workspace.me.start_count
   source     = "registry.coder.com/coder/vscode-web/coder"
-  version    = "1.5.0"
+  version    = "1.5.1"
   agent_id   = coder_agent.example.id
   extensions = ["dracula-theme.theme-dracula"]
   settings = {
@@ -80,7 +80,7 @@ By default, this module installs the latest. To pin a specific version, retrieve
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/vscode-web/coder"
-  version        = "1.5.0"
+  version        = "1.5.1"
   agent_id       = coder_agent.example.id
   commit_id      = "e54c774e0add60467559eb0d1e229c6452cf8447"
   accept_license = true
@@ -96,7 +96,7 @@ Note: Either `workspace` or `folder` can be used, but not both simultaneously. T
 module "vscode-web" {
   count     = data.coder_workspace.me.start_count
   source    = "registry.coder.com/coder/vscode-web/coder"
-  version   = "1.5.0"
+  version   = "1.5.1"
   agent_id  = coder_agent.example.id
   workspace = "/home/coder/coder.code-workspace"
 }

--- a/registry/coder/modules/vscode-web/main.tf
+++ b/registry/coder/modules/vscode-web/main.tf
@@ -240,5 +240,5 @@ locals {
     "http://localhost:${var.port}${local.server_base_path}?folder=${urlencode(var.folder)}" :
     "http://localhost:${var.port}${local.server_base_path}"
   )
-  healthcheck_url = var.subdomain ? "http://localhost:${var.port}/healthz" : "http://localhost:${var.port}${local.server_base_path}/healthz"
+  healthcheck_url = var.subdomain ? "http://localhost:${var.port}/version" : "http://localhost:${var.port}${local.server_base_path}/version"
 }


### PR DESCRIPTION
Closes #922.

## Summary

The vscode-web module's `coder_app` healthcheck probes `/healthz`, but Microsoft's standalone VS Code web server exposes no such route — it returns 404 (the path was presumably carried over from the code-server module, where code-server really does serve `/healthz`). Against the current stable build (1.124.2):

```
$ curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:13338/healthz
404
$ curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:13338/version
200
```

The 404 never surfaced in dashboards because the agent treats any response below 500 as healthy (`agent/apphealth.go`), but as-is the check only verifies that something answers HTTP on the port, and the URL misleads anyone copying the pattern into their own templates.

This switches the healthcheck to `/version`, which returns 200 in both the subdomain and path-based branches.

## Changes

- `main.tf`: `healthcheck_url` probes `/version` instead of `/healthz`
- `README.md`: patch version bump via `./.github/scripts/version-bump.sh patch`

Found while building a vscode-web dev container feature (coder/devcontainer-features#22).