### PR TITLE
docs(registry/coder/modules/agent-firewall): add Codex MCP TLS workaround note

### DIFF
--- a/registry/coder/modules/agent-firewall/README.md
+++ b/registry/coder/modules/agent-firewall/README.md
@@ -82,6 +82,45 @@ resource "coder_app" "claude_with_agent_firewall" {
 }
 ```
 
+### With Codex
+
+Use agent-firewall alongside the `codex` module the same way as other AI modules.
+
+> [!WARNING]
+> **MCP subprocesses and TLS verification**
+>
+> Codex clears the subprocess environment when spawning MCP stdio servers, stripping
+> the CA cert and proxy vars that agent-firewall injects into the Codex process.
+> This causes MCP subprocesses to fail TLS verification against agent-firewall's
+> intercepting proxy. This is a known upstream issue:
+> [openai/codex#29124](https://github.com/openai/codex/issues/29124).
+>
+> **Workaround:** pass the required vars through explicitly via `env_vars` in each
+> `[mcp_servers.*]` block in `~/.codex/config.toml`:
+>
+> ```toml
+> [mcp_servers.memory]
+> command  = "npx"
+> args     = ["-y", "@modelcontextprotocol/server-memory"]
+> env_vars = ["NODE_EXTRA_CA_CERTS", "HTTPS_PROXY"]
+> ```
+>
+> This must be repeated for every MCP server. There is no global default in Codex.
+>
+> **All vars agent-firewall injects** (from [`landjail/child.go`](https://github.com/coder/boundary/blob/main/landjail/child.go)):
+>
+> | Variable                     | Description                              |
+> | ---------------------------- | ---------------------------------------- |
+> | `NODE_EXTRA_CA_CERTS`        | CA cert for Node.js TLS verification     |
+> | `SSL_CERT_FILE`              | CA cert for OpenSSL/LibreSSL-based tools |
+> | `SSL_CERT_DIR`               | CA cert directory for OpenSSL            |
+> | `CURL_CA_BUNDLE`             | CA cert for curl                         |
+> | `GIT_SSL_CAINFO`             | CA cert for Git                          |
+> | `REQUESTS_CA_BUNDLE`         | CA cert for Python requests              |
+> | `HTTPS_PROXY` / `HTTP_PROXY` | Proxy address for HTTPS/HTTP traffic     |
+> | `https_proxy` / `http_proxy` | Lowercase aliases for the above          |
+> | `NO_PROXY` / `no_proxy`      | Cleared to prevent bypassing the proxy   |
+
 ## Configuration
 
 The module ships with a comprehensive default config based on the

--- a/registry/coder/modules/agent-firewall/README.md
+++ b/registry/coder/modules/agent-firewall/README.md
@@ -84,7 +84,7 @@ resource "coder_app" "claude_with_agent_firewall" {
 
 ### With Codex
 
-Use agent-firewall alongside the `codex` module the same way as other AI modules.
+Use agent-firewall alongside the [`codex`](https://registry.coder.com/modules/coder-labs/codex) module the same way as other AI modules.
 
 > [!WARNING]
 > **MCP subprocesses and TLS verification**
@@ -95,8 +95,9 @@ Use agent-firewall alongside the `codex` module the same way as other AI modules
 > intercepting proxy. This is a known upstream issue:
 > [openai/codex#29124](https://github.com/openai/codex/issues/29124).
 >
-> **Workaround:** pass the required vars through explicitly via `env_vars` in each
-> `[mcp_servers.*]` block in `~/.codex/config.toml`:
+> **Workaround:** pass the vars your MCP server's runtime needs via `env_vars` in
+> each `[mcp_servers.*]` block in `~/.codex/config.toml`. For example, for a
+> Node.js-based server:
 >
 > ```toml
 > [mcp_servers.memory]
@@ -106,20 +107,20 @@ Use agent-firewall alongside the `codex` module the same way as other AI modules
 > ```
 >
 > This must be repeated for every MCP server. There is no global default in Codex.
->
-> **All vars agent-firewall injects** (from [`landjail/child.go`](https://github.com/coder/boundary/blob/main/landjail/child.go)):
->
-> | Variable                     | Description                              |
-> | ---------------------------- | ---------------------------------------- |
-> | `NODE_EXTRA_CA_CERTS`        | CA cert for Node.js TLS verification     |
-> | `SSL_CERT_FILE`              | CA cert for OpenSSL/LibreSSL-based tools |
-> | `SSL_CERT_DIR`               | CA cert directory for OpenSSL            |
-> | `CURL_CA_BUNDLE`             | CA cert for curl                         |
-> | `GIT_SSL_CAINFO`             | CA cert for Git                          |
-> | `REQUESTS_CA_BUNDLE`         | CA cert for Python requests              |
-> | `HTTPS_PROXY` / `HTTP_PROXY` | Proxy address for HTTPS/HTTP traffic     |
-> | `https_proxy` / `http_proxy` | Lowercase aliases for the above          |
-> | `NO_PROXY` / `no_proxy`      | Cleared to prevent bypassing the proxy   |
+
+The full list of vars agent-firewall injects (from [`landjail/child.go`](https://github.com/coder/boundary/blob/main/landjail/child.go)). Add the ones relevant to your MCP server's runtime:
+
+| Variable                     | Description                              |
+| ---------------------------- | ---------------------------------------- |
+| `NODE_EXTRA_CA_CERTS`        | CA cert for Node.js TLS verification     |
+| `SSL_CERT_FILE`              | CA cert for OpenSSL/LibreSSL-based tools |
+| `SSL_CERT_DIR`               | CA cert directory for OpenSSL            |
+| `CURL_CA_BUNDLE`             | CA cert for curl                         |
+| `GIT_SSL_CAINFO`             | CA cert for Git                          |
+| `REQUESTS_CA_BUNDLE`         | CA cert for Python requests              |
+| `HTTPS_PROXY` / `HTTP_PROXY` | Proxy address for HTTPS/HTTP traffic     |
+| `https_proxy` / `http_proxy` | Lowercase aliases for the above          |
+| `NO_PROXY` / `no_proxy`      | Cleared to prevent bypassing the proxy   |
 
 ## Configuration
 

--- a/registry/coder/modules/agent-firewall/README.md
+++ b/registry/coder/modules/agent-firewall/README.md
@@ -21,7 +21,7 @@ This module:
 ```tf
 module "agent-firewall" {
   source   = "registry.coder.com/coder/agent-firewall/coder"
-  version  = "0.0.1"
+  version  = "0.0.2"
   agent_id = coder_agent.main.id
 }
 ```
@@ -40,7 +40,7 @@ network-isolated environment.
 ```tf
 module "agent-firewall" {
   source   = "registry.coder.com/coder/agent-firewall/coder"
-  version  = "0.0.1"
+  version  = "0.0.2"
   agent_id = coder_agent.main.id
 }
 
@@ -65,7 +65,7 @@ resource "coder_script" "claude_with_agent_firewall" {
 ```tf
 module "agent-firewall" {
   source   = "registry.coder.com/coder/agent-firewall/coder"
-  version  = "0.0.1"
+  version  = "0.0.2"
   agent_id = coder_agent.main.id
 }
 
@@ -143,7 +143,7 @@ Pass the full YAML content directly:
 ```tf
 module "agent-firewall" {
   source   = "registry.coder.com/coder/agent-firewall/coder"
-  version  = "0.0.1"
+  version  = "0.0.2"
   agent_id = coder_agent.main.id
 
   agent_firewall_config = <<-YAML
@@ -167,7 +167,7 @@ your path. The file must exist on disk before agent-firewall starts.
 ```tf
 module "agent-firewall" {
   source   = "registry.coder.com/coder/agent-firewall/coder"
-  version  = "0.0.1"
+  version  = "0.0.2"
   agent_id = coder_agent.main.id
 
   agent_firewall_config_path = "/workspace/my-agent-firewall-config.yaml"

--- a/registry/coder/modules/agent-firewall/main.tf
+++ b/registry/coder/modules/agent-firewall/main.tf
@@ -103,7 +103,7 @@ locals {
 
 module "coder_utils" {
   source              = "registry.coder.com/coder/coder-utils/coder"
-  version             = "0.0.2"
+  version             = "0.0.1"
   agent_id            = var.agent_id
   display_name_prefix = "Agent Firewall"
   module_directory    = var.module_directory

--- a/registry/coder/modules/agent-firewall/main.tf
+++ b/registry/coder/modules/agent-firewall/main.tf
@@ -103,7 +103,7 @@ locals {
 
 module "coder_utils" {
   source              = "registry.coder.com/coder/coder-utils/coder"
-  version             = "0.0.1"
+  version             = "0.0.2"
   agent_id            = var.agent_id
   display_name_prefix = "Agent Firewall"
   module_directory    = var.module_directory


### PR DESCRIPTION
## Description

Documents the known upstream Codex CLI issue ([openai/codex#29124](https://github.com/openai/codex/issues/29124)) where MCP stdio subprocesses lose the CA cert and proxy environment variables injected by agent-firewall, causing TLS verification failures on startup. Adds a `### With Codex` section under Examples with a warning block that describes the issue, links upstream, provides the per-server `env_vars` workaround, and tables all vars agent-firewall injects.

> Generated by Coder Agents on behalf of @35C4n0r

## Type of Change

- [ ] New module
- [ ] New template
- [ ] Bug fix
- [ ] Feature/enhancement
- [x] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder/modules/agent-firewall`
**New version:** `0.0.2`
**Breaking change:** [ ] Yes [x] No

## Template Information

N/A — documentation-only change.

## Testing & Validation

- [ ] Tests pass (`bun test`)
- [ ] Code formatted (`bun fmt`)
- [x] Changes tested locally

## Related Issues

- [openai/codex#29124](https://github.com/openai/codex/issues/29124) — upstream Codex issue tracking the root cause
- [REG-15](https://linear.app/codercom/issue/REG-15)