### PR TITLE
chore(zed): make coder_script conditional on settings input

### DIFF
--- a/registry/coder/modules/zed/README.md
+++ b/registry/coder/modules/zed/README.md
@@ -19,7 +19,7 @@ Zed is a high-performance, multiplayer code editor from the creators of Atom and
 module "zed" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/zed/coder"
-  version  = "1.1.4"
+  version  = "1.1.5"
   agent_id = coder_agent.main.id
 }
 ```
@@ -32,7 +32,7 @@ module "zed" {
 module "zed" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/zed/coder"
-  version  = "1.1.4"
+  version  = "1.1.5"
   agent_id = coder_agent.main.id
   folder   = "/home/coder/project"
 }
@@ -44,7 +44,7 @@ module "zed" {
 module "zed" {
   count        = data.coder_workspace.me.start_count
   source       = "registry.coder.com/coder/zed/coder"
-  version      = "1.1.4"
+  version      = "1.1.5"
   agent_id     = coder_agent.main.id
   display_name = "Zed Editor"
   order        = 1
@@ -57,7 +57,7 @@ module "zed" {
 module "zed" {
   count      = data.coder_workspace.me.start_count
   source     = "registry.coder.com/coder/zed/coder"
-  version    = "1.1.4"
+  version    = "1.1.5"
   agent_id   = coder_agent.main.id
   agent_name = coder_agent.example.name
 }
@@ -73,7 +73,7 @@ You can declaratively set/merge settings with the `settings` input. Provide a JS
 module "zed" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/zed/coder"
-  version  = "1.1.4"
+  version  = "1.1.5"
   agent_id = coder_agent.main.id
 
   settings = jsonencode({
@@ -91,4 +91,4 @@ module "zed" {
 }
 ```
 
-See Zed’s settings files documentation: https://zed.dev/docs/configuring-zed#settings-files
+See Zed's settings files documentation: https://zed.dev/docs/configuring-zed#settings-files

--- a/registry/coder/modules/zed/main.test.ts
+++ b/registry/coder/modules/zed/main.test.ts
@@ -103,27 +103,16 @@ describe("zed", async () => {
     }
   }, 30000);
 
-  it("exits early with empty settings", async () => {
+  it("does not create coder_script when settings is empty", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",
       settings: "",
     });
 
-    const instance = findResourceInstance(state, "coder_script");
-    const id = await runContainer("alpine:latest");
-
-    try {
-      const result = await execContainer(id, ["sh", "-c", instance.script]);
-      expect(result.exitCode).toBe(0);
-
-      // Settings file should not be created
-      const catResult = await execContainer(id, [
-        "cat",
-        "/root/.config/zed/settings.json",
-      ]);
-      expect(catResult.exitCode).not.toBe(0);
-    } finally {
-      await removeContainer(id);
-    }
+    // With count = 0, no coder_script resource should exist
+    const scripts = state.resources?.filter(
+      (r: { type: string }) => r.type === "coder_script",
+    );
+    expect(scripts?.length ?? 0).toBe(0);
   }, 30000);
 });

--- a/registry/coder/modules/zed/main.tf
+++ b/registry/coder/modules/zed/main.tf
@@ -69,6 +69,7 @@ locals {
 }
 
 resource "coder_script" "zed_settings" {
+  count        = var.settings != "" ? 1 : 0
   agent_id     = var.agent_id
   display_name = "Configure Zed settings"
   icon         = "/icon/zed.svg"
@@ -77,9 +78,6 @@ resource "coder_script" "zed_settings" {
     #!/usr/bin/env bash
     set -eu
     SETTINGS_B64='${local.settings_b64}'
-    if [ -z "$${SETTINGS_B64}" ]; then
-      exit 0
-    fi
     SETTINGS_JSON="$(echo -n "$${SETTINGS_B64}" | base64 -d)"
     if [ -z "$${SETTINGS_JSON}" ] || [ "$${SETTINGS_JSON}" = "{}" ]; then
       exit 0

--- a/registry/coder/modules/zed/zed.tftest.hcl
+++ b/registry/coder/modules/zed/zed.tftest.hcl
@@ -94,12 +94,12 @@ run "settings_base64_encoding" {
 
   # Verify settings are base64 encoded (eyJ = base64 prefix for JSON starting with {")
   assert {
-    condition     = can(regex("SETTINGS_B64='eyJ", coder_script.zed_settings.script))
+    condition     = can(regex("SETTINGS_B64='eyJ", coder_script.zed_settings[0].script))
     error_message = "settings should be base64 encoded in the script"
   }
 }
 
-run "empty_settings" {
+run "empty_settings_no_script" {
   command = apply
 
   variables {
@@ -108,7 +108,7 @@ run "empty_settings" {
   }
 
   assert {
-    condition     = can(regex("SETTINGS_B64=''", coder_script.zed_settings.script))
-    error_message = "empty settings should result in empty SETTINGS_B64"
+    condition     = length(coder_script.zed_settings) == 0
+    error_message = "coder_script should not be created when settings is empty"
   }
 }


### PR DESCRIPTION
The `coder_script` resource for configuring Zed settings was always created, even when no settings were provided. The script handled this at runtime with an early exit check, but it's cleaner to not create the resource at all.

## Changes

- Add `count = var.settings != "" ? 1 : 0` to `coder_script "zed_settings"` so it's only created when settings are provided
- Remove the redundant empty `SETTINGS_B64` runtime check from the shell script
- Update `zed.tftest.hcl` to use indexed reference (`coder_script.zed_settings[0]`) and assert no resource is created when settings is empty
- Update `main.test.ts` to verify no `coder_script` exists in state when settings is empty

This follows the same pattern used in cursor, windsurf, kiro, and antigravity modules.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻