### PR TITLE
fix(coder-labs/modules/codex): rename AI Gateway session token env to OPENAI_ prefix

### DIFF
--- a/registry/coder-labs/modules/codex/README.md
+++ b/registry/coder-labs/modules/codex/README.md
@@ -13,7 +13,7 @@ Install and configure the [Codex CLI](https://github.com/openai/codex) in your w
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.2.0"
+  version        = "5.2.1"
   agent_id       = coder_agent.main.id
   openai_api_key = var.openai_api_key
 }
@@ -33,7 +33,7 @@ locals {
 
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.2.0"
+  version        = "5.2.1"
   agent_id       = coder_agent.main.id
   workdir        = local.codex_workdir
   openai_api_key = var.openai_api_key
@@ -64,7 +64,7 @@ resource "coder_app" "codex" {
 ```tf
 module "codex" {
   source            = "registry.coder.com/coder-labs/codex/coder"
-  version           = "5.2.0"
+  version           = "5.2.1"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   enable_ai_gateway = true
@@ -88,7 +88,7 @@ When `enable_ai_gateway = true`, the module configures Codex to use the `aigatew
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.2.0"
+  version        = "5.2.1"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   openai_api_key = var.openai_api_key
@@ -117,7 +117,7 @@ The module exposes the `scripts` output: an ordered list of `coder exp sync` nam
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.2.0"
+  version        = "5.2.1"
   agent_id       = coder_agent.main.id
   openai_api_key = var.openai_api_key
 }

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -398,7 +398,7 @@ describe("codex", async () => {
       "[model_providers.aigateway]",
       'name = "Custom AI Bridge"',
       'base_url = "https://custom.example.com"',
-      'env_key = "CODER_AIBRIDGE_SESSION_TOKEN"',
+      'env_key = "OPENAI_CODER_AIGATEWAY_SESSION_TOKEN"',
       'wire_api = "responses"',
     ].join("\n");
     const { id, coderEnvVars, scripts } = await setup({

--- a/registry/coder-labs/modules/codex/main.tf
+++ b/registry/coder-labs/modules/codex/main.tf
@@ -118,10 +118,12 @@ resource "coder_env" "openai_api_key" {
 
 # Authenticates the client against Coder's AI Gateway using the workspace
 # owner's session token. Referenced by config.toml model_providers.aigateway.
+# Uses OPENAI_ prefix so the variable is preserved in OIAgent's filtered
+# subprocess environment (OIAgent strips non-OPENAI_ env vars).
 resource "coder_env" "ai_gateway_session_token" {
   count    = var.enable_ai_gateway ? 1 : 0
   agent_id = var.agent_id
-  name     = "CODER_AIBRIDGE_SESSION_TOKEN"
+  name     = "OPENAI_CODER_AIGATEWAY_SESSION_TOKEN"
   value    = data.coder_workspace_owner.me.session_token
 }
 
@@ -131,7 +133,7 @@ locals {
   [model_providers.aigateway]
   name = "AI Gateway"
   base_url = "${data.coder_workspace.me.access_url}/api/v2/aibridge/openai/v1"
-  env_key = "CODER_AIBRIDGE_SESSION_TOKEN"
+  env_key = "OPENAI_CODER_AIGATEWAY_SESSION_TOKEN"
   wire_api = "responses"
 
   EOF

--- a/registry/coder-labs/modules/codex/main.tf
+++ b/registry/coder-labs/modules/codex/main.tf
@@ -118,8 +118,6 @@ resource "coder_env" "openai_api_key" {
 
 # Authenticates the client against Coder's AI Gateway using the workspace
 # owner's session token. Referenced by config.toml model_providers.aigateway.
-# Uses OPENAI_ prefix so the variable is preserved in OIAgent's filtered
-# subprocess environment (OIAgent strips non-OPENAI_ env vars).
 resource "coder_env" "ai_gateway_session_token" {
   count    = var.enable_ai_gateway ? 1 : 0
   agent_id = var.agent_id

--- a/registry/coder-labs/modules/codex/main.tftest.hcl
+++ b/registry/coder-labs/modules/codex/main.tftest.hcl
@@ -60,8 +60,8 @@ run "test_ai_gateway_enabled" {
   }
 
   assert {
-    condition     = coder_env.ai_gateway_session_token[0].name == "CODER_AIBRIDGE_SESSION_TOKEN"
-    error_message = "CODER_AIBRIDGE_SESSION_TOKEN should be set"
+    condition     = coder_env.ai_gateway_session_token[0].name == "OPENAI_CODER_AIGATEWAY_SESSION_TOKEN"
+    error_message = "OPENAI_CODER_AIGATEWAY_SESSION_TOKEN should be set"
   }
 
   assert {


### PR DESCRIPTION
## Problem

Omnigent's native Codex bridge runs Codex in a filtered subprocess environment that strips env vars not prefixed with `OPENAI_`. The current `CODER_AIBRIDGE_SESSION_TOKEN` env var gets dropped, breaking AI Gateway authentication when Codex runs through Omnigent.

Discovered while working on the Omnigent module in #925 — the workaround was a `sed` hack in `post_install_script` to rewrite the `env_key` in `config.toml` at runtime. This fix eliminates that workaround.

## Fix

Rename the env var from `CODER_AIBRIDGE_SESSION_TOKEN` to `OPENAI_CODER_AIGATEWAY_SESSION_TOKEN` at the source, so it survives Omnigent's env filtering without any workarounds.

## Changes

| File | Change |
|------|--------|
| `main.tf` | `coder_env` name + `env_key` in `aibridge_config` |
| `main.tftest.hcl` | Updated assertion to match new env var name |
| `main.test.ts` | Updated custom config test to use new env var name |
| `README.md` | Version bump `5.2.0` → `5.2.1` |

## Module Information
Path: `registry/coder-labs/modules/codex`
New version: v5.2.1

Breaking change: [ ] Yes [x] No

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻