### PR TITLE
fix(vscode-web): add open_in parameter

### DIFF
--- a/registry/coder/modules/vscode-web/README.md
+++ b/registry/coder/modules/vscode-web/README.md
@@ -14,7 +14,7 @@ Automatically install [Visual Studio Code Server](https://code.visualstudio.com/
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/vscode-web/coder"
-  version = "1.6.0"
+  version        = "1.6.0"
   agent_id       = coder_agent.example.id
   accept_license = true
 }
@@ -30,7 +30,7 @@ module "vscode-web" {
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/vscode-web/coder"
-  version = "1.6.0"
+  version        = "1.6.0"
   agent_id       = coder_agent.example.id
   install_prefix = "/home/coder/.vscode-web"
   folder         = "/home/coder"
@@ -44,7 +44,7 @@ module "vscode-web" {
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/vscode-web/coder"
-  version = "1.6.0"
+  version        = "1.6.0"
   agent_id       = coder_agent.example.id
   extensions     = ["github.copilot", "ms-python.python", "ms-toolsai.jupyter"]
   accept_license = true
@@ -59,7 +59,7 @@ Configure VS Code's [Machine settings.json](https://code.visualstudio.com/docs/g
 module "vscode-web" {
   count      = data.coder_workspace.me.start_count
   source     = "registry.coder.com/coder/vscode-web/coder"
-  version = "1.6.0"
+  version    = "1.6.0"
   agent_id   = coder_agent.example.id
   extensions = ["dracula-theme.theme-dracula"]
   settings = {
@@ -80,7 +80,7 @@ By default, this module installs the latest. To pin a specific version, retrieve
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/vscode-web/coder"
-  version = "1.6.0"
+  version        = "1.6.0"
   agent_id       = coder_agent.example.id
   commit_id      = "e54c774e0add60467559eb0d1e229c6452cf8447"
   accept_license = true
@@ -96,7 +96,7 @@ Note: Either `workspace` or `folder` can be used, but not both simultaneously. T
 module "vscode-web" {
   count     = data.coder_workspace.me.start_count
   source    = "registry.coder.com/coder/vscode-web/coder"
-  version = "1.6.0"
+  version   = "1.6.0"
   agent_id  = coder_agent.example.id
   workspace = "/home/coder/coder.code-workspace"
 }

--- a/registry/coder/modules/vscode-web/README.md
+++ b/registry/coder/modules/vscode-web/README.md
@@ -14,7 +14,7 @@ Automatically install [Visual Studio Code Server](https://code.visualstudio.com/
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/vscode-web/coder"
-  version        = "1.5.1"
+  version = "1.6.0"
   agent_id       = coder_agent.example.id
   accept_license = true
 }
@@ -30,7 +30,7 @@ module "vscode-web" {
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/vscode-web/coder"
-  version        = "1.5.1"
+  version = "1.6.0"
   agent_id       = coder_agent.example.id
   install_prefix = "/home/coder/.vscode-web"
   folder         = "/home/coder"
@@ -44,7 +44,7 @@ module "vscode-web" {
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/vscode-web/coder"
-  version        = "1.5.1"
+  version = "1.6.0"
   agent_id       = coder_agent.example.id
   extensions     = ["github.copilot", "ms-python.python", "ms-toolsai.jupyter"]
   accept_license = true
@@ -59,7 +59,7 @@ Configure VS Code's [Machine settings.json](https://code.visualstudio.com/docs/g
 module "vscode-web" {
   count      = data.coder_workspace.me.start_count
   source     = "registry.coder.com/coder/vscode-web/coder"
-  version    = "1.5.1"
+  version = "1.6.0"
   agent_id   = coder_agent.example.id
   extensions = ["dracula-theme.theme-dracula"]
   settings = {
@@ -80,7 +80,7 @@ By default, this module installs the latest. To pin a specific version, retrieve
 module "vscode-web" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/vscode-web/coder"
-  version        = "1.5.1"
+  version = "1.6.0"
   agent_id       = coder_agent.example.id
   commit_id      = "e54c774e0add60467559eb0d1e229c6452cf8447"
   accept_license = true
@@ -96,7 +96,7 @@ Note: Either `workspace` or `folder` can be used, but not both simultaneously. T
 module "vscode-web" {
   count     = data.coder_workspace.me.start_count
   source    = "registry.coder.com/coder/vscode-web/coder"
-  version   = "1.5.1"
+  version = "1.6.0"
   agent_id  = coder_agent.example.id
   workspace = "/home/coder/coder.code-workspace"
 }

--- a/registry/coder/modules/vscode-web/main.tf
+++ b/registry/coder/modules/vscode-web/main.tf
@@ -150,7 +150,7 @@ variable "subdomain" {
 
 variable "open_in" {
   description = <<-EOT
-    Determines where the app will be opened. Valid values are `"tab"` and `"slim-window" (default)`.
+    Determines where the app will be opened. Valid values are `"tab"` and `"slim-window"` (default).
     `"tab"` opens in a new tab in the same browser window.
     `"slim-window"` opens a new browser window without navigation controls.
   EOT

--- a/registry/coder/modules/vscode-web/main.tf
+++ b/registry/coder/modules/vscode-web/main.tf
@@ -148,6 +148,20 @@ variable "subdomain" {
   default     = true
 }
 
+variable "open_in" {
+  description = <<-EOT
+    Determines where the app will be opened. Valid values are `"tab"` and `"slim-window" (default)`.
+    `"tab"` opens in a new tab in the same browser window.
+    `"slim-window"` opens a new browser window without navigation controls.
+  EOT
+  type        = string
+  default     = "slim-window"
+  validation {
+    condition     = contains(["tab", "slim-window"], var.open_in)
+    error_message = "The 'open_in' variable must be one of: 'tab', 'slim-window'."
+  }
+}
+
 variable "platform" {
   type        = string
   description = "The platform to use for the VS Code Web."
@@ -223,6 +237,7 @@ resource "coder_app" "vscode-web" {
   share        = var.share
   order        = var.order
   group        = var.group
+  open_in      = var.open_in
 
   healthcheck {
     url       = local.healthcheck_url

--- a/registry/coder/modules/vscode-web/vscode-web.tftest.hcl
+++ b/registry/coder/modules/vscode-web/vscode-web.tftest.hcl
@@ -1,0 +1,42 @@
+run "default_open_in" {
+  command = plan
+
+  variables {
+    agent_id       = "foo"
+    accept_license = true
+  }
+
+  assert {
+    condition     = resource.coder_app.vscode-web.open_in == "slim-window"
+    error_message = "Default open_in value should be 'slim-window'."
+  }
+}
+
+run "custom_open_in" {
+  command = plan
+
+  variables {
+    agent_id       = "foo"
+    accept_license = true
+    open_in        = "tab"
+  }
+
+  assert {
+    condition     = resource.coder_app.vscode-web.open_in == "tab"
+    error_message = "Custom open_in value should be applied to the Coder app."
+  }
+}
+
+run "invalid_open_in" {
+  command = plan
+
+  variables {
+    agent_id       = "foo"
+    accept_license = true
+    open_in        = "invalid"
+  }
+
+  expect_failures = [
+    var.open_in,
+  ]
+}


### PR DESCRIPTION
## Description

Add an `open_in` input to the `vscode-web` module and pass it through to `coder_app.vscode-web`.

The input accepts `tab` or `slim-window` and defaults to `slim-window`, preserving the existing behavior while allowing users to open VS Code Web in a normal browser tab.

## Type of Change

- [x] Bug fix
- [ ] New module
- [ ] New template
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder/modules/vscode-web`  
**New version:** `v1.6.0`  
**Breaking change:** [ ] Yes [x] No

## Testing & Validation

- [x] Terraform tests pass (`terraform test -verbose`: 3 passed, 0 failed)
- [x] Terraform configuration validates (`terraform validate`)
- [x] Terraform and README formatting checks pass
- [x] Minor version bump validated with `.github/scripts/version-bump.sh --ci minor origin/main`
- [ ] Container-backed TypeScript tests completed locally (3 non-container tests passed; 4 existing container tests could not start because the local Docker Linux engine was unavailable and are left to CI)

## Related Issues

Fixes #929