### PR TITLE
fix(git-clone): scan SSH host key before cloning to fix known_hosts error

### DIFF
--- a/registry/coder/modules/git-clone/README.md
+++ b/registry/coder/modules/git-clone/README.md
@@ -14,7 +14,7 @@ This module allows you to automatically clone a repository by URL and skip if it
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "2.0.1"
+  version  = "2.0.2"
   agent_id = coder_agent.example.id
   url      = "https://github.com/coder/coder"
 }
@@ -28,7 +28,7 @@ module "git-clone" {
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "2.0.1"
+  version  = "2.0.2"
   agent_id = coder_agent.example.id
   url      = "https://github.com/coder/coder"
   base_dir = "~/projects/coder"
@@ -43,7 +43,7 @@ To use with [Git Authentication](https://coder.com/docs/v2/latest/admin/git-prov
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "2.0.1"
+  version  = "2.0.2"
   agent_id = coder_agent.example.id
   url      = "https://github.com/coder/coder"
 }
@@ -70,7 +70,7 @@ data "coder_parameter" "git_repo" {
 module "git_clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "2.0.1"
+  version  = "2.0.2"
   agent_id = coder_agent.example.id
   url      = data.coder_parameter.git_repo.value
 }
@@ -105,7 +105,7 @@ Configuring `git-clone` for a self-hosted GitHub Enterprise Server running at `g
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "2.0.1"
+  version  = "2.0.2"
   agent_id = coder_agent.example.id
   url      = "https://github.example.com/coder/coder/tree/feat/example"
   git_providers = {
@@ -125,7 +125,7 @@ To GitLab clone with a specific branch like `feat/example`
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "2.0.1"
+  version  = "2.0.2"
   agent_id = coder_agent.example.id
   url      = "https://gitlab.com/coder/coder/-/tree/feat/example"
 }
@@ -137,7 +137,7 @@ Configuring `git-clone` for a self-hosted GitLab running at `gitlab.example.com`
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "2.0.1"
+  version  = "2.0.2"
   agent_id = coder_agent.example.id
   url      = "https://gitlab.example.com/coder/coder/-/tree/feat/example"
   git_providers = {
@@ -159,7 +159,7 @@ For example, to clone the `feat/example` branch:
 module "git-clone" {
   count       = data.coder_workspace.me.start_count
   source      = "registry.coder.com/coder/git-clone/coder"
-  version     = "2.0.1"
+  version     = "2.0.2"
   agent_id    = coder_agent.example.id
   url         = "https://github.com/coder/coder"
   branch_name = "feat/example"
@@ -177,7 +177,7 @@ For example, this will clone into the `~/projects/coder/coder-dev` folder:
 module "git-clone" {
   count       = data.coder_workspace.me.start_count
   source      = "registry.coder.com/coder/git-clone/coder"
-  version     = "2.0.1"
+  version     = "2.0.2"
   agent_id    = coder_agent.example.id
   url         = "https://github.com/coder/coder"
   folder_name = "coder-dev"
@@ -202,7 +202,7 @@ fetches, or partial clones.
 module "git-clone" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/git-clone/coder"
-  version  = "2.0.1"
+  version  = "2.0.2"
   agent_id = coder_agent.example.id
   url      = "https://github.com/coder/coder"
   extra_args = [
@@ -223,7 +223,7 @@ This is useful for preparing the environment or validating prerequisites before 
 module "git-clone" {
   count            = data.coder_workspace.me.start_count
   source           = "registry.coder.com/coder/git-clone/coder"
-  version          = "2.0.1"
+  version          = "2.0.2"
   agent_id         = coder_agent.example.id
   url              = "https://github.com/coder/coder"
   pre_clone_script = <<-EOT
@@ -246,7 +246,7 @@ This is useful for running initialization tasks like installing dependencies or 
 module "git-clone" {
   count             = data.coder_workspace.me.start_count
   source            = "registry.coder.com/coder/git-clone/coder"
-  version           = "2.0.1"
+  version           = "2.0.2"
   agent_id          = coder_agent.example.id
   url               = "https://github.com/coder/coder"
   post_clone_script = <<-EOT

--- a/registry/coder/modules/git-clone/main.test.ts
+++ b/registry/coder/modules/git-clone/main.test.ts
@@ -426,6 +426,81 @@ describe("git-clone", async () => {
     expect(log.stdout).toContain("Cloning fake-url to /root/fake-url...");
   });
 
+  it("adds SSH host key to known_hosts for SSH URLs", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      url: "git@github.com:coder/coder.git",
+      base_dir: "/tmp",
+    });
+    const setupFakeTools = [
+      installFakeGit,
+      "cat > /usr/local/bin/ssh-keyscan <<'SHIM'",
+      "#!/bin/sh",
+      "echo 'github.com ssh-rsa AAAAB3NzaC1yc2EFAKE'",
+      "SHIM",
+      "chmod +x /usr/local/bin/ssh-keyscan",
+    ].join("\n");
+    const output = await executeScriptInContainer(
+      state,
+      "alpine/git",
+      setupFakeTools,
+    );
+    expect(output.stdout).toContain(
+      "Adding host key for github.com to known_hosts...",
+    );
+    expect(output.stdout).toContain(
+      "Host key for github.com added to known_hosts.",
+    );
+    expect(output.exitCode).toBe(0);
+  });
+
+  it("uses StrictHostKeyChecking=accept-new when ssh-keyscan is unavailable for SSH URLs", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      url: "git@github.com:coder/coder.git",
+      base_dir: "/tmp",
+    });
+    const setupWithoutSshKeyscan = [
+      installFakeGit,
+      "rm -f /usr/bin/ssh-keyscan /usr/local/bin/ssh-keyscan 2>/dev/null || true",
+    ].join("\n");
+    const output = await executeScriptInContainer(
+      state,
+      "alpine/git",
+      setupWithoutSshKeyscan,
+    );
+    expect(output.stdout).toContain(
+      "Adding host key for github.com to known_hosts...",
+    );
+    expect(output.stdout).toContain(
+      "ssh-keyscan not available. Using StrictHostKeyChecking=accept-new.",
+    );
+    expect(output.exitCode).toBe(0);
+  });
+
+  it("skips SSH host key scan when host is already in known_hosts", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      url: "git@github.com:coder/coder.git",
+      base_dir: "/tmp",
+    });
+    const setupWithExistingKey = [
+      installFakeGit,
+      "mkdir -p /root/.ssh && chmod 700 /root/.ssh",
+      "echo 'github.com ssh-rsa AAAAB3NzaC1yc2EEXISTING' >> /root/.ssh/known_hosts",
+      "chmod 600 /root/.ssh/known_hosts",
+    ].join("\n");
+    const output = await executeScriptInContainer(
+      state,
+      "alpine/git",
+      setupWithExistingKey,
+    );
+    expect(output.stdout).not.toContain(
+      "Adding host key for github.com to known_hosts...",
+    );
+    expect(output.exitCode).toBe(0);
+  });
+
   it("fails when post-clone script fails", async () => {
     const state = await runTerraformApply(import.meta.dir, {
       agent_id: "foo",

--- a/registry/coder/modules/git-clone/run.sh
+++ b/registry/coder/modules/git-clone/run.sh
@@ -56,6 +56,30 @@ if [ -n "$EXTRA_ARGS" ]; then
   done < <(echo "$EXTRA_ARGS" | base64 -d)
 fi
 
+# For SSH URLs, populate known_hosts before cloning to prevent "Host key verification failed"
+# on new workspaces where known_hosts is empty.
+if echo "$REPO_URL" | grep -qE '^git@|^ssh://'; then
+  SSH_HOST=$(echo "$REPO_URL" | sed -E 's|^(ssh://)?([^@/]+@)?([^:/]+).*|\3|')
+  mkdir -p "$HOME/.ssh"
+  chmod 700 "$HOME/.ssh"
+  touch "$HOME/.ssh/known_hosts"
+  chmod 600 "$HOME/.ssh/known_hosts"
+  if ! ssh-keygen -F "$SSH_HOST" > /dev/null 2>&1; then
+    echo "Adding host key for $SSH_HOST to known_hosts..."
+    if command -v ssh-keyscan > /dev/null 2>&1; then
+      if KNOWN_HOST_ENTRY=$(ssh-keyscan -H -t rsa,ecdsa,ed25519 "$SSH_HOST" 2>/dev/null) && [ -n "$KNOWN_HOST_ENTRY" ]; then
+        printf '%s\n' "$KNOWN_HOST_ENTRY" >> "$HOME/.ssh/known_hosts"
+        echo "Host key for $SSH_HOST added to known_hosts."
+      else
+        echo "WARNING: ssh-keyscan failed for $SSH_HOST. Clone may fail if host key is not trusted."
+      fi
+    else
+      echo "ssh-keyscan not available. Using StrictHostKeyChecking=accept-new."
+      export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=accept-new"
+    fi
+  fi
+fi
+
 # Check if the directory is empty
 # and if it is, clone the repo, otherwise skip cloning
 if [ -z "$(ls -A "$CLONE_PATH")" ]; then

--- a/registry/coder/modules/git-clone/run.sh
+++ b/registry/coder/modules/git-clone/run.sh
@@ -67,7 +67,7 @@ if echo "$REPO_URL" | grep -qE '^git@|^ssh://'; then
   if ! ssh-keygen -F "$SSH_HOST" > /dev/null 2>&1; then
     echo "Adding host key for $SSH_HOST to known_hosts..."
     if command -v ssh-keyscan > /dev/null 2>&1; then
-      if KNOWN_HOST_ENTRY=$(ssh-keyscan -H -t rsa,ecdsa,ed25519 "$SSH_HOST" 2>/dev/null) && [ -n "$KNOWN_HOST_ENTRY" ]; then
+      if KNOWN_HOST_ENTRY=$(ssh-keyscan -H -t rsa,ecdsa,ed25519 "$SSH_HOST" 2> /dev/null) && [ -n "$KNOWN_HOST_ENTRY" ]; then
         printf '%s\n' "$KNOWN_HOST_ENTRY" >> "$HOME/.ssh/known_hosts"
         echo "Host key for $SSH_HOST added to known_hosts."
       else


### PR DESCRIPTION
## Description

Fix SSH clone failures on new workspaces where `~/.ssh/known_hosts` is empty. When cloning over SSH, the SSH client exits with "Host key verification failed" because there is no trusted entry for the server. This change adds a host-key scan step in `run.sh` before `git clone` runs.

**Behaviour added:**
- Detects SSH clone URLs (`git@` or `ssh://`).
- Runs `ssh-keyscan -H -t rsa,ecdsa,ed25519 <host>` and appends the result to `known_hosts` only when the host is not already present (idempotent).
- Falls back to `GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=accept-new"` when `ssh-keyscan` is not installed; this accepts new keys but still rejects changed ones.
- HTTPS URLs and subsequent workspace starts are unaffected.

## Type of Change

- [ ] New module
- [ ] New template
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder/modules/git-clone`
**New version:** bump patch
**Breaking change:** [ ] Yes [x] No

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun fmt`)
- [x] Changes tested locally

Three new test cases in `main.test.ts`:
1. SSH URL with `ssh-keyscan` available: verifies the key is scanned and added.
2. SSH URL without `ssh-keyscan`: verifies the `StrictHostKeyChecking=accept-new` fallback.
3. SSH URL with host already in `known_hosts`: verifies the scan is skipped.

## Related Issues

Fixes #60

---
> Generated by Coder Agents