### PR TITLE
feat(coder-utils): support login-blocking scripts

### DIFF
--- a/registry/coder/modules/coder-utils/README.md
+++ b/registry/coder/modules/coder-utils/README.md
@@ -16,7 +16,7 @@ The Coder Utils module is a building block for modules that need to run multiple
 ```tf
 module "coder_utils" {
   source  = "registry.coder.com/coder/coder-utils/coder"
-  version = "0.0.1"
+  version = "0.1.0"
 
   agent_id         = coder_agent.main.id
   module_directory = "$HOME/.coder-modules/coder/claude-code"
@@ -65,7 +65,7 @@ By default each `coder_script` renders in the Coder UI as plain "Install Script"
 ```tf
 module "coder_utils" {
   source  = "registry.coder.com/coder/coder-utils/coder"
-  version = "0.0.1"
+  version = "0.1.0"
 
   agent_id         = coder_agent.main.id
   module_directory = "$HOME/.coder-modules/coder/claude-code"
@@ -77,6 +77,10 @@ module "coder_utils" {
 ```
 
 Both variables are optional. `display_name_prefix` defaults to `""` (no prefix), and `icon` defaults to `null` (use the Coder provider's default).
+
+## Blocking workspace login
+
+Set `start_blocks_login = true` when every configured script must finish before a user can connect to the workspace. The default is `false`, which preserves the existing non-blocking behavior.
 
 ## Log file locations
 

--- a/registry/coder/modules/coder-utils/main.tf
+++ b/registry/coder/modules/coder-utils/main.tf
@@ -65,6 +65,12 @@ variable "icon" {
   default     = null
 }
 
+variable "start_blocks_login" {
+  description = "Whether configured scripts block workspace login until they complete."
+  type        = bool
+  default     = false
+}
+
 locals {
   path_parts  = split("/", var.module_directory)
   caller_name = "${local.path_parts[length(local.path_parts) - 2]}-${local.path_parts[length(local.path_parts) - 1]}"
@@ -104,12 +110,13 @@ locals {
 }
 
 resource "coder_script" "pre_install_script" {
-  count        = var.pre_install_script == null ? 0 : 1
-  agent_id     = var.agent_id
-  display_name = "${local.display_name_prefix}Pre-Install Script"
-  icon         = var.icon
-  run_on_start = true
-  script       = <<-EOT
+  count              = var.pre_install_script == null ? 0 : 1
+  agent_id           = var.agent_id
+  display_name       = "${local.display_name_prefix}Pre-Install Script"
+  icon               = var.icon
+  run_on_start       = true
+  start_blocks_login = var.start_blocks_login
+  script             = <<-EOT
     #!/bin/bash
     set -o errexit
     set -o pipefail
@@ -129,11 +136,12 @@ resource "coder_script" "pre_install_script" {
 }
 
 resource "coder_script" "install_script" {
-  agent_id     = var.agent_id
-  display_name = "${local.display_name_prefix}Install Script"
-  icon         = var.icon
-  run_on_start = true
-  script       = <<-EOT
+  agent_id           = var.agent_id
+  display_name       = "${local.display_name_prefix}Install Script"
+  icon               = var.icon
+  run_on_start       = true
+  start_blocks_login = var.start_blocks_login
+  script             = <<-EOT
     #!/bin/bash
     set -o errexit
     set -o pipefail
@@ -155,12 +163,13 @@ resource "coder_script" "install_script" {
 }
 
 resource "coder_script" "post_install_script" {
-  count        = var.post_install_script != null ? 1 : 0
-  agent_id     = var.agent_id
-  display_name = "${local.display_name_prefix}Post-Install Script"
-  icon         = var.icon
-  run_on_start = true
-  script       = <<-EOT
+  count              = var.post_install_script != null ? 1 : 0
+  agent_id           = var.agent_id
+  display_name       = "${local.display_name_prefix}Post-Install Script"
+  icon               = var.icon
+  run_on_start       = true
+  start_blocks_login = var.start_blocks_login
+  script             = <<-EOT
     #!/bin/bash
     set -o errexit
     set -o pipefail
@@ -177,12 +186,13 @@ resource "coder_script" "post_install_script" {
 }
 
 resource "coder_script" "start_script" {
-  count        = var.start_script != null ? 1 : 0
-  agent_id     = var.agent_id
-  display_name = "${local.display_name_prefix}Start Script"
-  icon         = var.icon
-  run_on_start = true
-  script       = <<-EOT
+  count              = var.start_script != null ? 1 : 0
+  agent_id           = var.agent_id
+  display_name       = "${local.display_name_prefix}Start Script"
+  icon               = var.icon
+  run_on_start       = true
+  start_blocks_login = var.start_blocks_login
+  script             = <<-EOT
     #!/bin/bash
     set -o errexit
     set -o pipefail

--- a/registry/coder/modules/coder-utils/main.tftest.hcl
+++ b/registry/coder/modules/coder-utils/main.tftest.hcl
@@ -382,6 +382,55 @@ run "test_icon_applied" {
   }
 }
 
+run "test_start_blocks_login_applied" {
+  command = plan
+
+  variables {
+    agent_id            = "test-agent-id"
+    module_directory    = "$HOME/.coder-modules/test/example"
+    pre_install_script  = "echo pre"
+    install_script      = "echo install"
+    post_install_script = "echo post"
+    start_script        = "echo start"
+    start_blocks_login  = true
+  }
+
+  assert {
+    condition     = coder_script.pre_install_script[0].start_blocks_login
+    error_message = "Pre-install script should block login when configured"
+  }
+
+  assert {
+    condition     = coder_script.install_script.start_blocks_login
+    error_message = "Install script should block login when configured"
+  }
+
+  assert {
+    condition     = coder_script.post_install_script[0].start_blocks_login
+    error_message = "Post-install script should block login when configured"
+  }
+
+  assert {
+    condition     = coder_script.start_script[0].start_blocks_login
+    error_message = "Start script should block login when configured"
+  }
+}
+
+run "test_start_blocks_login_disabled_by_default" {
+  command = plan
+
+  variables {
+    agent_id         = "test-agent-id"
+    module_directory = "$HOME/.coder-modules/test/example"
+    install_script   = "echo install"
+  }
+
+  assert {
+    condition     = !coder_script.install_script.start_blocks_login
+    error_message = "Install script should not block login by default"
+  }
+}
+
 # Verify optional scripts are not created when their variables are unset
 run "test_optional_scripts_absent_by_default" {
   command = plan


### PR DESCRIPTION
## Closed after architecture review

This change is not required for #425: neither `vscode-desktop-core` nor Windsurf currently depends on `coder-utils`.

The proposed input also applies `start_blocks_login` to every lifecycle phase, including `start_script`. That phase may contain a long-running process, while the Coder provider expects startup scripts to exit when complete and uses no timeout by default. Applying one broad blocking flag therefore risks leaving ordinary workspace login blocked indefinitely. The provider also documents that `start_blocks_login` sets a user-overridable default, not an absolute guarantee.

The safer implementation for #425 is a dedicated, finite extension-installation `coder_script` in `vscode-desktop-core`, with login blocking scoped only to that resource. No generic `coder-utils` behavior change is needed.

The version bump and listed validation were valid for the submitted diff, but the architecture was broader than the issue requires, so this draft is being closed rather than narrowed into an unrelated API change.