### PR TITLE
chore(registry/coder/modules/agent-firewall): revert version bump to patch (0.0.3)

### DIFF
--- a/registry/coder/modules/agent-firewall/README.md
+++ b/registry/coder/modules/agent-firewall/README.md
@@ -21,7 +21,7 @@ This module:
 ```tf
 module "agent-firewall" {
   source   = "registry.coder.com/coder/agent-firewall/coder"
-  version  = "1.0.0"
+  version  = "0.0.3"
   agent_id = coder_agent.main.id
 }
 ```
@@ -40,7 +40,7 @@ network-isolated environment.
 ```tf
 module "agent-firewall" {
   source   = "registry.coder.com/coder/agent-firewall/coder"
-  version  = "1.0.0"
+  version  = "0.0.3"
   agent_id = coder_agent.main.id
 }
 
@@ -65,7 +65,7 @@ resource "coder_script" "claude_with_agent_firewall" {
 ```tf
 module "agent-firewall" {
   source   = "registry.coder.com/coder/agent-firewall/coder"
-  version  = "1.0.0"
+  version  = "0.0.3"
   agent_id = coder_agent.main.id
 }
 
@@ -144,7 +144,7 @@ Pass the full YAML content directly:
 ```tf
 module "agent-firewall" {
   source   = "registry.coder.com/coder/agent-firewall/coder"
-  version  = "1.0.0"
+  version  = "0.0.3"
   agent_id = coder_agent.main.id
 
   agent_firewall_config = <<-YAML
@@ -168,7 +168,7 @@ your path. The file must exist on disk before agent-firewall starts.
 ```tf
 module "agent-firewall" {
   source   = "registry.coder.com/coder/agent-firewall/coder"
-  version  = "1.0.0"
+  version  = "0.0.3"
   agent_id = coder_agent.main.id
 
   agent_firewall_config_path = "/workspace/my-agent-firewall-config.yaml"


### PR DESCRIPTION
## Description

Reverts the agent-firewall module version from `1.0.0` to `0.0.3`. The major version bump in #940.

## Type of Change

- [ ] New module
- [ ] New template
- [ ] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [x] Other

## Module Information

**Path:** `registry/coder/modules/agent-firewall`
**New version:** `v0.0.3`
**Breaking change:** [ ] Yes [x] No

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun fmt`)
- [x] Changes tested locally

## Related Issues

[REG-3: Update agent-firewall registry compatibility surfaces](https://linear.app/codercom/issue/REG-3/update-agent-firewall-registry-compatibility-surfaces)

> [!NOTE]
> This PR was authored by Coder Agents on behalf of @35C4n0r.