### PR TITLE
fix(templates): fix terraform errors

### DIFF
--- a/registry/coder/templates/aws-devcontainer/main.tf
+++ b/registry/coder/templates/aws-devcontainer/main.tf
@@ -16,7 +16,8 @@ terraform {
 }
 
 module "aws_region" {
-  source  = "https://registry.coder.com/modules/aws-region"
+  source  = "registry.coder.com/coder/aws-region/coder"
+  version = "~> 1.0"
   default = "us-east-1"
 }
 
@@ -326,7 +327,6 @@ module "code-server" {
   count  = data.coder_workspace.me.start_count
   source = "registry.coder.com/coder/code-server/coder"
   # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
-  version    = "~> 1.0"
-  agent_id   = coder_agent.dev[0].id
-  agent_name = "dev"
+  version  = "~> 1.0"
+  agent_id = coder_agent.dev[0].id
 }

--- a/registry/coder/templates/aws-linux/main.tf
+++ b/registry/coder/templates/aws-linux/main.tf
@@ -201,15 +201,14 @@ module "code-server" {
   # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version = "~> 1.0"
 
-  agent_id   = coder_agent.dev[0].id
-  agent_name = "dev"
-  order      = 1
+  agent_id = coder_agent.dev[0].id
+  order    = 1
 }
 
 # See https://registry.coder.com/modules/coder/jetbrains
 module "jetbrains" {
   count      = data.coder_workspace.me.start_count
-  source     = "registry.coder.com/modules/coder/jetbrains/coder"
+  source     = "registry.coder.com/coder/jetbrains/coder"
   version    = "~> 1.0"
   agent_id   = coder_agent.dev[0].id
   agent_name = "dev"

--- a/registry/coder/templates/azure-linux/main.tf
+++ b/registry/coder/templates/azure-linux/main.tf
@@ -144,15 +144,14 @@ module "code-server" {
   # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version = "~> 1.0"
 
-  agent_id   = coder_agent.main.id
-  agent_name = "main"
-  order      = 1
+  agent_id = coder_agent.main.id
+  order    = 1
 }
 
 # See https://registry.coder.com/modules/coder/jetbrains
 module "jetbrains" {
   count      = data.coder_workspace.me.start_count
-  source     = "registry.coder.com/modules/coder/jetbrains/coder"
+  source     = "registry.coder.com/coder/jetbrains/coder"
   version    = "~> 1.0"
   agent_id   = coder_agent.main.id
   agent_name = "main"

--- a/registry/coder/templates/azure-windows/main.tf
+++ b/registry/coder/templates/azure-windows/main.tf
@@ -36,9 +36,7 @@ module "windows_rdp" {
   admin_username = local.admin_username
   admin_password = random_password.admin_password.result
 
-  agent_id    = coder_agent.main.id
-  agent_name  = "main"
-  resource_id = null # Unused, to be removed in a future version
+  agent_id = coder_agent.main.id
 }
 
 data "coder_parameter" "data_disk_size" {

--- a/registry/coder/templates/digitalocean-linux/main.tf
+++ b/registry/coder/templates/digitalocean-linux/main.tf
@@ -272,15 +272,14 @@ module "code-server" {
   # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version = "~> 1.0"
 
-  agent_id   = coder_agent.main.id
-  agent_name = "main"
-  order      = 1
+  agent_id = coder_agent.main.id
+  order    = 1
 }
 
 # See https://registry.coder.com/modules/coder/jetbrains
 module "jetbrains" {
   count      = data.coder_workspace.me.start_count
-  source     = "registry.coder.com/modules/coder/jetbrains/coder"
+  source     = "registry.coder.com/coder/jetbrains/coder"
   version    = "~> 1.0"
   agent_id   = coder_agent.main.id
   agent_name = "main"

--- a/registry/coder/templates/docker-devcontainer/main.tf
+++ b/registry/coder/templates/docker-devcontainer/main.tf
@@ -330,15 +330,14 @@ module "code-server" {
   # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version = "~> 1.0"
 
-  agent_id   = coder_agent.main.id
-  agent_name = "main"
-  order      = 1
+  agent_id = coder_agent.main.id
+  order    = 1
 }
 
 # See https://registry.coder.com/modules/coder/jetbrains
 module "jetbrains" {
   count      = data.coder_workspace.me.start_count
-  source     = "registry.coder.com/modules/coder/jetbrains/coder"
+  source     = "registry.coder.com/coder/jetbrains/coder"
   version    = "~> 1.0"
   agent_id   = coder_agent.main.id
   agent_name = "main"

--- a/registry/coder/templates/docker/main.tf
+++ b/registry/coder/templates/docker/main.tf
@@ -129,15 +129,14 @@ module "code-server" {
   # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version = "~> 1.0"
 
-  agent_id   = coder_agent.main.id
-  agent_name = "main"
-  order      = 1
+  agent_id = coder_agent.main.id
+  order    = 1
 }
 
 # See https://registry.coder.com/modules/coder/jetbrains
 module "jetbrains" {
   count      = data.coder_workspace.me.start_count
-  source     = "registry.coder.com/modules/coder/jetbrains/coder"
+  source     = "registry.coder.com/coder/jetbrains/coder"
   version    = "~> 1.0"
   agent_id   = coder_agent.main.id
   agent_name = "main"

--- a/registry/coder/templates/gcp-devcontainer/main.tf
+++ b/registry/coder/templates/gcp-devcontainer/main.tf
@@ -291,17 +291,16 @@ module "code-server" {
   # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version = "~> 1.0"
 
-  agent_id   = coder_agent.main.id
-  agent_name = "main"
-  order      = 1
+  agent_id = coder_agent.dev[0].id
+  order    = 1
 }
 
 # See https://registry.coder.com/modules/coder/jetbrains
 module "jetbrains" {
   count      = data.coder_workspace.me.start_count
-  source     = "registry.coder.com/modules/coder/jetbrains/coder"
+  source     = "registry.coder.com/coder/jetbrains/coder"
   version    = "~> 1.0"
-  agent_id   = coder_agent.main.id
+  agent_id   = coder_agent.dev[0].id
   agent_name = "main"
   folder     = "/workspaces"
 }

--- a/registry/coder/templates/gcp-linux/main.tf
+++ b/registry/coder/templates/gcp-linux/main.tf
@@ -99,15 +99,14 @@ module "code-server" {
   # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version = "~> 1.0"
 
-  agent_id   = coder_agent.main.id
-  agent_name = "main"
-  order      = 1
+  agent_id = coder_agent.main.id
+  order    = 1
 }
 
 # See https://registry.coder.com/modules/coder/jetbrains
 module "jetbrains" {
   count      = data.coder_workspace.me.start_count
-  source     = "registry.coder.com/modules/coder/jetbrains/coder"
+  source     = "registry.coder.com/coder/jetbrains/coder"
   version    = "~> 1.0"
   agent_id   = coder_agent.main.id
   agent_name = "main"

--- a/registry/coder/templates/gcp-vm-container/main.tf
+++ b/registry/coder/templates/gcp-vm-container/main.tf
@@ -52,15 +52,14 @@ module "code-server" {
   # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version = "~> 1.0"
 
-  agent_id   = coder_agent.main.id
-  agent_name = "main"
-  order      = 1
+  agent_id = coder_agent.main.id
+  order    = 1
 }
 
 # See https://registry.coder.com/modules/coder/jetbrains
 module "jetbrains" {
   count      = data.coder_workspace.me.start_count
-  source     = "registry.coder.com/modules/coder/jetbrains/coder"
+  source     = "registry.coder.com/coder/jetbrains/coder"
   version    = "~> 1.0"
   agent_id   = coder_agent.main.id
   agent_name = "main"
@@ -113,7 +112,6 @@ resource "google_compute_instance" "dev" {
 resource "coder_agent_instance" "dev" {
   count       = data.coder_workspace.me.start_count
   agent_id    = coder_agent.main.id
-  agent_name  = "main"
   instance_id = google_compute_instance.dev[0].instance_id
 }
 

--- a/registry/coder/templates/incus/main.tf
+++ b/registry/coder/templates/incus/main.tf
@@ -138,37 +138,31 @@ module "coder-login" {
   agent_id = local.agent_id
 }
 
-resource "incus_volume" "home" {
+resource "incus_storage_volume" "home" {
   name = "coder-${data.coder_workspace.me.id}-home"
   pool = local.pool
 }
 
-resource "incus_volume" "docker" {
+resource "incus_storage_volume" "docker" {
   name = "coder-${data.coder_workspace.me.id}-docker"
   pool = local.pool
 }
 
-resource "incus_cached_image" "image" {
-  source_remote = "images"
-  source_image  = data.coder_parameter.image.value
-}
-
-resource "incus_instance_file" "agent_token" {
-  count              = data.coder_workspace.me.start_count
-  instance           = incus_instance.dev.name
-  content            = <<EOF
-CODER_AGENT_TOKEN=${local.agent_token}
-EOF
-  create_directories = true
-  target_path        = "/opt/coder/init.env"
+resource "incus_image" "image" {
+  source_image = {
+    remote = "images"
+    name   = data.coder_parameter.image.value
+  }
 }
 
 resource "incus_instance" "dev" {
   running = data.coder_workspace.me.start_count == 1
   name    = "coder-${lower(data.coder_workspace_owner.me.name)}-${lower(data.coder_workspace.me.name)}"
-  image   = incus_cached_image.image.fingerprint
+  image   = incus_image.image.fingerprint
 
   config = {
+    "limits.cpu"                           = data.coder_parameter.cpu.value
+    "limits.memory"                        = "${data.coder_parameter.cpu.value}GiB"
     "security.nesting"                     = true
     "security.syscalls.intercept.mknod"    = true
     "security.syscalls.intercept.setxattr" = true
@@ -190,6 +184,10 @@ write_files:
     permissions: "0755"
     encoding: b64
     content: ${base64encode(local.agent_init_script)}
+  - path: /opt/coder/init.env
+    permissions: "0644"
+    encoding: b64
+    content: ${base64encode("CODER_AGENT_TOKEN=${local.agent_token}\n")}
   - path: /etc/systemd/system/coder-agent.service
     permissions: "0644"
     content: |
@@ -246,18 +244,13 @@ runcmd:
 EOF
   }
 
-  limits = {
-    cpu    = data.coder_parameter.cpu.value
-    memory = "${data.coder_parameter.cpu.value}GiB"
-  }
-
   device {
     name = "home"
     type = "disk"
     properties = {
       path   = "/home/${local.workspace_user}"
       pool   = local.pool
-      source = incus_volume.home.name
+      source = incus_storage_volume.home.name
     }
   }
 
@@ -267,7 +260,7 @@ EOF
     properties = {
       path   = "/var/lib/docker"
       pool   = local.pool
-      source = incus_volume.docker.name
+      source = incus_storage_volume.docker.name
     }
   }
 
@@ -296,11 +289,11 @@ resource "coder_metadata" "info" {
   resource_id = incus_instance.dev.name
   item {
     key   = "memory"
-    value = incus_instance.dev.limits.memory
+    value = incus_instance.dev.config["limits.memory"]
   }
   item {
     key   = "cpus"
-    value = incus_instance.dev.limits.cpu
+    value = incus_instance.dev.config["limits.cpu"]
   }
   item {
     key   = "instance"
@@ -308,10 +301,10 @@ resource "coder_metadata" "info" {
   }
   item {
     key   = "image"
-    value = "${incus_cached_image.image.source_remote}:${incus_cached_image.image.source_image}"
+    value = "${incus_image.image.source_image.remote}:${incus_image.image.source_image.name}"
   }
   item {
     key   = "image_fingerprint"
-    value = substr(incus_cached_image.image.fingerprint, 0, 12)
+    value = substr(incus_image.image.fingerprint, 0, 12)
   }
 }

--- a/registry/coder/templates/kubernetes/main.tf
+++ b/registry/coder/templates/kubernetes/main.tf
@@ -177,7 +177,6 @@ resource "coder_agent" "main" {
 # code-server
 resource "coder_app" "code-server" {
   agent_id     = coder_agent.main.id
-  agent_name   = "main"
   slug         = "code-server"
   display_name = "code-server"
   icon         = "/icon/code.svg"

--- a/registry/coder/templates/nomad-docker/main.tf
+++ b/registry/coder/templates/nomad-docker/main.tf
@@ -118,9 +118,8 @@ module "code-server" {
   # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version = "~> 1.0"
 
-  agent_id   = coder_agent.main.id
-  agent_name = "main"
-  order      = 1
+  agent_id = coder_agent.main.id
+  order    = 1
 }
 
 locals {

--- a/registry/coder/templates/scratch/main.tf
+++ b/registry/coder/templates/scratch/main.tf
@@ -34,10 +34,9 @@ resource "coder_agent" "main" {
 # Use this to set environment variables in your workspace
 # details: https://registry.terraform.io/providers/coder/coder/latest/docs/resources/env
 resource "coder_env" "welcome_message" {
-  agent_id   = coder_agent.main.id
-  agent_name = "main"
-  name       = "WELCOME_MESSAGE"
-  value      = "Welcome to your Coder workspace!"
+  agent_id = coder_agent.main.id
+  name     = "WELCOME_MESSAGE"
+  value    = "Welcome to your Coder workspace!"
 }
 
 # Adds code-server
@@ -49,15 +48,13 @@ module "code-server" {
   # This ensures that the latest non-breaking version of the module gets downloaded, you can also pin the module version to prevent breaking changes in production.
   version = "~> 1.0"
 
-  agent_id   = coder_agent.main.id
-  agent_name = "main"
+  agent_id = coder_agent.main.id
 }
 
 # Runs a script at workspace start/stop or on a cron schedule
 # details: https://registry.terraform.io/providers/coder/coder/latest/docs/resources/script
 resource "coder_script" "startup_script" {
   agent_id           = coder_agent.main.id
-  agent_name         = "main"
   display_name       = "Startup Script"
   script             = <<-EOF
     #!/bin/sh


### PR DESCRIPTION
## Problem

Now that `scripts/terraform_validate.sh` validates templates (from #948), running `terraform validate` across the registry surfaces pre-existing breakages in **14 `coder/*` templates**. This PR fixes all of them so they pass validation.

## Fixes

**Unsupported `agent_name` argument** (dominant issue)
- Removed `agent_name` from `code-server` / `windows_rdp` module calls and from `coder_app` / `coder_env` / `coder_script` / `coder_agent_instance` resources. Only the `jetbrains` and `filebrowser` modules actually declare an `agent_name` variable, so those usages are left intact.

**Invalid `jetbrains` module source**
- `registry.coder.com/modules/coder/jetbrains/coder` (5 components — invalid) → `registry.coder.com/coder/jetbrains/coder`.

**windows_rdp stray argument**
- Removed `resource_id = null` (no longer a supported argument).

**aws-devcontainer region module**
- Replaced the raw `source = "https://registry.coder.com/modules/aws-region"` URL with the proper registry source `registry.coder.com/coder/aws-region/coder` + `version = "~> 1.0"`.

**gcp-devcontainer agent reference**
- Fixed module calls referencing the non-existent `coder_agent.main`; the agent in that template is `coder_agent.dev` (count-based), so they now use `coder_agent.dev[0].id`.

**incus provider schema drift**
- `incus_volume` → `incus_storage_volume`
- `incus_cached_image` → `incus_image` (object-form `source_image = { remote, name }`)
- Dropped the unsupported `incus_instance_file` resource; the agent token is now delivered via cloud-init `write_files` (consistent with how the init script and systemd units are already delivered).
- Moved instance `limits` into `config` (`limits.cpu` / `limits.memory`) and updated `coder_metadata` references accordingly.

## Validation

All 14 previously-failing templates now pass `terraform validate`:

```
aws-devcontainer, aws-linux, azure-linux, azure-windows, digitalocean-linux,
docker, docker-devcontainer, gcp-devcontainer, gcp-linux, gcp-vm-container,
kubernetes, nomad-docker, scratch, incus  → all Success
```

`terraform fmt` / prettier applied. No `.terraform` artifacts or lockfiles committed.

> [!NOTE]
> Changes are confined to template `main.tf` files. The incus rework in particular adapts to the current `lxc/incus` provider schema; the token-via-cloud-init approach matches the sibling `bpmct/incus-*` templates.

Generated with [Mux](https://mux.coder.com/).
