### PR TITLE
fix(mux): bootstrap Node.js runtime when missing from workspace image

### DIFF
--- a/registry/coder/modules/mux/README.md
+++ b/registry/coder/modules/mux/README.md
@@ -63,7 +63,7 @@ Start Mux with `mux server --add-project /path/to/project`:
 module "mux" {
   count       = data.coder_workspace.me.start_count
   source      = "registry.coder.com/coder/mux/coder"
-  version  = "1.5.0"
+  version     = "1.5.0"
   agent_id    = coder_agent.main.id
   add_project = "/path/to/project"
 }
@@ -78,7 +78,7 @@ The module parses quoted values, so grouped arguments remain intact.
 module "mux" {
   count                = data.coder_workspace.me.start_count
   source               = "registry.coder.com/coder/mux/coder"
-  version  = "1.5.0"
+  version              = "1.5.0"
   agent_id             = coder_agent.main.id
   additional_arguments = "--open-mode pinned --add-project '/workspaces/my repo'"
 }
@@ -92,7 +92,7 @@ Enable automatic restarts after Mux exits, including clean exits and intentional
 module "mux" {
   count                 = data.coder_workspace.me.start_count
   source                = "registry.coder.com/coder/mux/coder"
-  version  = "1.5.0"
+  version               = "1.5.0"
   agent_id              = coder_agent.main.id
   restart_on_kill       = true
   restart_delay_seconds = 3
@@ -120,7 +120,7 @@ Force a specific package manager instead of auto-detection:
 module "mux" {
   count           = data.coder_workspace.me.start_count
   source          = "registry.coder.com/coder/mux/coder"
-  version  = "1.5.0"
+  version         = "1.5.0"
   agent_id        = coder_agent.main.id
   package_manager = "pnpm" # or "npm", "bun"
 }
@@ -134,7 +134,7 @@ Use a private or mirrored npm registry:
 module "mux" {
   count        = data.coder_workspace.me.start_count
   source       = "registry.coder.com/coder/mux/coder"
-  version  = "1.5.0"
+  version      = "1.5.0"
   agent_id     = coder_agent.main.id
   registry_url = "https://npm.pkg.github.com"
 }
@@ -148,7 +148,7 @@ Run an existing copy of Mux if found, otherwise install from npm:
 module "mux" {
   count      = data.coder_workspace.me.start_count
   source     = "registry.coder.com/coder/mux/coder"
-  version  = "1.5.0"
+  version    = "1.5.0"
   agent_id   = coder_agent.main.id
   use_cached = true
 }

--- a/registry/coder/modules/mux/README.md
+++ b/registry/coder/modules/mux/README.md
@@ -14,7 +14,7 @@ Automatically install and run [Mux](https://github.com/coder/mux) in a Coder wor
 module "mux" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/mux/coder"
-  version  = "1.4.3"
+  version  = "1.5.0"
   agent_id = coder_agent.main.id
 }
 ```
@@ -37,7 +37,7 @@ module "mux" {
 module "mux" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/mux/coder"
-  version  = "1.4.3"
+  version  = "1.5.0"
   agent_id = coder_agent.main.id
 }
 ```
@@ -48,7 +48,7 @@ module "mux" {
 module "mux" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/mux/coder"
-  version  = "1.4.3"
+  version  = "1.5.0"
   agent_id = coder_agent.main.id
   # Default is "latest"; set to a specific version to pin
   install_version = "0.4.0"
@@ -63,7 +63,7 @@ Start Mux with `mux server --add-project /path/to/project`:
 module "mux" {
   count       = data.coder_workspace.me.start_count
   source      = "registry.coder.com/coder/mux/coder"
-  version     = "1.4.3"
+  version  = "1.5.0"
   agent_id    = coder_agent.main.id
   add_project = "/path/to/project"
 }
@@ -78,7 +78,7 @@ The module parses quoted values, so grouped arguments remain intact.
 module "mux" {
   count                = data.coder_workspace.me.start_count
   source               = "registry.coder.com/coder/mux/coder"
-  version              = "1.4.3"
+  version  = "1.5.0"
   agent_id             = coder_agent.main.id
   additional_arguments = "--open-mode pinned --add-project '/workspaces/my repo'"
 }
@@ -92,7 +92,7 @@ Enable automatic restarts after Mux exits, including clean exits and intentional
 module "mux" {
   count                 = data.coder_workspace.me.start_count
   source                = "registry.coder.com/coder/mux/coder"
-  version               = "1.4.3"
+  version  = "1.5.0"
   agent_id              = coder_agent.main.id
   restart_on_kill       = true
   restart_delay_seconds = 3
@@ -106,7 +106,7 @@ module "mux" {
 module "mux" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/mux/coder"
-  version  = "1.4.3"
+  version  = "1.5.0"
   agent_id = coder_agent.main.id
   port     = 8080
 }
@@ -120,7 +120,7 @@ Force a specific package manager instead of auto-detection:
 module "mux" {
   count           = data.coder_workspace.me.start_count
   source          = "registry.coder.com/coder/mux/coder"
-  version         = "1.4.3"
+  version  = "1.5.0"
   agent_id        = coder_agent.main.id
   package_manager = "pnpm" # or "npm", "bun"
 }
@@ -134,7 +134,7 @@ Use a private or mirrored npm registry:
 module "mux" {
   count        = data.coder_workspace.me.start_count
   source       = "registry.coder.com/coder/mux/coder"
-  version      = "1.4.3"
+  version  = "1.5.0"
   agent_id     = coder_agent.main.id
   registry_url = "https://npm.pkg.github.com"
 }
@@ -148,7 +148,7 @@ Run an existing copy of Mux if found, otherwise install from npm:
 module "mux" {
   count      = data.coder_workspace.me.start_count
   source     = "registry.coder.com/coder/mux/coder"
-  version    = "1.4.3"
+  version  = "1.5.0"
   agent_id   = coder_agent.main.id
   use_cached = true
 }
@@ -162,7 +162,7 @@ Run without installing from the network (requires Mux to be pre-installed):
 module "mux" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/mux/coder"
-  version  = "1.4.3"
+  version  = "1.5.0"
   agent_id = coder_agent.main.id
   install  = false
 }
@@ -177,6 +177,7 @@ module "mux" {
 - Mux is currently in preview and you may encounter bugs
 - Requires internet connectivity for agent operations (unless `install` is set to false)
 - Auto-detects `npm`, `pnpm`, or `bun` by default; set `package_manager` to force a specific one
+- Requires a Node.js runtime; if `node` is not on the workspace `PATH`, the module bootstraps a pinned Node.js runtime into `~/.local/share/coder-mux` (override the version with the `MUX_NODE_VERSION` environment variable)
 - Installs `mux@next` from the npm registry by default; set `registry_url` to use a private or mirrored registry
 - Falls back to a direct tarball download when no package manager is found
 - Appends best-effort signal and external-kill diagnostics to `log_path` if the mux process dies after startup

--- a/registry/coder/modules/mux/run.sh
+++ b/registry/coder/modules/mux/run.sh
@@ -194,6 +194,45 @@ while true; do
 done
 EOF_LAUNCHER
 }
+# Ensure a Node.js runtime is available (mux is a Node application launched
+# via "#!/usr/bin/env node"). When the workspace image does not provide node,
+# bootstrap a pinned runtime into $HOME so it persists across restarts.
+ensure_node() {
+  if command -v node > /dev/null 2>&1; then
+    return 0
+  fi
+
+  local node_version node_arch node_dir
+  node_version="$${MUX_NODE_VERSION:-22.14.0}"
+  case "$(uname -m)" in
+    x86_64 | amd64) node_arch="x64" ;;
+    aarch64 | arm64) node_arch="arm64" ;;
+    *)
+      echo "❌ node is required to run mux but was not found on PATH, and automatic bootstrap does not support architecture '$(uname -m)'."
+      exit 1
+      ;;
+  esac
+
+  node_dir="$HOME/.local/share/coder-mux/node-v$node_version-linux-$node_arch"
+  if [ ! -x "$node_dir/bin/node" ]; then
+    echo "⚠️ node not found on PATH; bootstrapping Node.js v$node_version into $node_dir..."
+    mkdir -p "$(dirname "$node_dir")"
+    if ! curl -fsSL "https://nodejs.org/dist/v$node_version/node-v$node_version-linux-$node_arch.tar.gz" | tar -xz -C "$(dirname "$node_dir")"; then
+      echo "❌ Failed to download Node.js v$node_version. mux cannot start without node."
+      exit 1
+    fi
+  fi
+
+  export PATH="$node_dir/bin:$PATH"
+
+  # Expose node to other workspace scripts via the agent bin dir.
+  if [ -n "$CODER_SCRIPT_BIN_DIR" ] && [ ! -e "$CODER_SCRIPT_BIN_DIR/node" ]; then
+    ln -s "$node_dir/bin/node" "$CODER_SCRIPT_BIN_DIR/node"
+  fi
+}
+
+ensure_node
+
 # Check if mux is already installed for offline mode
 if [ "${OFFLINE}" = true ]; then
   if [ -f "$MUX_BINARY" ]; then


### PR DESCRIPTION
## Description

The mux module launches mux via `#!/usr/bin/env node` but never verifies that a Node.js runtime exists in the workspace image. On images without node (e.g. `codercom/enterprise-base:ubuntu`), the install step succeeds via the tarball fallback, but the server immediately dies with:

```
/usr/bin/env: 'node': No such file or directory
[...] mux server exited with code 127.
```

This PR adds an `ensure_node` bootstrap to `run.sh`: if `node` is not on `PATH`, it downloads a pinned Node.js runtime (default `22.14.0`, overridable via the `MUX_NODE_VERSION` environment variable) into `~/.local/share/coder-mux` — which persists across workspace restarts on home-volume setups — exports it on `PATH` before launching mux, and symlinks `node` into `$CODER_SCRIPT_BIN_DIR` for other workspace scripts. Supports x64 and arm64; fails fast with a clear error on unsupported architectures or download failure instead of a bare exit 127.

Since the launcher inherits the modified `PATH` through `nohup env ... bash`, the `#!/usr/bin/env node` shebang resolves correctly. Images that already ship node are unaffected (`ensure_node` returns immediately).

## Type of Change

- [ ] New module
- [ ] New template
- [x] Bug fix
- [x] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder/modules/mux`
**New version:** `v1.5.0`
**Breaking change:** [ ] Yes [x] No

## Testing & Validation

- [ ] Tests pass (`bun test`)
- [ ] Code formatted (`bun fmt`)
- [x] Changes tested locally

Validated with `bash -n` on the rendered template, and functionally tested the bootstrap in a simulated node-less environment (`env -i` with a restricted `PATH`): Node 22.14.0 was downloaded to `~/.local/share/coder-mux`, resolved on `PATH`, and the `$CODER_SCRIPT_BIN_DIR/node` symlink was created. Also verified the failure mode end-to-end on a live Coder deployment where a workspace on `enterprise-base:ubuntu` hit exit 127.

## Related Issues

None
