### PR TITLE
fix(vault-jwt): correct display name and make it configurable

### DIFF
--- a/registry/coder/modules/vault-jwt/README.md
+++ b/registry/coder/modules/vault-jwt/README.md
@@ -14,7 +14,7 @@ This module lets you authenticate with [Hashicorp Vault](https://www.vaultprojec
 module "vault" {
   count           = data.coder_workspace.me.start_count
   source          = "registry.coder.com/coder/vault-jwt/coder"
-  version         = "1.2.2"
+  version         = "1.3.0"
   agent_id        = coder_agent.example.id
   vault_addr      = "https://vault.example.com"
   vault_jwt_role  = "coder"                # The Vault role to use for authentication
@@ -42,7 +42,7 @@ curl -H "X-Vault-Token: ${VAULT_TOKEN}" -X GET "${VAULT_ADDR}/v1/coder/secrets/d
 module "vault" {
   count               = data.coder_workspace.me.start_count
   source              = "registry.coder.com/coder/vault-jwt/coder"
-  version             = "1.2.2"
+  version             = "1.3.0"
   agent_id            = coder_agent.example.id
   vault_addr          = "https://vault.example.com"
   vault_jwt_auth_path = "oidc"
@@ -58,7 +58,7 @@ data "coder_workspace_owner" "me" {}
 module "vault" {
   count          = data.coder_workspace.me.start_count
   source         = "registry.coder.com/coder/vault-jwt/coder"
-  version        = "1.2.2"
+  version        = "1.3.0"
   agent_id       = coder_agent.example.id
   vault_addr     = "https://vault.example.com"
   vault_jwt_role = data.coder_workspace_owner.me.groups[0]
@@ -71,11 +71,27 @@ module "vault" {
 module "vault" {
   count             = data.coder_workspace.me.start_count
   source            = "registry.coder.com/coder/vault-jwt/coder"
-  version           = "1.2.2"
+  version           = "1.3.0"
   agent_id          = coder_agent.example.id
   vault_addr        = "https://vault.example.com"
   vault_jwt_role    = "coder" # The Vault role to use for authentication
   vault_cli_version = "1.2.2"
+}
+```
+
+### Customize the workspace logs display name
+
+By default the workspace logs entry is labeled `Vault (JWT)`. Override it with `display_name` if you run multiple Vault modules in the same workspace:
+
+```tf
+module "vault" {
+  count          = data.coder_workspace.me.start_count
+  source         = "registry.coder.com/coder/vault-jwt/coder"
+  version        = "1.3.0"
+  agent_id       = coder_agent.example.id
+  vault_addr     = "https://vault.example.com"
+  vault_jwt_role = "coder" # The Vault role to use for authentication
+  display_name   = "Vault (Coder OIDC)"
 }
 ```
 
@@ -132,7 +148,7 @@ resource "jwt_signed_token" "vault" {
 module "vault" {
   count           = data.coder_workspace.me.start_count
   source          = "registry.coder.com/coder/vault-jwt/coder"
-  version         = "1.2.2"
+  version         = "1.3.0"
   agent_id        = coder_agent.example.id
   vault_addr      = "https://vault.example.com"
   vault_jwt_role  = "coder" # The Vault role to use for authentication

--- a/registry/coder/modules/vault-jwt/main.tf
+++ b/registry/coder/modules/vault-jwt/main.tf
@@ -54,9 +54,15 @@ variable "vault_cli_version" {
   }
 }
 
+variable "display_name" {
+  type        = string
+  description = "The display name of the coder_script resource shown in the workspace logs."
+  default     = "Vault (JWT)"
+}
+
 resource "coder_script" "vault" {
   agent_id     = var.agent_id
-  display_name = "Vault (GitHub)"
+  display_name = var.display_name
   icon         = "/icon/vault.svg"
   script = templatefile("${path.module}/run.sh", {
     CODER_OIDC_ACCESS_TOKEN : var.vault_jwt_token != null ? var.vault_jwt_token : data.coder_workspace_owner.me.oidc_access_token,

--- a/registry/coder/modules/vault-jwt/main.tf
+++ b/registry/coder/modules/vault-jwt/main.tf
@@ -55,8 +55,8 @@ variable "vault_cli_version" {
 }
 
 variable "display_name" {
-  type        = string
   description = "The display name of the coder_script resource shown in the workspace logs."
+  type        = string
   default     = "Vault (JWT)"
 }
 


### PR DESCRIPTION
Closes coder/registry#1017

## Problem

The `vault-jwt` module's `coder_script` resource had a hardcoded `display_name = "Vault (GitHub)"`, copy-pasted from the `vault-github` module. Workspaces using `vault-jwt` showed the wrong label in the workspace logs.

## Fix

* Corrected the hardcoded label to `"Vault (JWT)"`.
* Made it configurable via a new `display_name` variable (defaults to `"Vault (JWT)"`), per the "nice to have" in the issue, so users running multiple Vault modules in one workspace can distinguish them.
* Documented the new variable with an example in the README and bumped the module version to `1.3.0` (minor, new input) per [CONTRIBUTING.md](<https://github.com/coder/registry/blob/main/CONTRIBUTING.md#versioning-guidelines>).

## Validation

Existing `main.test.ts` covers required variables; no behavioral test needed for a display label change. CI will run `terraform test` and `bun test` on this PR.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review. 🧑💻