### PR TITLE
fix(jupyterlab): empty positional root dir

### DIFF
--- a/registry/coder/modules/jupyterlab/README.md
+++ b/registry/coder/modules/jupyterlab/README.md
@@ -16,7 +16,7 @@ A module that adds JupyterLab in your Coder template.
 module "jupyterlab" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/jupyterlab/coder"
-  version  = "1.2.2"
+  version  = "1.2.3"
   agent_id = coder_agent.main.id
 }
 ```
@@ -29,7 +29,7 @@ JupyterLab is automatically configured to work with Coder's iframe embedding. Fo
 module "jupyterlab" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/jupyterlab/coder"
-  version  = "1.2.2"
+  version  = "1.2.3"
   agent_id = coder_agent.main.id
   config = {
     ServerApp = {

--- a/registry/coder/modules/jupyterlab/run.sh
+++ b/registry/coder/modules/jupyterlab/run.sh
@@ -19,10 +19,6 @@ check_available_installer() {
   exit 1
 }
 
-if [ -n "${BASE_URL}" ]; then
-  BASE_URL_FLAG="--ServerApp.base_url=${BASE_URL}"
-fi
-
 BOLD='\033[0;1m'
 
 # check if jupyterlab is installed
@@ -50,7 +46,7 @@ fi
 printf "👷 Starting jupyterlab in background..."
 printf "check logs at ${LOG_PATH}"
 $JUPYTER --no-browser \
-  "$BASE_URL_FLAG" \
+  --ServerApp.base_url=${BASE_URL} \
   --ServerApp.ip='*' \
   --ServerApp.port="${PORT}" \
   --ServerApp.token='' \


### PR DESCRIPTION
## Description

The JupyterLab module's `run.sh` builds the launch command with a  <br>`BASE_URL_FLAG` variable that is only set when `base_url` is non-empty.  <br>With `subdomain = true`, `base_url` is empty, so the flag expands to an  <br>empty argument. Jupyter reads that empty argument as a positional (the  <br>directory to open), which overrides `ServerApp.root_dir` — so a  <br>user-configured `root_dir` is silently ignored.

This drops `BASE_URL_FLAG` and passes `--ServerApp.base_url=${BASE_URL}`  <br>inline. An empty value normalizes to `/` and is never treated as a  <br>positional, so `root_dir` is respected in both the subdomain and  <br>path-based cases.

## Type of Change

- [X] Bug fix

## Module Information

**Path:** `registry/coder/modules/jupyterlab`  <br>**New version:** `v1.2.3`  <br>**Breaking change:** No

## Testing & Validation

- [X] Changes tested locally (Coder workspace, subdomain routing: launch  <br>line shows `--ServerApp.base_url=` with no empty positional, and  <br>`root_dir` is honored)

## Related Issues

Closes coder/registry#1026