### PR TITLE
fix(.github): write scorecard discussions with GITHUB_TOKEN and fail runs on scoring errors

### DIFF
--- a/.github/scorecard/score-modules.ts
+++ b/.github/scorecard/score-modules.ts
@@ -384,6 +384,7 @@ async function main() {
   if (args.limit) modules = modules.slice(0, args.limit);
 
   const prSections: string[] = [];
+  const failed: string[] = [];
   for (const mod of modules) {
     if (!existsSync(path.join(MODULES_DIR, mod, "README.md"))) {
       console.error(`skip ${mod}: no README.md`);
@@ -434,8 +435,16 @@ async function main() {
       );
       process.stderr.write(`${created ? "created" : "updated"} ${url}\n`);
     } catch (err) {
+      failed.push(mod);
       process.stderr.write(`FAILED: ${err}\n`);
     }
+  }
+
+  if (failed.length > 0) {
+    process.stderr.write(
+      `\n${failed.length} module(s) failed to score: ${failed.join(", ")}\n`,
+    );
+    process.exitCode = 1;
   }
 
   if (args.prReport) {

--- a/.github/workflows/module-scorecard-check.yaml
+++ b/.github/workflows/module-scorecard-check.yaml
@@ -9,7 +9,9 @@
 #
 # Required repository secrets:
 #   SCORECARD_ANTHROPIC_API_KEY  Anthropic API key used for scoring
-#   SCORECARD_DISCUSSIONS_TOKEN  GitHub PAT with Discussions read (baseline lookup)
+#
+# The baseline lookup reads discussions with the built-in GITHUB_TOKEN
+# (discussions: read below); no PAT is needed.
 
 name: Module Scorecard Check
 
@@ -20,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  discussions: read
   pull-requests: write
 
 concurrency:
@@ -62,7 +65,7 @@ jobs:
         if: steps.changed.outputs.modules != ''
         env:
           ANTHROPIC_API_KEY: ${{ secrets.SCORECARD_ANTHROPIC_API_KEY }}
-          GITHUB_DISCUSSIONS_TOKEN: ${{ secrets.SCORECARD_DISCUSSIONS_TOKEN }}
+          GITHUB_DISCUSSIONS_TOKEN: ${{ github.token }}
           MODULES: ${{ steps.changed.outputs.modules }}
         run: bun run .github/scorecard/score-modules.ts --modules "${MODULES}" --pr-report /tmp/scorecard-report.md
 

--- a/.github/workflows/module-scorecards.yaml
+++ b/.github/workflows/module-scorecards.yaml
@@ -10,7 +10,9 @@
 #
 # Required repository secrets:
 #   SCORECARD_ANTHROPIC_API_KEY  Anthropic API key used for scoring
-#   SCORECARD_DISCUSSIONS_TOKEN  GitHub PAT with Discussions read/write
+#
+# Discussions are written with the built-in GITHUB_TOKEN (discussions: write
+# below), so no PAT is needed and there is nothing to expire or rotate.
 
 name: Module Scorecards
 
@@ -28,6 +30,7 @@ on:
 
 permissions:
   contents: read
+  discussions: write
 
 concurrency:
   group: module-scorecards
@@ -86,12 +89,12 @@ jobs:
       - name: Score modules and update module discussions
         env:
           ANTHROPIC_API_KEY: ${{ secrets.SCORECARD_ANTHROPIC_API_KEY }}
-          GITHUB_DISCUSSIONS_TOKEN: ${{ secrets.SCORECARD_DISCUSSIONS_TOKEN }}
+          GITHUB_DISCUSSIONS_TOKEN: ${{ github.token }}
         run: bun run .github/scorecard/score-modules.ts ${{ steps.scope.outputs.args }}
 
       - name: Update index discussion
         env:
-          GITHUB_DISCUSSIONS_TOKEN: ${{ secrets.SCORECARD_DISCUSSIONS_TOKEN }}
+          GITHUB_DISCUSSIONS_TOKEN: ${{ github.token }}
         # The index reads scores back from the module discussions, so a
         # single-module run still produces a complete index.
         run: bun run .github/scorecard/scorecard-index.ts


### PR DESCRIPTION
The scorecard workflows authenticated to Discussions with a fine-grained PAT (`SCORECARD_DISCUSSIONS_TOKEN`). It expired after its 30-day default on ~Aug 16 and every run since failed with 401 until the secret was refreshed. This removes the expiring credential entirely and fixes the failure mode that hid the breakage.

## Changes

- **Use the built-in `GITHUB_TOKEN` for Discussions.** `module-scorecards.yaml` gets `discussions: write`, `module-scorecard-check.yaml` gets `discussions: read` (baseline lookup only). Nothing to expire or rotate; `SCORECARD_DISCUSSIONS_TOKEN` can be deleted from repo secrets after this merges. Trade-off: discussion creates/edits now show as `github-actions[bot]` instead of a user.
- **Fail runs on scoring errors.** `score-modules.ts` caught per-module errors and continued, exiting 0. During the token outage the scoring step logged `FAILED: 401` for every module and stayed green; the run only failed at the index step. Modules changed during the outage (`amazon-dcv-windows`, `personalize`) silently missed re-scoring. Now failures are collected and the process exits non-zero, naming the failed modules.

## Verification plan

GraphQL `createDiscussion`/`updateDiscussion` accept `GITHUB_TOKEN` with `discussions: write`, but the existing 48 discussions are user-owned. After merge, trigger a `workflow_dispatch` and confirm the log shows `updated` (not `created`) for existing discussions. If the app token cannot edit them, the fallback is reverting the env line to a PAT while keeping the fail-loudly fix.

🤖 Generated with [Coder Agents](https://coder.com/docs/ai-coder/agents)