### PR TITLE
fix(tag_release): avoid jq reserved keyword `module` in add_json_warning

### DIFF
--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -110,7 +110,10 @@ add_json_warning() {
   local message="$2"
   local type="$3"
 
-  JSON_OUTPUT=$(echo "$JSON_OUTPUT" | jq --arg module "$module" --arg msg "$message" --arg type "$type" '.warnings += [{"module": $module, "message": $msg, "type": $type}]')
+  # NOTE: `module` is a reserved keyword in jq, so we cannot name the jq
+  # variable `$module` (it will fail to parse). Use `$mod` internally and
+  # map it to the "module" JSON key.
+  JSON_OUTPUT=$(echo "$JSON_OUTPUT" | jq --arg mod "$module" --arg msg "$message" --arg type "$type" '.warnings += [{"module": $mod, "message": $msg, "type": $type}]')
 }
 
 add_json_module() {


### PR DESCRIPTION
## Problem

Running `./scripts/tag_release.sh` with no filters aborts mid-scan with:

```
jq: error: syntax error, unexpected module, expecting IDENT or __loc__ (Unix shell quoting issues?) at <top-level>, line 1:
.warnings += [{"module": $module, "message": $msg, "type": $type}]
```

`module` is a reserved keyword in jq, so `--arg module "$module"` produces an invalid `$module` reference. `add_json_warning` is only invoked when a module fails version extraction/validation, so this path went untriggered until a deprecated module (e.g. `amazon-q`) was removed and the next full scan hit a module without a resolvable version. Narrowing the run with `--module=<name>` masked the bug because the warning path was skipped.

## Fix

Rename the internal jq variable to `$mod` in `add_json_warning`. The emitted JSON key stays `"module"`, so output shape is unchanged.

## Verification

- `bash -n scripts/tag_release.sh` — parses cleanly.
- The offending jq filter now parses: `jq --arg mod x --arg msg y --arg type z '.warnings += [{"module": $mod, "message": $msg, "type": $type}]'` succeeds where the original failed.

---

_This PR was generated by Coder Agents on behalf of @DevelopmentCats._