### PR TITLE
fix: repair oci-vm template home volume mount, region default, and ssh debug access

### DIFF
--- a/registry/anis/templates/oci-vm/README.md
+++ b/registry/anis/templates/oci-vm/README.md
@@ -29,6 +29,9 @@ Before deploying, ensure your Oracle Cloud tenancy has:
 
 > The available regions and instance shapes listed in this template are examples only, not all shapes are available in every region, and availability depends on your OCI tenancy and subscription tier. Check the [OCI documentation](https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm) to confirm which shapes are available in your target region before deploying.
 
+> [!IMPORTANT]
+> Your tenancy is only auto-subscribed to its **home region** — everything else requires an explicit region subscription (**Governance & Administration > Region Management** in the OCI Console). `us-ashburn-1` (the default here) is one of OCI's two original commercial regions and a common home region, but it isn't universal. If your tenancy's home region is different (for example `us-phoenix-1`), change the `region` parameter's default to match — otherwise both `coder templates push` and workspace builds fail with what looks like a credentials/authentication error, even though the credentials themselves are fine.
+
 ### OCI Authentication
 
 You’ll also need the following credentials:
@@ -52,6 +55,12 @@ You’ll also need the following credentials:
 | **Workspace stopped** | The compute instance is destroyed, but the home volume (`oci_core_volume`) persists     |
 | **Workspace deleted** | All resources are destroyed, including the home volume                                  |
 
+> Only `/home/<username>` (mounted from the persistent block volume) survives a stop. Everything else, including the root disk and anything installed outside `/home`, is recreated from the base Ubuntu image on every start.
+
+### Debugging
+
+If you set the `ssh_public_key` template variable, its matching private key can be used to `ssh <username>@<instance-public-ip>` directly, independent of the Coder agent — useful if the agent itself fails to come up.
+
 ---
 
 ## Example `.tfvars` File
@@ -60,8 +69,7 @@ You’ll also need the following credentials:
 tenancy_ocid     = "ocid1.tenancy.oc1..xxxx"
 user_ocid        = "ocid1.user.oc1..xxxx"
 fingerprint      = "aa:bb:cc:dd:ee:ff"
-subnet_id        = "ocid1.subnet.oc1.eu-marseille-1.aaaaaaaaxxx"
-region           = "eu-marseille-1"
+subnet_id        = "ocid1.subnet.oc1.iad.aaaaaaaaxxx"
 private_key = <<EOT
 -----BEGIN PRIVATE KEY-----
 MIIEvQIBADANBgkqhkiG9w0BAQEFAASC...

--- a/registry/anis/templates/oci-vm/cloud-init/cloud-config.yaml.tftpl
+++ b/registry/anis/templates/oci-vm/cloud-init/cloud-config.yaml.tftpl
@@ -10,23 +10,65 @@ packages:
   - curl
   - wget
   - unzip
-disk_setup:
-  /dev/sdb:
-    table_type: 'gpt'
-    layout: true
-    overwrite: false
-fs_setup:
-  - label: ${home_volume_label}
-    filesystem: ext4
-    device: /dev/sdb
-    partition: auto
-mounts:
-  - ["/dev/sdb", "/home/${username}", "ext4", "defaults", "0", "2"]
 write_files:
   - path: /opt/coder/init
     permissions: "0755"
     encoding: b64
     content: ${init_script}
+  - path: /opt/coder/mount-home-volume.sh
+    permissions: "0755"
+    content: |
+      #!/bin/bash
+      set -euo pipefail
+
+      label="${home_fs_label}"
+      mount_point="/home/${username}"
+      device="/dev/sdb"
+
+      mkdir -p "$mount_point"
+
+      # The block volume attaches to the instance asynchronously (a separate
+      # OCI API call after the instance itself is running), so it usually
+      # isn't present yet when cloud-init boots. Poll for it instead of
+      # assuming it's already there.
+      for i in $(seq 1 60); do
+        udevadm settle --timeout=2 || true
+        [ -b "$device" ] && break
+        sleep 2
+      done
+
+      if [ ! -b "$device" ]; then
+        echo "mount-home-volume: $device never showed up, giving up" >&2
+        exit 0
+      fi
+
+      # Only format on first boot. On every later stop/start cycle the
+      # volume already has our filesystem + label, and re-running mkfs
+      # would destroy whatever the user saved in their home directory.
+      if ! blkid "$device" >/dev/null 2>&1; then
+        mkfs.ext4 -L "$label" "$device"
+      fi
+
+      if ! grep -q "LABEL=$label" /etc/fstab; then
+        echo "LABEL=$label $mount_point ext4 defaults,nofail 0 2" >> /etc/fstab
+      fi
+
+      mount "$mount_point"
+      chown "${username}:${username}" "$mount_point"
+
+      # cloud-init's own ssh_authorized_keys handling runs before this
+      # script and writes to the root disk, but mounting the home volume
+      # here immediately shadows that. Provision the debug key directly on
+      # the mounted volume instead, so it actually survives.
+      ssh_public_key="${ssh_public_key}"
+      if [ -n "$ssh_public_key" ]; then
+        mkdir -p "$mount_point/.ssh"
+        chmod 700 "$mount_point/.ssh"
+        touch "$mount_point/.ssh/authorized_keys"
+        grep -qxF "$ssh_public_key" "$mount_point/.ssh/authorized_keys" || echo "$ssh_public_key" >> "$mount_point/.ssh/authorized_keys"
+        chmod 600 "$mount_point/.ssh/authorized_keys"
+        chown -R "${username}:${username}" "$mount_point/.ssh"
+      fi
   - path: /etc/systemd/system/coder-agent.service
     permissions: "0644"
     content: |
@@ -50,7 +92,6 @@ write_files:
       [Install]
       WantedBy=multi-user.target
 runcmd:
-  - mkdir -p /home/${username}
-  - chown ${username}:${username} /home/${username}
+  - /opt/coder/mount-home-volume.sh
   - systemctl enable coder-agent
   - systemctl start coder-agent

--- a/registry/anis/templates/oci-vm/main.tf
+++ b/registry/anis/templates/oci-vm/main.tf
@@ -59,8 +59,17 @@ data "coder_parameter" "region" {
   name         = "region"
   display_name = "Region"
   description  = "The region to deploy the workspace in."
-  default      = "eu-marseille-1"
-  mutable      = false
+  # us-ashburn-1 is one of OCI's two original commercial regions (alongside
+  # us-phoenix-1) and the most common home region for new sign-ups, so it's
+  # a safer default than a specialty region like eu-marseille-1. That said,
+  # no single default works for every tenancy: OCI only auto-subscribes you
+  # to your home region, and picking a region your tenancy isn't subscribed
+  # to causes `coder templates push` itself to fail with an auth-looking
+  # 401, since the OCI API rejects requests to unsubscribed regions
+  # outright. Set this to a region your tenancy actually has (Governance &
+  # Administration > Region Management in the OCI Console).
+  default = "us-ashburn-1"
+  mutable = false
   option {
     name  = "France South (Marseille)"
     value = "eu-marseille-1"
@@ -217,6 +226,12 @@ locals {
   vm_name           = "coder-${lower(data.coder_workspace_owner.me.name)}-${lower(data.coder_workspace.me.name)}"
   root_disk_label   = substr("${local.vm_name}-root", 0, 32)
   home_volume_label = substr("${local.vm_name}-home", 0, 32)
+  # ext4 filesystem labels are capped at 16 bytes and mkfs silently
+  # truncates anything longer. home_volume_label (above) is fine for the
+  # OCI volume's display name (32-char limit) but can't double as the
+  # filesystem label without the two going out of sync, so it gets its
+  # own, guaranteed-short value.
+  home_fs_label = substr("${local.vm_name}-home", 0, 16)
 }
 
 data "oci_core_images" "ubuntu_image" {
@@ -281,9 +296,10 @@ resource "oci_core_instance" "workspace" {
     user_data = base64encode(templatefile("cloud-init/cloud-config.yaml.tftpl", {
       hostname          = local.vm_name
       username          = lower(data.coder_workspace_owner.me.name)
-      home_volume_label = local.home_volume_label
+      home_fs_label     = local.home_fs_label
       init_script       = base64encode(coder_agent.main.init_script)
       coder_agent_token = coder_agent.main.token
+      ssh_public_key    = var.ssh_public_key
     }))
   }
 }


### PR DESCRIPTION
## Description

While testing this template end-to-end against a real OCI tenancy, I found a few things that don't actually work once you get past the reviews:

- The home volume never mounts. `disk_setup`/`mounts` run early in cloud-init's boot sequence, before the OCI volume attachment (a separate, async API call) has actually shown up as a device. Confirmed via the instance's serial console: `Device /dev/sdb did not exist and was not created with a udevadm settle`. `/home/<user>` silently ends up on the ephemeral root disk instead, so it's wiped on every stop despite the template (and README) claiming it persists.
- `region` defaults to `eu-marseille-1`, which most tenancies aren't subscribed to (including a fresh trial account, per the review thread, and my own tenancy's home region). Since the AD/image data sources aren't gated by `start_count`, this makes `coder templates push` itself fail with an auth-looking 401 before anyone even gets to create a workspace.
- `ssh_public_key` is documented ("SSH public key for debugging access") but never wired into cloud-init, so there's no way to get into a workspace to debug it.

This PR builds on top of this branch's `main.tf`/README/cloud-init with:

- A `runcmd` script that waits for the volume device to show up, formats it only if it isn't already formatted (matched by filesystem label, so repeated stop/start cycles don't wipe it), and mounts it via `/etc/fstab`. Also fixes a subtler bug this introduced: ext4 labels are capped at 16 bytes, but the existing `home_volume_label` local is (correctly, for OCI's own 32-char display name limit) longer than that, so `mkfs` was silently truncating it and later lookups by the untruncated label never matched. Added a dedicated 16-byte `home_fs_label`.
- `region` now defaults to `us-ashburn-1` instead of `eu-marseille-1`. Still not universal (no single default can be, since OCI only auto-subscribes your home region), but it's one of OCI's two original commercial regions and a much more common default than a specialty region — documented the caveat clearly either way.
- `ssh_public_key` now actually lands in `~/.ssh/authorized_keys`. Had to provision it from inside the mount script rather than through cloud-init's normal `ssh_authorized_keys`, since that runs before the home volume mount and would otherwise get shadowed by it.

Tested all of the above against a real OCI tenancy (instance + volume + attachment, connected agent, `df`/`lsblk` showing `/home` on the block volume, `ssh <user>@<ip>` working with the debug key).

Opened this against your `oci-vm` branch directly rather than `main` so it's easy to pull in — feel free to merge, cherry-pick, or push back on any of it.

## Type of Change

- [ ] New module
- [ ] New template
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Template Information

**Path:** `registry/anis/templates/oci-vm`

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun fmt`)
- [x] Changes tested locally

## Related Issues

Related to coder/registry#525
