### PR TITLE
scorecard: verify README image references to prevent false positives

### DIFF
--- a/.github/scorecard/score-modules.ts
+++ b/.github/scorecard/score-modules.ts
@@ -112,7 +112,7 @@ async function verifyReadmeImages(
   const imageRegex = /!\[[^\]]*\]\(([^)]+)\)/g;
   const results: ImageVerification[] = [];
 
-  let match;
+  let match: RegExpExecArray | null;
   while ((match = imageRegex.exec(readme)) !== null) {
     const reference = match[1];
 
@@ -125,7 +125,15 @@ async function verifyReadmeImages(
       continue;
     }
 
+    if (path.isAbsolute(reference)) {
+      continue;
+    }
+
     const resolvedPath = path.resolve(moduleDir, reference);
+    if (!resolvedPath.startsWith(REGISTRY_ROOT)) {
+      continue;
+    }
+
     const verification: ImageVerification = {
       reference,
       resolvedPath,

--- a/.github/scorecard/score-modules.ts
+++ b/.github/scorecard/score-modules.ts
@@ -65,6 +65,13 @@ interface Args {
   prReport?: string;
 }
 
+interface ImageVerification {
+  reference: string;
+  resolvedPath: string;
+  exists: boolean;
+  sizeBytes?: number;
+}
+
 function parseArgs(): Args {
   const args: Args = { dryRun: false };
   const argv = process.argv.slice(2);
@@ -96,6 +103,49 @@ async function readTruncated(filePath: string): Promise<string> {
   return content.slice(0, MAX_FILE_BYTES) + "\n... [truncated]";
 }
 
+async function verifyReadmeImages(
+  moduleName: string,
+): Promise<ImageVerification[]> {
+  const readmePath = path.join(MODULES_DIR, moduleName, "README.md");
+  const readme = await readFile(readmePath, "utf8");
+  const moduleDir = path.join(MODULES_DIR, moduleName);
+  const imageRegex = /!\[[^\]]*\]\(([^)]+)\)/g;
+  const results: ImageVerification[] = [];
+
+  let match;
+  while ((match = imageRegex.exec(readme)) !== null) {
+    const reference = match[1];
+
+    if (reference.startsWith("http://") || reference.startsWith("https://")) {
+      results.push({
+        reference,
+        resolvedPath: "(external)",
+        exists: true,
+      });
+      continue;
+    }
+
+    const resolvedPath = path.resolve(moduleDir, reference);
+    const verification: ImageVerification = {
+      reference,
+      resolvedPath,
+      exists: existsSync(resolvedPath),
+    };
+
+    if (verification.exists) {
+      try {
+        const { stat } = await import("node:fs/promises");
+        const stats = await stat(resolvedPath);
+        verification.sizeBytes = stats.size;
+      } catch {}
+    }
+
+    results.push(verification);
+  }
+
+  return results;
+}
+
 async function gatherModuleContext(moduleName: string): Promise<string> {
   const dir = path.join(MODULES_DIR, moduleName);
   const parts: string[] = [];
@@ -114,6 +164,26 @@ async function gatherModuleContext(moduleName: string): Promise<string> {
     const full = path.join(dir, f);
     parts.push(`=== FILE: ${f} ===\n${await readTruncated(full)}`);
   }
+
+  const imageVerifications = await verifyReadmeImages(moduleName);
+  if (imageVerifications.length > 0) {
+    const verificationLines = imageVerifications.map((v) => {
+      if (v.resolvedPath === "(external)") {
+        return `  → ${v.reference} — external URL`;
+      } else if (v.exists) {
+        const size = v.sizeBytes
+          ? ` (${(v.sizeBytes / 1024).toFixed(1)} KB)`
+          : "";
+        return `  ✓ ${v.reference} — exists${size}`;
+      } else {
+        return `  ✗ ${v.reference} — NOT FOUND`;
+      }
+    });
+    parts.push(
+      `=== README IMAGE VERIFICATION ===\n${verificationLines.join("\n")}`,
+    );
+  }
+
   return parts.join("\n\n");
 }
 


### PR DESCRIPTION
## Problem

PR #1057 (a bug fix for `vscode-web`) triggered a scorecard regression from 82 → 79 due to Visual preview dropping from 5 → 2. The LLM noted:

> README references an image (`![VS Code Web...](../../.images/vscode-web.gif)`) but the actual file is not included in the provided module content, only the reference exists.

The image exists at `registry/coder/.images/vscode-web.gif` and renders correctly on the registry website. This is the documented pattern — module screenshots live in a shared `.images/` directory outside the module folder.

## Root Cause

`gatherModuleContext()` only collects files inside the module directory. The LLM sees markdown image references like `![alt](../../.images/foo.gif)` but receives no evidence that the referenced file exists. Without verification, it sometimes gives full credit (inferring the image exists) and sometimes gives partial credit (noting the file isn't in the provided content).

## Fix

Add `verifyReadmeImages()` which:
1. Parses the README for markdown image references
2. Resolves relative paths against the module directory  
3. Checks existence with `existsSync()`
4. Appends verification results to the context sent to the LLM

The LLM now sees deterministic proof:

```
=== README IMAGE VERIFICATION ===
  ✓ ../../.images/vscode-web.gif — exists (5277.4 KB)
```

Or for broken references:

```
=== README IMAGE VERIFICATION ===
  ✗ ../.images/missing.png — NOT FOUND
```

## Testing

| Module | Before | After |
|--------|--------|-------|
| vscode-web | Visual preview: 2/5 (false positive) | Visual preview: 5/5 ✓ |
| jetbrains-gateway | Broken ref undetected | Visual preview: 0/5 + "NOT FOUND" ✓ |

The fix also caught a real bug: `jetbrains-gateway` uses `../.images/` (one level) instead of `../../.images/` (two levels).