### PR TITLE
fix(.github/workflows): use literal pathspec when materializing PR module content

### DIFF
--- a/.github/workflows/module-scorecard-check.yaml
+++ b/.github/workflows/module-scorecard-check.yaml
@@ -20,7 +20,7 @@
 #
 # Both paths execute only trusted code: the checkout is the base
 # repository, and PR content is fetched separately and materialized ONLY
-# under registry/*/modules/, where the scoring script reads it as
+# under registry/, where the scoring script reads it as
 # inert text for the LLM prompt. Nothing from the PR head is executed.
 #
 # Required repository secrets:
@@ -97,13 +97,15 @@ jobs:
 
       - name: Materialize PR module content (data only)
         if: steps.changed.outputs.modules != ''
-        # Overlay ONLY the module directories from the PR merge commit onto
-        # the trusted checkout. The scoring script reads these files as
-        # plain text for the LLM prompt; it never executes them. Everything
-        # under .github/ stays at the trusted base.
+        # Overlay the registry/ tree from the PR merge commit onto the
+        # trusted checkout. The scoring script reads these files as plain
+        # text for the LLM prompt; it never executes them. Everything under
+        # .github/ stays at the trusted base. A literal pathspec is used
+        # because wildcard pathspecs (registry/*/modules) do not
+        # directory-prefix match and fail to match any files.
         run: |
-          git rm -rq --ignore-unmatch 'registry/*/modules'
-          git checkout FETCH_HEAD -- 'registry/*/modules'
+          git rm -rq --ignore-unmatch registry
+          git checkout FETCH_HEAD -- registry
 
       - name: Score changed modules
         if: steps.changed.outputs.modules != ''


### PR DESCRIPTION
Follow-up to #1069. The `/scorecard` run on #1068 detected `droopy4096/mise-install` correctly but failed at the materialize step:

```
error: pathspec 'registry/*/modules' did not match any file(s) known to git
```

Wildcard pathspecs don't directory-prefix match the way literal paths do, so `registry/*/modules` matched nothing. Fixed by overlaying the whole `registry/` tree instead, which is simpler and equally safe: it's all inert data read as text for the scoring prompt, and everything under `.github/` stays at the trusted base.

Verified locally against `refs/pull/1068/merge`: the checkout now materializes `registry/droopy4096/modules/mise-install`.

🤖 Generated with Coder Agents on behalf of @bpmct