### PR TITLE
fix(.github/scorecard): clarify community module score expectations in PR report

### DIFF
--- a/.github/scorecard/score-modules.ts
+++ b/.github/scorecard/score-modules.ts
@@ -422,7 +422,7 @@ function prReportSection(
     const followup =
       spec.ns === "coder"
         ? `No existing scorecard discussion found for ${name}; this is the initial score. A dedicated discussion is created after merge.`
-        : "Community modules do not get scorecard discussions; this score is advisory.";
+        : "No specific score is required to contribute, but modules with higher scores are more likely to be approved by the Coder team and widely used.";
     return `### \`${spec.label}\`: first scorecard, **${summary.overall}**\n\n${followup}\n\n${details}`;
   }
   const delta = summary.overallNum - baseline.overallNum;


### PR DESCRIPTION
Changes the community-module line in the PR scorecard report from

> Community modules do not get scorecard discussions; this score is advisory.

to

> No specific score is required to contribute, but modules with higher scores are more likely to be approved by the Coder team and widely used.

🤖 Generated with Coder Agents on behalf of @bpmct