### PR TITLE
fix(github-upload-public-key): use ssh_signing_keys uri

### DIFF
--- a/registry/coder/modules/github-upload-public-key/run.sh
+++ b/registry/coder/modules/github-upload-public-key/run.sh
@@ -68,7 +68,7 @@ GITHUB_KEYS_RESPONSE=$(
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer $GITHUB_TOKEN" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
-    $GITHUB_API_URL/user/keys
+    $GITHUB_API_URL/user/ssh_signing_keys
 )
 GITHUB_KEYS_RESPONSE_STATUS=$(tail -n1 <<< "$GITHUB_KEYS_RESPONSE")
 GITHUB_KEYS_RESPONSE_BODY=$(sed \$d <<< "$GITHUB_KEYS_RESPONSE")
@@ -96,7 +96,7 @@ UPLOAD_RESPONSE=$(
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer $GITHUB_TOKEN" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
-    $GITHUB_API_URL/user/keys \
+    $GITHUB_API_URL/user/ssh_signing_keys \
     -d "$(jq -nc --arg title "$CODER_PUBLIC_KEY_NAME" --arg key "$PUBLIC_KEY" '{title: $title, key: $key}')"
 )
 UPLOAD_RESPONSE_STATUS=$(tail -n1 <<< "$UPLOAD_RESPONSE")


### PR DESCRIPTION
## Description

- The type of SSH key must be specified when uploading otherwise the upload key is not used to verify commits.
- Reference: https://docs.github.com/en/rest/users/ssh-signing-keys?apiVersion=2026-03-10

## Type of Change

- [ ] New module
- [ ] New template
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

<!-- Delete this section if not applicable -->

**Path:** `registry/coder/modules/github-upload-public-key`  
**New version:** `v1.1.1`  
**Breaking change:**
- [ ] Yes
- [x] No


## Testing & Validation

- [ ] Tests pass (`bun test`)
- [ ] Code formatted (`bun fmt`)
- [ ] Changes tested locally

## Related Issues

<!-- Link related issues or write "None" if not applicable -->
