### PR TITLE
chore: add bun check and check:* script namespace

### DIFF
--- a/.agents/skills/coder-modules/SKILL.md
+++ b/.agents/skills/coder-modules/SKILL.md
@@ -329,12 +329,12 @@ Cleanup of `*.tfstate` files and `modules-test` Docker containers is handled aut
 | Task             | Command                                               | Scope      |
 | ---------------- | ----------------------------------------------------- | ---------- |
 | Format all       | `bun run fmt`                                         | Repo       |
-| Terraform tests  | `bun run tftest`                                      | Repo       |
-| TypeScript tests | `bun run tstest`                                      | Repo       |
+| Terraform tests  | `bun run test:terraform`                              | Repo       |
+| TypeScript tests | `bun run test:typescript`                             | Repo       |
 | Single TF test   | `terraform init -upgrade && terraform test -verbose`  | Module dir |
 | Single TS test   | `bun test main.test.ts`                               | Module dir |
 | Validate         | `./scripts/terraform_validate.sh`                     | Repo       |
-| ShellCheck       | `bun run shellcheck`                                  | Repo       |
+| ShellCheck       | `bun run test:shellcheck`                             | Repo       |
 | Version bump     | `.github/scripts/version-bump.sh patch\|minor\|major` | Repo       |
 
 ## Version Management
@@ -351,9 +351,9 @@ The script automatically updates `version` references in README usage examples.
 
 Before considering the work complete, verify:
 
-- Tests pass: `bun run tftest` and `bun run tstest`
+- Tests pass: `bun run test:terraform` and `bun run test:typescript` (or `bun check` to run everything)
 - `bun run fmt` has been run
-- `bun run shellcheck` passes if the module includes shell scripts
+- `bun run test:shellcheck` passes if the module includes shell scripts
 - New variables have sensible defaults for backward compatibility
 - Breaking changes are documented if any inputs were removed, defaults changed, or new required variables added
 - Shell scripts handle errors gracefully (`|| echo "Warning..."` for non-fatal failures)

--- a/.agents/skills/coder-modules/SKILL.md
+++ b/.agents/skills/coder-modules/SKILL.md
@@ -329,12 +329,12 @@ Cleanup of `*.tfstate` files and `modules-test` Docker containers is handled aut
 | Task             | Command                                               | Scope      |
 | ---------------- | ----------------------------------------------------- | ---------- |
 | Format all       | `bun run fmt`                                         | Repo       |
-| Terraform tests  | `bun run test:terraform`                              | Repo       |
-| TypeScript tests | `bun run test:typescript`                             | Repo       |
+| Terraform tests  | `bun run check:terraform`                             | Repo       |
+| TypeScript tests | `bun run check:typescript`                            | Repo       |
 | Single TF test   | `terraform init -upgrade && terraform test -verbose`  | Module dir |
 | Single TS test   | `bun test main.test.ts`                               | Module dir |
 | Validate         | `./scripts/terraform_validate.sh`                     | Repo       |
-| ShellCheck       | `bun run test:shellcheck`                             | Repo       |
+| ShellCheck       | `bun run check:shellcheck`                            | Repo       |
 | Version bump     | `.github/scripts/version-bump.sh patch\|minor\|major` | Repo       |
 
 ## Version Management
@@ -351,9 +351,9 @@ The script automatically updates `version` references in README usage examples.
 
 Before considering the work complete, verify:
 
-- Tests pass: `bun run test:terraform` and `bun run test:typescript` (or `bun check` to run everything)
+- Tests pass: `bun run check:terraform` and `bun run check:typescript` (or `bun check` to run everything)
 - `bun run fmt` has been run
-- `bun run test:shellcheck` passes if the module includes shell scripts
+- `bun run check:shellcheck` passes if the module includes shell scripts
 - New variables have sensible defaults for backward compatibility
 - Breaking changes are documented if any inputs were removed, defaults changed, or new required variables added
 - Shell scripts handle errors gracefully (`|| echo "Warning..."` for non-fatal failures)

--- a/.agents/skills/coder-templates/SKILL.md
+++ b/.agents/skills/coder-templates/SKILL.md
@@ -250,7 +250,7 @@ Templates do NOT require `.tftest.hcl` or `main.test.ts`. Testing is done by pus
 | ---------- | --------------------------------- | ----- |
 | Format all | `bun run fmt`                     | Repo  |
 | Validate   | `./scripts/terraform_validate.sh` | Repo  |
-| ShellCheck | `bun run shellcheck`              | Repo  |
+| ShellCheck | `bun run test:shellcheck`         | Repo  |
 
 ## Final Checks
 
@@ -258,7 +258,7 @@ Before considering the work complete, verify:
 
 - `terraform init && terraform validate` passes in the template directory
 - `bun run fmt` has been run
-- `bun run shellcheck` passes if the template includes shell scripts
+- `bun run test:shellcheck` passes if the template includes shell scripts
 - README documents prerequisites and architecture
 - Shell scripts handle errors gracefully (`|| echo "Warning..."` for non-fatal failures). If a script sources external files (`$HOME/.bashrc`, `/etc/bashrc`, `/etc/os-release`), the `source` must come before `set -u`; CI enforces this ordering.
 - No hardcoded values that should be configurable via variables or parameters

--- a/.agents/skills/coder-templates/SKILL.md
+++ b/.agents/skills/coder-templates/SKILL.md
@@ -250,7 +250,7 @@ Templates do NOT require `.tftest.hcl` or `main.test.ts`. Testing is done by pus
 | ---------- | --------------------------------- | ----- |
 | Format all | `bun run fmt`                     | Repo  |
 | Validate   | `./scripts/terraform_validate.sh` | Repo  |
-| ShellCheck | `bun run test:shellcheck`         | Repo  |
+| ShellCheck | `bun run check:shellcheck`        | Repo  |
 
 ## Final Checks
 
@@ -258,7 +258,7 @@ Before considering the work complete, verify:
 
 - `terraform init && terraform validate` passes in the template directory
 - `bun run fmt` has been run
-- `bun run test:shellcheck` passes if the template includes shell scripts
+- `bun run check:shellcheck` passes if the template includes shell scripts
 - README documents prerequisites and architecture
 - Shell scripts handle errors gracefully (`|| echo "Warning..."` for non-fatal failures). If a script sources external files (`$HOME/.bashrc`, `/etc/bashrc`, `/etc/os-release`), the `source` must come before `set -u`; CI enforces this ordering.
 - No hardcoded values that should be configurable via variables or parameters

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,26 +58,26 @@ jobs:
           ALL_CHANGED_FILES: ${{ steps.filter.outputs.all_files }}
           SHARED_CHANGED: ${{ steps.filter.outputs.shared }}
           MODULE_CHANGED_FILES: ${{ steps.filter.outputs.modules_files }}
-        run: bun tstest
+        run: bun run test:typescript
       - name: Run Terraform tests
         env:
           ALL_CHANGED_FILES: ${{ steps.filter.outputs.all_files }}
           SHARED_CHANGED: ${{ steps.filter.outputs.shared }}
           MODULE_CHANGED_FILES: ${{ steps.filter.outputs.modules_files }}
-        run: bun tftest
+        run: bun run test:terraform
       - name: Run Terraform Validate
         env:
           ALL_CHANGED_FILES: ${{ steps.filter.outputs.all_files }}
           SHARED_CHANGED: ${{ steps.filter.outputs.shared }}
           MODULE_CHANGED_FILES: ${{ steps.filter.outputs.modules_files }}
           TEMPLATE_CHANGED_FILES: ${{ steps.filter.outputs.templates_files }}
-        run: bun terraform-validate
+        run: bun run test:validate
       - name: Run ShellCheck
         env:
           ALL_CHANGED_FILES: ${{ steps.filter.outputs.all_files }}
           SHARED_CHANGED: ${{ steps.filter.outputs.shared }}
           SHELL_CHANGED_FILES: ${{ steps.filter.outputs.shell_files }}
-        run: bun shellcheck
+        run: bun run test:shellcheck
       - name: Validate set -u ordering
         run: ./scripts/validate_set_u_order.sh
   validate-style:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,26 +58,26 @@ jobs:
           ALL_CHANGED_FILES: ${{ steps.filter.outputs.all_files }}
           SHARED_CHANGED: ${{ steps.filter.outputs.shared }}
           MODULE_CHANGED_FILES: ${{ steps.filter.outputs.modules_files }}
-        run: bun run test:typescript
+        run: bun run check:typescript
       - name: Run Terraform tests
         env:
           ALL_CHANGED_FILES: ${{ steps.filter.outputs.all_files }}
           SHARED_CHANGED: ${{ steps.filter.outputs.shared }}
           MODULE_CHANGED_FILES: ${{ steps.filter.outputs.modules_files }}
-        run: bun run test:terraform
+        run: bun run check:terraform
       - name: Run Terraform Validate
         env:
           ALL_CHANGED_FILES: ${{ steps.filter.outputs.all_files }}
           SHARED_CHANGED: ${{ steps.filter.outputs.shared }}
           MODULE_CHANGED_FILES: ${{ steps.filter.outputs.modules_files }}
           TEMPLATE_CHANGED_FILES: ${{ steps.filter.outputs.templates_files }}
-        run: bun run test:validate
+        run: bun run check:validate
       - name: Run ShellCheck
         env:
           ALL_CHANGED_FILES: ${{ steps.filter.outputs.all_files }}
           SHARED_CHANGED: ${{ steps.filter.outputs.shared }}
           SHELL_CHANGED_FILES: ${{ steps.filter.outputs.shell_files }}
-        run: bun run test:shellcheck
+        run: bun run check:shellcheck
       - name: Validate set -u ordering
         run: ./scripts/validate_set_u_order.sh
   validate-style:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,9 @@ Coder Registry: Terraform modules/templates for Coder workspaces under `registry
 
 ```bash
 bun run fmt                                           # Format code (Prettier + Terraform) - run before commits
-bun run tftest                                        # Run all Terraform tests
-bun run tstest                                        # Run all TypeScript tests
+bun run test:terraform                                # Run all Terraform tests
+bun run test:typescript                               # Run all TypeScript tests
+bun check                                             # Run all tests + validation (validate, shellcheck, terraform, typescript)
 terraform init -upgrade && terraform test -verbose    # Test single module (run from module dir)
 bun test main.test.ts                                 # Run single TS test (from module dir)
 ./scripts/terraform_validate.sh                       # Validate Terraform syntax
@@ -136,7 +137,7 @@ variable "api_key" {
 - Version bumped via `.github/scripts/version-bump.sh` if module changed (patch=bugfix, minor=feature, major=breaking)
 - Breaking changes documented: removed inputs, changed defaults, new required variables
 - New variables have sensible defaults to maintain backward compatibility
-- Tests pass (`bun run tftest`, `bun run tstest`); add diagnostic logging for test failures
+- Tests pass (`bun run test:terraform`, `bun run test:typescript`, or `bun check` for everything); add diagnostic logging for test failures
 - README examples updated with new version number; tooltip/behavior changes noted
 - Shell scripts handle errors gracefully (use `|| echo "Warning..."` for non-fatal failures)
 - No hardcoded values that should be configurable; no absolute URLs (use relative paths)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ Coder Registry: Terraform modules/templates for Coder workspaces under `registry
 
 ```bash
 bun run fmt                                           # Format code (Prettier + Terraform) - run before commits
-bun run test:terraform                                # Run all Terraform tests
-bun run test:typescript                               # Run all TypeScript tests
+bun run check:terraform                               # Run all Terraform tests
+bun run check:typescript                              # Run all TypeScript tests
 bun check                                             # Run all tests + validation (validate, shellcheck, terraform, typescript)
 terraform init -upgrade && terraform test -verbose    # Test single module (run from module dir)
 bun test main.test.ts                                 # Run single TS test (from module dir)
@@ -137,7 +137,7 @@ variable "api_key" {
 - Version bumped via `.github/scripts/version-bump.sh` if module changed (patch=bugfix, minor=feature, major=breaking)
 - Breaking changes documented: removed inputs, changed defaults, new required variables
 - New variables have sensible defaults to maintain backward compatibility
-- Tests pass (`bun run test:terraform`, `bun run test:typescript`, or `bun check` for everything); add diagnostic logging for test failures
+- Tests pass (`bun run check:terraform`, `bun run check:typescript`, or `bun check` for everything); add diagnostic logging for test failures
 - README examples updated with new version number; tooltip/behavior changes noted
 - Shell scripts handle errors gracefully (use `|| echo "Warning..."` for non-fatal failures)
 - No hardcoded values that should be configurable; no absolute URLs (use relative paths)

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "scripts": {
     "fmt": "bun x prettier --write . && terraform fmt -recursive -diff",
     "fmt:ci": "bun x prettier --check . && terraform fmt -check -recursive -diff",
-    "test:terraform": "./scripts/terraform_test_all.sh",
-    "test:typescript": "./scripts/ts_test_auto.sh",
-    "test:validate": "./scripts/terraform_validate.sh",
-    "test:shellcheck": "./scripts/shellcheck_validate.sh",
-    "check": "bun run test:validate && bun run test:shellcheck && bun run test:terraform && bun run test:typescript",
+    "check:terraform": "./scripts/terraform_test_all.sh",
+    "check:typescript": "./scripts/ts_test_auto.sh",
+    "check:validate": "./scripts/terraform_validate.sh",
+    "check:shellcheck": "./scripts/shellcheck_validate.sh",
+    "check": "bun run check:validate && bun run check:shellcheck && bun run check:terraform && bun run check:typescript",
     "update-version": "./update-version.sh"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "scripts": {
     "fmt": "bun x prettier --write . && terraform fmt -recursive -diff",
     "fmt:ci": "bun x prettier --check . && terraform fmt -check -recursive -diff",
-    "terraform-validate": "./scripts/terraform_validate.sh",
-    "tftest": "./scripts/terraform_test_all.sh",
-    "tstest": "./scripts/ts_test_auto.sh",
-    "shellcheck": "./scripts/shellcheck_validate.sh",
+    "test:terraform": "./scripts/terraform_test_all.sh",
+    "test:typescript": "./scripts/ts_test_auto.sh",
+    "test:validate": "./scripts/terraform_validate.sh",
+    "test:shellcheck": "./scripts/shellcheck_validate.sh",
+    "check": "bun run test:validate && bun run test:shellcheck && bun run test:terraform && bun run test:typescript",
     "update-version": "./update-version.sh"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Group the test/validate npm scripts under a consistent `check:*` namespace and add a single aggregate command.

| Before | After |
| --- | --- |
| `tftest` | `check:terraform` |
| `tstest` | `check:typescript` |
| `terraform-validate` | `check:validate` |
| `shellcheck` | `check:shellcheck` |
| — | `check` (runs all four) |

## Why `check` and not `test`

`bun test` is reserved by Bun's native test runner and never resolves a package.json `test` script, so an aggregate named `test` would be unreachable via `bun test`. The aggregate is named `check` and is invoked as `bun check`.

## CI

The four CI steps in `ci.yaml` now call `bun run check:*`. They're kept as separate steps so each check keeps its own annotations/visibility. The paths-filter and `set -u` ordering step are unchanged. Underlying `scripts/*.sh` filenames are unchanged; only the npm script names moved.

Docs referencing the old names were updated: `AGENTS.md`, `.agents/skills/coder-modules/SKILL.md`, `.agents/skills/coder-templates/SKILL.md`.

## Verification

- `bun check` runs all four in order, exit 0
- `bun x prettier --check` passes on all edited files

---
Generated with Coder Agents.
