### PR TITLE
fix(.icons/poolside.svg): use official Poolside logo

### DIFF
--- a/.icons/poolside.svg
+++ b/.icons/poolside.svg
@@ -1,4 +1,30 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
-  <rect width="128" height="128" rx="28" fill="#151515"/>
-  <path fill="#D8FF53" d="M28 31h43c17.12 0 29 10.78 29 25.87 0 8.21-3.88 15.28-10.47 19.57C99.9 80.73 106 89.2 106 100H83.32c0-10.83-6.22-17.31-16.55-17.31H50.65V100H28V31Zm22.65 19.37v13.55h18.9c5.49 0 8.88-2.66 8.88-6.78 0-4.09-3.39-6.77-8.88-6.77h-18.9Z"/>
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<style>
+  .pool-mark { fill: #4137FF; }
+  @media (prefers-color-scheme: dark) { .pool-mark { fill: #B9B6FF; } }
+</style>
+<mask id="mask0_1451_45954" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="2" y="2" width="28" height="28">
+<rect x="2" y="2" width="28" height="28" fill="url(#paint0_linear_1451_45954)" style=""/>
+<rect x="2" y="2" width="28" height="28" fill="url(#paint1_linear_1451_45954)" style=""/>
+<rect x="2" y="2" width="28" height="28" fill="url(#paint2_linear_1451_45954)" style=""/>
+</mask>
+<g mask="url(#mask0_1451_45954)">
+<path d="M3.41712 9.86302C6.80654 2.91367 15.1874 0.0275226 22.1368 3.41673C29.0863 6.80621 31.9726 15.188 28.5831 22.1374C25.1936 29.0867 16.8118 31.9722 9.86243 28.5827C4.66204 26.0461 1.73968 20.7158 2.01477 15.2849L2.05188 14.7595L2.07239 14.6081C2.21562 13.8614 2.90513 13.3305 3.67884 13.3992C4.45222 13.468 5.03641 14.1117 5.04602 14.8718L5.04016 15.0251L5.01087 15.4382C4.81888 19.2309 6.61285 22.9542 9.87512 25.1355L13.9933 16.6902L4.10755 11.8689C3.40938 11.5284 3.09379 10.7172 3.35657 10.0036L3.41712 9.86302ZM12.5714 26.4499C17.2445 27.9897 22.4003 26.2141 25.1349 22.1238L16.6896 18.0056L12.5714 26.4499ZM23.7208 8.16575C23.7497 8.57599 23.771 9.00755 23.7794 9.45579C23.8234 11.8115 23.5514 14.7561 22.5206 17.5115L26.4493 19.4275C27.7704 15.4172 26.6506 11.0524 23.7208 8.16575ZM20.5333 6.70384C19.8869 7.05321 19.0593 7.56983 18.1691 8.239C16.5266 9.47362 14.7653 11.1474 13.504 13.114L19.8097 16.1892C20.5828 13.9845 20.8187 11.5667 20.7804 9.51243C20.7596 8.39857 20.656 7.42837 20.5333 6.70384ZM17.4181 5.09153C13.3401 4.56091 9.21077 6.36601 6.86438 9.87571L10.7941 11.7917C12.3304 9.28322 14.4831 7.25617 16.3663 5.84056C16.7246 5.57129 17.0771 5.32128 17.4181 5.09153Z" class="pool-mark" style="fill:#4137FF;fill:color(display-p3 0.2549 0.2157 1.0000);fill-opacity:1;"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_1451_45954" x1="9.875" y1="25.975" x2="8.5625" y2="25.975" gradientUnits="userSpaceOnUse">
+<stop style="stop-color:black;stop-opacity:1;"/>
+<stop offset="1" stop-opacity="0" style="stop-color:none;stop-opacity:0;"/>
+</linearGradient>
+<linearGradient id="paint1_linear_1451_45954" x1="9.9625" y1="15.825" x2="10.4" y2="14.9937" gradientUnits="userSpaceOnUse">
+<stop stop-opacity="0" style="stop-color:none;stop-opacity:0;"/>
+<stop offset="1" style="stop-color:black;stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="paint2_linear_1451_45954" x1="3.1375" y1="25.9312" x2="3.1375" y2="14.7312" gradientUnits="userSpaceOnUse">
+<stop style="stop-color:black;stop-opacity:1;"/>
+<stop offset="0.105" stop-opacity="0.9" style="stop-color:black;stop-opacity:0.9;"/>
+<stop offset="0.903766" stop-opacity="0.04" style="stop-color:black;stop-opacity:0.04;"/>
+<stop offset="1" stop-opacity="0" style="stop-color:none;stop-opacity:0;"/>
+</linearGradient>
+</defs>
 </svg>

--- a/.icons/poolside.svg
+++ b/.icons/poolside.svg
@@ -1,4 +1,4 @@
-<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="150" height="150" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
 <style>
   .pool-mark { fill: #4137FF; }
   @media (prefers-color-scheme: dark) { .pool-mark { fill: #B9B6FF; } }


### PR DESCRIPTION
## Summary

The `coder-labs/pool` module (added in #1033) shipped a placeholder icon at `.icons/poolside.svg` that renders as a lime letterform on a dark square rather than Poolside's actual logo. This replaces it with Poolside's **official logo** (the spiral mark from poolside.ai), so it displays correctly next to the module on registry.coder.com.

## Details

- Sourced from Poolside's official brand asset (`poolside.ai` favicon SVG), transparent background, no baked-in tile.
- Theme-adaptive fill so the mark reads on both registry themes:
  - Light: `#4137FF` (Poolside primary indigo)
  - Dark: `#B9B6FF` (Poolside light lavender), via `@media (prefers-color-scheme: dark)`.
- No module code changes; the `pool` module already references `.icons/poolside.svg` via frontmatter (`icon:`) and `var.icon` (`/icon/poolside.svg`).

## Before / after

- Before: lime letter mark on `#151515` rounded square (not the Poolside logo).
- After: Poolside's official spiral logo.

---

_Opened by Coder Agents on behalf of @ausbru87._