### PR TITLE
fix(antigravity): use IDE launch protocol

### DIFF
--- a/registry/coder/modules/antigravity/README.md
+++ b/registry/coder/modules/antigravity/README.md
@@ -16,7 +16,7 @@ Uses the [Coder Remote VS Code Extension](https://github.com/coder/vscode-coder)
 module "antigravity" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/antigravity/coder"
-  version  = "1.0.1"
+  version  = "1.0.2"
   agent_id = coder_agent.example.id
 }
 ```
@@ -29,7 +29,7 @@ module "antigravity" {
 module "antigravity" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/antigravity/coder"
-  version  = "1.0.1"
+  version  = "1.0.2"
   agent_id = coder_agent.example.id
   folder   = "/home/coder/project"
 }
@@ -45,7 +45,7 @@ The following example configures Antigravity to use the GitHub MCP server with a
 module "antigravity" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/antigravity/coder"
-  version  = "1.0.1"
+  version  = "1.0.2"
   agent_id = coder_agent.example.id
   folder   = "/home/coder/project"
   mcp = jsonencode({

--- a/registry/coder/modules/antigravity/main.test.ts
+++ b/registry/coder/modules/antigravity/main.test.ts
@@ -22,7 +22,7 @@ describe("antigravity", async () => {
       agent_id: "foo",
     });
     expect(state.outputs.antigravity_url.value).toBe(
-      "antigravity://coder.coder-remote/open?owner=default&workspace=default&url=https://mydeployment.coder.com&token=$SESSION_TOKEN",
+      "antigravity-ide://coder.coder-remote/open?owner=default&workspace=default&url=https://mydeployment.coder.com&token=$SESSION_TOKEN",
     );
 
     const coder_app = state.resources.find(
@@ -43,7 +43,7 @@ describe("antigravity", async () => {
       folder: "/foo/bar",
     });
     expect(state.outputs.antigravity_url.value).toBe(
-      "antigravity://coder.coder-remote/open?owner=default&workspace=default&folder=/foo/bar&url=https://mydeployment.coder.com&token=$SESSION_TOKEN",
+      "antigravity-ide://coder.coder-remote/open?owner=default&workspace=default&folder=/foo/bar&url=https://mydeployment.coder.com&token=$SESSION_TOKEN",
     );
   });
 
@@ -54,7 +54,7 @@ describe("antigravity", async () => {
       open_recent: "true",
     });
     expect(state.outputs.antigravity_url.value).toBe(
-      "antigravity://coder.coder-remote/open?owner=default&workspace=default&folder=/foo/bar&openRecent&url=https://mydeployment.coder.com&token=$SESSION_TOKEN",
+      "antigravity-ide://coder.coder-remote/open?owner=default&workspace=default&folder=/foo/bar&openRecent&url=https://mydeployment.coder.com&token=$SESSION_TOKEN",
     );
   });
 
@@ -65,7 +65,7 @@ describe("antigravity", async () => {
       open_recent: "false",
     });
     expect(state.outputs.antigravity_url.value).toBe(
-      "antigravity://coder.coder-remote/open?owner=default&workspace=default&folder=/foo/bar&url=https://mydeployment.coder.com&token=$SESSION_TOKEN",
+      "antigravity-ide://coder.coder-remote/open?owner=default&workspace=default&folder=/foo/bar&url=https://mydeployment.coder.com&token=$SESSION_TOKEN",
     );
   });
 
@@ -75,7 +75,7 @@ describe("antigravity", async () => {
       open_recent: "true",
     });
     expect(state.outputs.antigravity_url.value).toBe(
-      "antigravity://coder.coder-remote/open?owner=default&workspace=default&openRecent&url=https://mydeployment.coder.com&token=$SESSION_TOKEN",
+      "antigravity-ide://coder.coder-remote/open?owner=default&workspace=default&openRecent&url=https://mydeployment.coder.com&token=$SESSION_TOKEN",
     );
   });
 

--- a/registry/coder/modules/antigravity/main.tf
+++ b/registry/coder/modules/antigravity/main.tf
@@ -78,7 +78,7 @@ module "vscode-desktop-core" {
 
   folder      = var.folder
   open_recent = var.open_recent
-  protocol    = "antigravity"
+  protocol    = "antigravity-ide"
 }
 
 resource "coder_script" "antigravity_mcp" {


### PR DESCRIPTION
## Description

Update the Antigravity module to use the `antigravity-ide:` protocol so workspace links open the IDE instead of the chat canvas.

Depends on: https://github.com/coder/coder/pull/28784

## Type of Change

- [ ] New module
- [ ] New template
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder/modules/antigravity`  
**New version:** `v1.0.2`  
**Breaking change:** [ ] Yes [x] No

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun fmt`)
- [x] Changes tested locally

## Related Issues

Closes #1079

Generated by Coder Agents on behalf of @35C4n0r.
