### PR TITLE
feat(vscode-desktop): pre-install remote extensions

### DIFF
--- a/registry/coder/modules/vscode-desktop/README.md
+++ b/registry/coder/modules/vscode-desktop/README.md
@@ -16,7 +16,7 @@ Uses the [Coder Remote VS Code Extension](https://github.com/coder/vscode-coder)
 module "vscode" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/vscode-desktop/coder"
-  version  = "1.2.1"
+  version  = "1.3.0"
   agent_id = coder_agent.main.id
 }
 ```
@@ -29,8 +29,30 @@ module "vscode" {
 module "vscode" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/vscode-desktop/coder"
-  version  = "1.2.1"
+  version  = "1.3.0"
   agent_id = coder_agent.main.id
   folder   = "/home/coder/project"
 }
 ```
+
+### Pre-install extensions on the workspace host
+
+Use `extensions` to install VS Code extension IDs before the first ordinary VS Code Desktop connection. The module downloads the official stable VS Code Server and installs the extensions under `~/.vscode-server/extensions`.
+
+```tf
+module "vscode" {
+  count    = data.coder_workspace.me.start_count
+  source   = "registry.coder.com/coder/vscode-desktop/coder"
+  version  = "1.3.0"
+  agent_id = coder_agent.main.id
+
+  extensions = [
+    "ms-python.python",
+    "esbenp.prettier-vscode@12.4.0",
+  ]
+}
+```
+
+The installation blocks ordinary workspace login for up to 30 minutes so extensions are ready before VS Code Desktop connects. A download, extraction, validation, or extension installation failure remains visible in the Coder startup logs. Later workspace starts reuse the existing VS Code Server CLI and do not force extension updates.
+
+The workspace image must provide Bash, `base64`, `sed`, `tar`, and either `curl` or `wget`. The workspace also needs HTTPS egress to the VS Code update and artifact hosts. Extension availability and compatibility depend on the Visual Studio Marketplace; use `publisher.extension@version` to request a specific version.

--- a/registry/coder/modules/vscode-desktop/main.test.ts
+++ b/registry/coder/modules/vscode-desktop/main.test.ts
@@ -1,10 +1,26 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, setDefaultTimeout } from "bun:test";
 import {
-  executeScriptInContainer,
+  execContainer,
+  findResourceInstance,
+  removeContainer,
+  runContainer,
   runTerraformApply,
   runTerraformInit,
   testRequiredVariables,
+  writeFileContainer,
 } from "~test";
+
+setDefaultTimeout(30 * 1000);
+
+const decodeBootstrapScript = (installScript: string): string => {
+  const match = installScript.match(/IDE_CLI_INSTALL_SCRIPT_B64='([^']+)'/);
+  if (!match) {
+    throw new Error(
+      "The extension installer does not contain a bootstrap script",
+    );
+  }
+  return Buffer.from(match[1], "base64").toString("utf8");
+};
 
 describe("vscode-desktop", async () => {
   await runTerraformInit(import.meta.dir);
@@ -31,6 +47,13 @@ describe("vscode-desktop", async () => {
     expect(coder_app).not.toBeNull();
     expect(coder_app?.instances.length).toBe(1);
     expect(coder_app?.instances[0].attributes.order).toBeNull();
+
+    const extensionScripts = state.resources.filter(
+      (resource) =>
+        resource.type === "coder_script" &&
+        resource.name === "install_extensions",
+    );
+    expect(extensionScripts).toHaveLength(0);
   });
 
   it("adds folder", async () => {
@@ -73,5 +96,75 @@ describe("vscode-desktop", async () => {
     expect(state.outputs.vscode_url.value).toBe(
       "vscode://coder.coder-remote/open?owner=default&workspace=default&openRecent&url=https://mydeployment.coder.com&token=$SESSION_TOKEN",
     );
+  });
+
+  it("passes extensions and VS Code Server paths to the core", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      extensions: JSON.stringify([
+        "ms-python.python",
+        "esbenp.prettier-vscode@12.4.0",
+      ]),
+    });
+    const extensionInstaller = findResourceInstance(
+      state,
+      "coder_script",
+      "install_extensions",
+    );
+    const bootstrapScript = decodeBootstrapScript(extensionInstaller.script);
+
+    expect(extensionInstaller.start_blocks_login).toBe(true);
+    expect(extensionInstaller.timeout).toBe(1800);
+    expect(bootstrapScript).toContain(
+      "https://update.code.visualstudio.com/api/latest/server-linux-$remote_arch/stable",
+    );
+    expect(bootstrapScript).toContain(
+      "https://update.code.visualstudio.com/commit:$release_commit/server-linux-$remote_arch/stable",
+    );
+    expect(extensionInstaller.script).toContain(
+      Buffer.from(
+        "$HOME/.coder-modules/coder/vscode-desktop/server/bin/code-server",
+      ).toString("base64"),
+    );
+    expect(extensionInstaller.script).toContain(
+      Buffer.from("$HOME/.vscode-server/extensions").toString("base64"),
+    );
+    expect(extensionInstaller.script).toContain(
+      Buffer.from("esbenp.prettier-vscode@12.4.0").toString("base64"),
+    );
+    expect(extensionInstaller.script).not.toContain("--force");
+  });
+
+  it("does not download VS Code Server again when its CLI is executable", async () => {
+    const state = await runTerraformApply(import.meta.dir, {
+      agent_id: "foo",
+      extensions: JSON.stringify(["esbenp.prettier-vscode"]),
+    });
+    const extensionInstaller = findResourceInstance(
+      state,
+      "coder_script",
+      "install_extensions",
+    );
+    const bootstrapScript = decodeBootstrapScript(extensionInstaller.script);
+    const id = await runContainer("node:22-bookworm-slim");
+    const cliPath =
+      "/root/.coder-modules/coder/vscode-desktop/server/bin/code-server";
+
+    try {
+      await execContainer(
+        id,
+        ["mkdir", "-p", "/root/.coder-modules/coder/vscode-desktop/server/bin"],
+        ["--user", "root"],
+      );
+      await writeFileContainer(id, cliPath, "#!/bin/sh\nexit 0\n", {
+        user: "root",
+      });
+      await execContainer(id, ["chmod", "755", cliPath], ["--user", "root"]);
+
+      const result = await execContainer(id, ["bash", "-c", bootstrapScript]);
+      expect(result.exitCode).toBe(0);
+    } finally {
+      await removeContainer(id);
+    }
   });
 });

--- a/registry/coder/modules/vscode-desktop/main.tf
+++ b/registry/coder/modules/vscode-desktop/main.tf
@@ -38,9 +38,25 @@ variable "group" {
   default     = null
 }
 
+variable "extensions" {
+  description = "VS Code extension IDs to pre-install on the workspace host."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = alltrue([for extension in var.extensions : trimspace(extension) != ""])
+    error_message = "extensions must not contain empty extension IDs."
+  }
+}
+
+locals {
+  module_directory = "$HOME/.coder-modules/coder/vscode-desktop"
+  server_directory = "${local.module_directory}/server"
+}
+
 module "vscode-desktop-core" {
   source  = "registry.coder.com/coder/vscode-desktop-core/coder"
-  version = "1.0.2"
+  version = "1.2.0"
 
   agent_id = var.agent_id
 
@@ -53,6 +69,17 @@ module "vscode-desktop-core" {
   folder      = var.folder
   open_recent = var.open_recent
   protocol    = "vscode"
+  config_dir  = "$HOME/.vscode"
+
+  extensions     = var.extensions
+  extensions_dir = "$HOME/.vscode-server/extensions"
+  ide_cli_path   = "${local.server_directory}/bin/code-server"
+  ide_cli_install_script = length(var.extensions) > 0 ? templatefile(
+    "${path.module}/scripts/install-remote-server.sh.tftpl",
+    {
+      SERVER_DIRECTORY_B64 = base64encode(local.server_directory)
+    },
+  ) : null
 }
 
 output "vscode_url" {

--- a/registry/coder/modules/vscode-desktop/main.tftest.hcl
+++ b/registry/coder/modules/vscode-desktop/main.tftest.hcl
@@ -1,0 +1,42 @@
+mock_provider "coder" {}
+
+variables {
+  agent_id = "test-agent"
+}
+
+run "defaults_preserve_vscode_uri" {
+  command = plan
+
+  assert {
+    condition     = startswith(output.vscode_url, "vscode://coder.coder-remote/open")
+    error_message = "The default app URL must keep the vscode protocol."
+  }
+}
+
+run "extensions_accept_remote_ids" {
+  command = plan
+
+  variables {
+    extensions = [
+      "ms-python.python",
+      "esbenp.prettier-vscode@12.4.0",
+    ]
+  }
+
+  assert {
+    condition     = length(var.extensions) == 2
+    error_message = "The VS Code Desktop wrapper must accept configured extension IDs."
+  }
+}
+
+run "extensions_reject_empty_ids" {
+  command = plan
+
+  variables {
+    extensions = [""]
+  }
+
+  expect_failures = [
+    var.extensions,
+  ]
+}

--- a/registry/coder/modules/vscode-desktop/scripts/install-remote-server.sh.tftpl
+++ b/registry/coder/modules/vscode-desktop/scripts/install-remote-server.sh.tftpl
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+expand_home() {
+  case "$1" in
+    '$HOME')
+      printf '%s\n' "$HOME"
+      ;;
+    '$HOME/'*)
+      printf '%s/%s\n' "$HOME" "$${1#\$HOME/}"
+      ;;
+    *)
+      printf '%s\n' "$1"
+      ;;
+  esac
+}
+
+download() {
+  local url="$1"
+  local destination="$2"
+
+  if command -v curl > /dev/null 2>&1; then
+    curl --fail --location --silent --show-error "$url" --output "$destination"
+  elif command -v wget > /dev/null 2>&1; then
+    wget --output-document="$destination" "$url"
+  else
+    printf 'VS Code Server installation requires curl or wget.\n' >&2
+    exit 1
+  fi
+}
+
+extract_json_string() {
+  local key="$1"
+  local source_file="$2"
+  local value
+
+  value="$(
+    sed -n "s/.*\"$${key}\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" "$source_file" \
+      | head -n 1
+  )"
+  if [ -z "$value" ]; then
+    printf 'VS Code update response does not contain %s.\n' "$key" >&2
+    exit 1
+  fi
+  printf '%s\n' "$value"
+}
+
+SERVER_DIRECTORY="$(printf '%s' '${SERVER_DIRECTORY_B64}' | base64 -d)"
+SERVER_DIRECTORY="$(expand_home "$SERVER_DIRECTORY")"
+IDE_CLI_PATH="$SERVER_DIRECTORY/bin/code-server"
+
+if [ -x "$IDE_CLI_PATH" ]; then
+  exit 0
+fi
+
+case "$(uname -m)" in
+  x86_64)
+    remote_arch="x64"
+    ;;
+  aarch64 | arm64)
+    remote_arch="arm64"
+    ;;
+  *)
+    printf 'Unsupported architecture for VS Code Server: %s\n' "$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+update_response="$temporary_directory/update.json"
+archive="$temporary_directory/vscode-server.tar.gz"
+extracted_server="$temporary_directory/server"
+update_url="https://update.code.visualstudio.com/api/latest/server-linux-$remote_arch/stable"
+
+download "$update_url" "$update_response"
+release_commit="$(extract_json_string version "$update_response")"
+
+case "$release_commit" in
+  *[!0-9a-f]*)
+    printf 'VS Code update response returned an invalid commit.\n' >&2
+    exit 1
+    ;;
+esac
+if [ "$${#release_commit}" -ne 40 ]; then
+  printf 'VS Code update response returned an invalid commit.\n' >&2
+  exit 1
+fi
+
+download \
+  "https://update.code.visualstudio.com/commit:$release_commit/server-linux-$remote_arch/stable" \
+  "$archive"
+
+mkdir -p "$extracted_server"
+tar -xzf "$archive" -C "$extracted_server" --strip-components=1
+
+if [ ! -x "$extracted_server/bin/code-server" ]; then
+  printf 'VS Code Server archive does not contain the expected CLI executable.\n' >&2
+  exit 1
+fi
+
+archive_commit="$(extract_json_string commit "$extracted_server/product.json")"
+if [ "$archive_commit" != "$release_commit" ]; then
+  printf 'VS Code Server archive commit does not match the update response.\n' >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$SERVER_DIRECTORY")"
+rm -rf "$SERVER_DIRECTORY"
+mv "$extracted_server" "$SERVER_DIRECTORY"


### PR DESCRIPTION
## Why

The VS Code Desktop wrapper could not pre-install remote extensions before the first desktop connection . This advances the extension pre-installation portion of #207 by bootstrapping the official stable remote server and delegating installation to `vscode-desktop-core`.

## Changes

- add an optional validated `extensions` input while preserving the existing empty default
- adopt `vscode-desktop-core` v1.2.0 and pass the remote CLI, config, and extension paths
- download and validate the official stable VS Code Server only when its CLI is absent
- block ordinary workspace login while configured extensions are installed
- document extension configuration and bump the module version to v1.3.0
- cover defaults, validation, rendered configuration, and server reuse

## Validation

- `bun test registry/coder/modules/vscode-desktop/main.test.ts` — 9 passed, 0 failed
- `terraform validate -no-color` — passed
- `terraform fmt -check for the changed Terraform files — passed
- real E2E with Coder v2.33.11

## Description

Adds opt-in remote extension pre-installation to the VS Code Desktop module.

## Type of Change

- [ ] New module
- [ ] New template
- [ ] Bug fix
- [x] Feature/enhancement
- [x] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder/modules/vscode-desktop`  
**New version:** `v1.3.0`  
**Breaking change:** [ ] Yes [x] No

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (`bun fmt`)
- [x] Changes tested locally

## Related Issues

Related to #207
