### PR TITLE
feat(claude-code): add Microsoft Foundry support

### DIFF
--- a/registry/coder/modules/claude-code/README.md
+++ b/registry/coder/modules/claude-code/README.md
@@ -13,7 +13,7 @@ Install and configure the [Claude Code](https://docs.anthropic.com/en/docs/agent
 ```tf
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.4.1"
+  version           = "5.5.0"
   agent_id          = coder_agent.main.id
   anthropic_api_key = "xxxx-xxxxx-xxxx"
 }
@@ -32,6 +32,7 @@ Provide exactly one authentication method:
 - **Coder AI Gateway** (Coder Premium, Coder >= 2.30.0): set `enable_ai_gateway = true`. The module authenticates against the gateway using the workspace owner's session token. Do not combine with `anthropic_api_key` or `claude_code_oauth_token`.
 - **Amazon Bedrock**: set `use_bedrock = true`. Authentication uses the workspace's AWS credential chain. See [Usage with AWS Bedrock](#usage-with-aws-bedrock).
 - **Google Vertex AI**: set `use_vertex = true`. Authentication uses Google Application Default Credentials inside the workspace. See [Usage with Google Vertex AI](#usage-with-google-vertex-ai).
+- **Microsoft Foundry**: set `use_foundry = true` and provide either `foundry_resource` or `foundry_base_url`. Authentication uses the Azure default credential chain unless a Foundry API key or bearer token is provided separately. See [Usage with Microsoft Foundry](#usage-with-microsoft-foundry).
 - **Custom API gateway**: set `anthropic_base_url` to a self-hosted gateway that speaks the Anthropic Messages API. See [Usage with a custom API gateway](#usage-with-a-custom-api-gateway).
 
 ## workdir
@@ -51,7 +52,7 @@ locals {
 
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.4.1"
+  version           = "5.5.0"
   agent_id          = coder_agent.main.id
   workdir           = local.claude_workdir
   anthropic_api_key = "xxxx-xxxxx-xxxx"
@@ -82,7 +83,7 @@ resource "coder_app" "claude" {
 ```tf
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.4.1"
+  version           = "5.5.0"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   enable_ai_gateway = true
@@ -106,7 +107,7 @@ The `managed_settings` input writes a policy file to `/etc/claude-code/managed-s
 ```tf
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.4.1"
+  version           = "5.5.0"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   anthropic_api_key = "xxxx-xxxxx-xxxx"
@@ -133,7 +134,7 @@ For production deployments we recommend `api_key_helper` over a static `anthropi
 ```tf
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "5.4.1"
+  version  = "5.5.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -152,7 +153,7 @@ Or, sourcing from AWS Secrets Manager:
 ```tf
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "5.4.1"
+  version  = "5.5.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -177,7 +178,7 @@ This example shows version pinning, a pre-installed binary path, a custom model,
 ```tf
 module "claude-code" {
   source   = "registry.coder.com/coder/claude-code/coder"
-  version  = "5.4.1"
+  version  = "5.5.0"
   agent_id = coder_agent.main.id
   workdir  = "/home/coder/project"
 
@@ -241,7 +242,7 @@ Downstream `coder_script` resources can wait for this module's install pipeline 
 ```tf
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.4.1"
+  version           = "5.5.0"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   anthropic_api_key = "xxxx-xxxxx-xxxx"
@@ -271,7 +272,7 @@ Set `use_bedrock = true` to route Claude Code through Amazon Bedrock. The module
 ```tf
 module "claude-code" {
   source      = "registry.coder.com/coder/claude-code/coder"
-  version     = "5.4.1"
+  version     = "5.5.0"
   agent_id    = coder_agent.main.id
   workdir     = "/home/coder/project"
   use_bedrock = true
@@ -324,7 +325,7 @@ Set `use_vertex = true` to route Claude Code through Google Vertex AI. The modul
 ```tf
 module "claude-code" {
   source     = "registry.coder.com/coder/claude-code/coder"
-  version    = "5.4.1"
+  version    = "5.5.0"
   agent_id   = coder_agent.main.id
   workdir    = "/home/coder/project"
   use_vertex = true
@@ -350,6 +351,52 @@ resource "coder_env" "cloud_ml_region" {
 > [!NOTE]
 > Prerequisites: GCP project with Vertex AI API enabled, Claude models enabled through Model Garden, and the `Vertex AI User` role on the workspace identity. For additional configuration, see the [Claude Code Vertex AI documentation](https://docs.claude.com/en/docs/claude-code/google-vertex-ai).
 
+### Usage with Microsoft Foundry
+
+Set `use_foundry = true` and provide exactly one endpoint: the Azure resource name through `foundry_resource`, or the full endpoint through `foundry_base_url`. The module sets `CLAUDE_CODE_USE_FOUNDRY=1` and the corresponding endpoint environment variable.
+
+This example uses the Azure default credential chain. Attach a managed identity or workload identity with the `Azure AI User` or `Cognitive Services User` role to the workspace so Claude Code can authenticate without a static secret.
+
+```tf
+module "claude-code" {
+  source           = "registry.coder.com/coder/claude-code/coder"
+  version          = "5.5.0"
+  agent_id         = coder_agent.main.id
+  workdir          = "/home/coder/project"
+  use_foundry      = true
+  foundry_resource = "coder-foundry"
+  model            = "claude-sonnet-5"
+}
+```
+
+For multi-user deployments, pin each Claude alias to a deployment that exists in the Foundry resource. Foundry does not check model availability at startup, so an unavailable default fails on the first request.
+
+```tf
+resource "coder_env" "foundry_default_opus_model" {
+  agent_id = coder_agent.main.id
+  name     = "ANTHROPIC_DEFAULT_OPUS_MODEL"
+  value    = "claude-opus-4-8"
+}
+
+resource "coder_env" "foundry_default_sonnet_model" {
+  agent_id = coder_agent.main.id
+  name     = "ANTHROPIC_DEFAULT_SONNET_MODEL"
+  value    = "claude-sonnet-5"
+}
+
+resource "coder_env" "foundry_default_haiku_model" {
+  agent_id = coder_agent.main.id
+  name     = "ANTHROPIC_DEFAULT_HAIKU_MODEL"
+  value    = "claude-haiku-4-5"
+}
+```
+
+> [!TIP]
+> Microsoft Entra ID is the recommended authentication path for managed workspaces. If the workspace cannot use the Azure default credential chain, set the sensitive `foundry_api_key` input. Alternatively, set `foundry_auth_token` to a short-lived Entra bearer token; bearer-token authentication requires Claude Code 2.1.203 or later. The module rejects setting both credentials to avoid relying on precedence rules.
+
+> [!NOTE]
+> Microsoft Foundry has no interactive setup wizard. Verify the configured provider and endpoint with `/status` after starting Claude Code. See the [official Microsoft Foundry documentation](https://code.claude.com/docs/en/microsoft-foundry).
+
 ### Usage with a custom API gateway
 
 Set `anthropic_base_url` to point Claude Code at a self-hosted gateway or proxy that speaks the Anthropic Messages API. The module sets `ANTHROPIC_BASE_URL` and skips its built-in Anthropic authentication setup; provide whatever credentials your gateway requires via separate `coder_env` resources.
@@ -357,7 +404,7 @@ Set `anthropic_base_url` to point Claude Code at a self-hosted gateway or proxy 
 ```tf
 module "claude-code" {
   source             = "registry.coder.com/coder/claude-code/coder"
-  version            = "5.4.1"
+  version            = "5.5.0"
   agent_id           = coder_agent.main.id
   workdir            = "/home/coder/project"
   anthropic_base_url = "https://llm-gateway.example.com/anthropic"
@@ -365,7 +412,7 @@ module "claude-code" {
 ```
 
 > [!CAUTION]
-> `anthropic_base_url` is mutually exclusive with `enable_ai_gateway`, which sets `ANTHROPIC_BASE_URL` to the Coder AI Gateway endpoint. `use_bedrock` and `use_vertex` are likewise mutually exclusive with `enable_ai_gateway` and with each other.
+> `anthropic_base_url` is mutually exclusive with `enable_ai_gateway`, which sets `ANTHROPIC_BASE_URL` to the Coder AI Gateway endpoint. `use_bedrock`, `use_vertex`, and `use_foundry` are mutually exclusive provider backends.
 
 ### Telemetry export (OpenTelemetry)
 
@@ -376,7 +423,7 @@ The module automatically tags every span and metric with `coder.workspace_id`, `
 ```tf
 module "claude-code" {
   source            = "registry.coder.com/coder/claude-code/coder"
-  version           = "5.4.1"
+  version           = "5.5.0"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   anthropic_api_key = "xxxx-xxxxx-xxxx"

--- a/registry/coder/modules/claude-code/main.test.ts
+++ b/registry/coder/modules/claude-code/main.test.ts
@@ -703,6 +703,38 @@ describe("claude-code", async () => {
     expect(installLog).not.toContain("No authentication configured");
   });
 
+  test("use-foundry-with-resource-no-api-key", async () => {
+    const { id, coderEnvVars, scripts } = await setup({
+      moduleVariables: {
+        use_foundry: "true",
+        foundry_resource: "coder-foundry",
+      },
+    });
+    expect(coderEnvVars["CLAUDE_CODE_USE_FOUNDRY"]).toBe("1");
+    expect(coderEnvVars["ANTHROPIC_FOUNDRY_RESOURCE"]).toBe("coder-foundry");
+    expect(coderEnvVars["ANTHROPIC_FOUNDRY_BASE_URL"]).toBeUndefined();
+    expect(coderEnvVars["ANTHROPIC_FOUNDRY_API_KEY"]).toBeUndefined();
+    expect(coderEnvVars["ANTHROPIC_FOUNDRY_AUTH_TOKEN"]).toBeUndefined();
+    expect(coderEnvVars["ANTHROPIC_API_KEY"]).toBeUndefined();
+
+    await runScripts(id, scripts, coderEnvVars);
+    const installLog = await readFileContainer(
+      id,
+      "/home/coder/.coder-modules/coder/claude-code/logs/install.log",
+    );
+    expect(installLog).toContain(
+      "Using Microsoft Foundry (CLAUDE_CODE_USE_FOUNDRY=1)",
+    );
+    expect(installLog).not.toContain("No authentication configured");
+    expect(installLog).toContain("Standalone mode configured successfully");
+
+    const claudeConfig = await readFileContainer(
+      id,
+      "/home/coder/.claude.json",
+    );
+    expect(JSON.parse(claudeConfig).hasCompletedOnboarding).toBe(true);
+  });
+
   test("anthropic-base-url-custom", async () => {
     const baseUrl = "https://llm-gateway.example.com/anthropic";
     const { id, coderEnvVars, scripts } = await setup({

--- a/registry/coder/modules/claude-code/main.tf
+++ b/registry/coder/modules/claude-code/main.tf
@@ -105,7 +105,7 @@ variable "claude_binary_path" {
 
 variable "managed_settings" {
   type        = any
-  description = "Policy settings written to /etc/claude-code/managed-settings.d/10-coder.json. Highest-precedence client config; works with any inference backend (Anthropic API, Bedrock, Vertex, AI Gateway). See https://docs.anthropic.com/en/docs/claude-code/settings for the schema."
+  description = "Policy settings written to /etc/claude-code/managed-settings.d/10-coder.json. Highest-precedence client config; works with any inference backend (Anthropic API, Bedrock, Vertex, Foundry, AI Gateway). See https://docs.anthropic.com/en/docs/claude-code/settings for the schema."
   default     = null
 }
 
@@ -139,7 +139,7 @@ variable "telemetry" {
 
 variable "anthropic_base_url" {
   type        = string
-  description = "Override the Anthropic API base URL (sets ANTHROPIC_BASE_URL). Use for self-hosted gateways or proxies that speak the Anthropic Messages API. Mutually exclusive with enable_ai_gateway, which sets ANTHROPIC_BASE_URL to the Coder AI Gateway endpoint."
+  description = "Override the Anthropic API base URL (sets ANTHROPIC_BASE_URL). Use for self-hosted gateways or proxies that speak the Anthropic Messages API. Mutually exclusive with enable_ai_gateway and use_foundry."
   default     = ""
 
   validation {
@@ -150,7 +150,7 @@ variable "anthropic_base_url" {
 
 variable "use_bedrock" {
   type        = bool
-  description = "Run Claude Code against Amazon Bedrock (sets CLAUDE_CODE_USE_BEDROCK=1). Authentication uses the workspace's AWS credential chain (IRSA, instance profile, or AWS_* env vars). Mutually exclusive with enable_ai_gateway and use_vertex."
+  description = "Run Claude Code against Amazon Bedrock (sets CLAUDE_CODE_USE_BEDROCK=1). Authentication uses the workspace's AWS credential chain (IRSA, instance profile, or AWS_* env vars). Mutually exclusive with enable_ai_gateway, use_vertex, and use_foundry."
   default     = false
 
   validation {
@@ -166,13 +166,75 @@ variable "use_bedrock" {
 
 variable "use_vertex" {
   type        = bool
-  description = "Run Claude Code against Google Vertex AI (sets CLAUDE_CODE_USE_VERTEX=1). Authentication uses Google Application Default Credentials inside the workspace. Mutually exclusive with enable_ai_gateway and use_bedrock."
+  description = "Run Claude Code against Google Vertex AI (sets CLAUDE_CODE_USE_VERTEX=1). Authentication uses Google Application Default Credentials inside the workspace. Mutually exclusive with enable_ai_gateway, use_bedrock, and use_foundry."
   default     = false
 
   validation {
     condition     = !(var.use_vertex && var.enable_ai_gateway)
     error_message = "use_vertex cannot be combined with enable_ai_gateway."
   }
+}
+
+variable "use_foundry" {
+  description = "Run Claude Code against Microsoft Foundry (sets CLAUDE_CODE_USE_FOUNDRY=1). Authentication uses the Azure credential chain unless ANTHROPIC_FOUNDRY_API_KEY or ANTHROPIC_FOUNDRY_AUTH_TOKEN is provided separately."
+  type        = bool
+  default     = false
+
+  validation {
+    condition = !var.use_foundry || (
+      !var.enable_ai_gateway &&
+      !var.use_bedrock &&
+      !var.use_vertex &&
+      var.anthropic_base_url == "" &&
+      var.anthropic_api_key == "" &&
+      var.claude_code_oauth_token == "" &&
+      var.api_key_helper == null
+    )
+    error_message = "use_foundry cannot be combined with enable_ai_gateway, use_bedrock, use_vertex, anthropic_base_url, anthropic_api_key, claude_code_oauth_token, or api_key_helper."
+  }
+
+  validation {
+    condition = var.use_foundry ? (
+      (var.foundry_resource != "") != (var.foundry_base_url != "")
+      ) : (
+      var.foundry_resource == "" &&
+      var.foundry_base_url == "" &&
+      var.foundry_api_key == "" &&
+      var.foundry_auth_token == ""
+    )
+    error_message = "Set exactly one of foundry_resource or foundry_base_url when use_foundry is true, and leave all Foundry inputs empty otherwise."
+  }
+
+  validation {
+    condition     = !var.use_foundry || var.foundry_api_key == "" || var.foundry_auth_token == ""
+    error_message = "Set at most one of foundry_api_key or foundry_auth_token. Leave both empty to use the Azure default credential chain."
+  }
+}
+
+variable "foundry_resource" {
+  description = "Microsoft Foundry resource name passed through ANTHROPIC_FOUNDRY_RESOURCE. Mutually exclusive with foundry_base_url."
+  type        = string
+  default     = ""
+}
+
+variable "foundry_base_url" {
+  description = "Full Microsoft Foundry endpoint passed through ANTHROPIC_FOUNDRY_BASE_URL. Mutually exclusive with foundry_resource."
+  type        = string
+  default     = ""
+}
+
+variable "foundry_api_key" {
+  description = "Optional Microsoft Foundry API key passed through ANTHROPIC_FOUNDRY_API_KEY. Prefer the Azure default credential chain for managed workspaces."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "foundry_auth_token" {
+  description = "Optional short-lived Microsoft Entra bearer token passed through ANTHROPIC_FOUNDRY_AUTH_TOKEN. Requires Claude Code 2.1.203 or later."
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 
 variable "api_key_helper" {
@@ -253,6 +315,41 @@ resource "coder_env" "use_vertex" {
   value    = "1"
 }
 
+resource "coder_env" "use_foundry" {
+  count    = var.use_foundry ? 1 : 0
+  agent_id = var.agent_id
+  name     = "CLAUDE_CODE_USE_FOUNDRY"
+  value    = "1"
+}
+
+resource "coder_env" "foundry_resource" {
+  count    = var.use_foundry && var.foundry_resource != "" ? 1 : 0
+  agent_id = var.agent_id
+  name     = "ANTHROPIC_FOUNDRY_RESOURCE"
+  value    = var.foundry_resource
+}
+
+resource "coder_env" "foundry_base_url" {
+  count    = var.use_foundry && var.foundry_base_url != "" ? 1 : 0
+  agent_id = var.agent_id
+  name     = "ANTHROPIC_FOUNDRY_BASE_URL"
+  value    = var.foundry_base_url
+}
+
+resource "coder_env" "foundry_api_key" {
+  count    = var.use_foundry && var.foundry_api_key != "" ? 1 : 0
+  agent_id = var.agent_id
+  name     = "ANTHROPIC_FOUNDRY_API_KEY"
+  value    = var.foundry_api_key
+}
+
+resource "coder_env" "foundry_auth_token" {
+  count    = var.use_foundry && var.foundry_auth_token != "" ? 1 : 0
+  agent_id = var.agent_id
+  name     = "ANTHROPIC_FOUNDRY_AUTH_TOKEN"
+  value    = var.foundry_auth_token
+}
+
 resource "coder_env" "api_key_helper_ttl" {
   count    = var.api_key_helper != null ? 1 : 0
   agent_id = var.agent_id
@@ -325,6 +422,7 @@ locals {
     ARG_MANAGED_SETTINGS_JSON  = var.managed_settings != null ? base64encode(jsonencode(var.managed_settings)) : ""
     ARG_USE_BEDROCK            = tostring(var.use_bedrock)
     ARG_USE_VERTEX             = tostring(var.use_vertex)
+    ARG_USE_FOUNDRY            = tostring(var.use_foundry)
     ARG_ANTHROPIC_BASE_URL     = var.anthropic_base_url
     ARG_API_KEY_HELPER_SCRIPT  = var.api_key_helper != null ? base64encode(var.api_key_helper.script) : ""
   })

--- a/registry/coder/modules/claude-code/main.tftest.hcl
+++ b/registry/coder/modules/claude-code/main.tftest.hcl
@@ -363,6 +363,245 @@ run "test_use_vertex" {
   }
 }
 
+run "test_use_foundry_with_resource" {
+  command = plan
+
+  variables {
+    agent_id         = "test-agent-foundry-resource"
+    workdir          = "/home/coder/test"
+    use_foundry      = true
+    foundry_resource = "coder-foundry"
+  }
+
+  assert {
+    condition     = coder_env.use_foundry[0].name == "CLAUDE_CODE_USE_FOUNDRY" && coder_env.use_foundry[0].value == "1"
+    error_message = "CLAUDE_CODE_USE_FOUNDRY should be set to 1 when use_foundry is true"
+  }
+
+  assert {
+    condition     = coder_env.foundry_resource[0].name == "ANTHROPIC_FOUNDRY_RESOURCE" && coder_env.foundry_resource[0].value == "coder-foundry"
+    error_message = "ANTHROPIC_FOUNDRY_RESOURCE should use foundry_resource"
+  }
+
+  assert {
+    condition     = length(coder_env.foundry_base_url) == 0
+    error_message = "ANTHROPIC_FOUNDRY_BASE_URL should not be set when foundry_resource is used"
+  }
+
+  assert {
+    condition     = length(coder_env.foundry_api_key) == 0 && length(coder_env.foundry_auth_token) == 0
+    error_message = "Foundry credentials should be omitted when the Azure default credential chain is used"
+  }
+}
+
+run "test_use_foundry_with_base_url" {
+  command = plan
+
+  variables {
+    agent_id         = "test-agent-foundry-base-url"
+    workdir          = "/home/coder/test"
+    use_foundry      = true
+    foundry_base_url = "https://coder-foundry.services.ai.azure.com/anthropic"
+  }
+
+  assert {
+    condition     = coder_env.foundry_base_url[0].name == "ANTHROPIC_FOUNDRY_BASE_URL" && coder_env.foundry_base_url[0].value == "https://coder-foundry.services.ai.azure.com/anthropic"
+    error_message = "ANTHROPIC_FOUNDRY_BASE_URL should use foundry_base_url"
+  }
+
+  assert {
+    condition     = length(coder_env.foundry_resource) == 0
+    error_message = "ANTHROPIC_FOUNDRY_RESOURCE should not be set when foundry_base_url is used"
+  }
+}
+
+run "test_use_foundry_with_api_key" {
+  command = plan
+
+  variables {
+    agent_id         = "test-agent-foundry-api-key"
+    use_foundry      = true
+    foundry_resource = "coder-foundry"
+    foundry_api_key  = "foundry-test-key"
+  }
+
+  assert {
+    condition     = coder_env.foundry_api_key[0].name == "ANTHROPIC_FOUNDRY_API_KEY" && coder_env.foundry_api_key[0].value == "foundry-test-key"
+    error_message = "ANTHROPIC_FOUNDRY_API_KEY should use foundry_api_key"
+  }
+
+  assert {
+    condition     = length(coder_env.foundry_auth_token) == 0
+    error_message = "ANTHROPIC_FOUNDRY_AUTH_TOKEN should not be set when foundry_api_key is used"
+  }
+}
+
+run "test_use_foundry_with_auth_token" {
+  command = plan
+
+  variables {
+    agent_id           = "test-agent-foundry-auth-token"
+    use_foundry        = true
+    foundry_base_url   = "https://coder-foundry.services.ai.azure.com/anthropic"
+    foundry_auth_token = "foundry-test-token"
+  }
+
+  assert {
+    condition     = coder_env.foundry_auth_token[0].name == "ANTHROPIC_FOUNDRY_AUTH_TOKEN" && coder_env.foundry_auth_token[0].value == "foundry-test-token"
+    error_message = "ANTHROPIC_FOUNDRY_AUTH_TOKEN should use foundry_auth_token"
+  }
+
+  assert {
+    condition     = length(coder_env.foundry_api_key) == 0
+    error_message = "ANTHROPIC_FOUNDRY_API_KEY should not be set when foundry_auth_token is used"
+  }
+}
+
+run "test_use_foundry_requires_endpoint" {
+  command = plan
+
+  variables {
+    agent_id    = "test-agent-foundry-missing-endpoint"
+    use_foundry = true
+  }
+
+  expect_failures = [
+    var.use_foundry,
+  ]
+}
+
+run "test_use_foundry_rejects_ambiguous_endpoint" {
+  command = plan
+
+  variables {
+    agent_id         = "test-agent-foundry-ambiguous-endpoint"
+    use_foundry      = true
+    foundry_resource = "coder-foundry"
+    foundry_base_url = "https://coder-foundry.services.ai.azure.com/anthropic"
+  }
+
+  expect_failures = [
+    var.use_foundry,
+  ]
+}
+
+run "test_foundry_endpoint_requires_foundry" {
+  command = plan
+
+  variables {
+    agent_id         = "test-agent-foundry-disabled"
+    foundry_resource = "coder-foundry"
+  }
+
+  expect_failures = [
+    var.use_foundry,
+  ]
+}
+
+run "test_foundry_credentials_require_foundry" {
+  command = plan
+
+  variables {
+    agent_id        = "test-agent-foundry-credentials-disabled"
+    foundry_api_key = "foundry-test-key"
+  }
+
+  expect_failures = [
+    var.use_foundry,
+  ]
+}
+
+run "test_use_foundry_rejects_multiple_credentials" {
+  command = plan
+
+  variables {
+    agent_id           = "test-agent-foundry-multiple-credentials"
+    use_foundry        = true
+    foundry_resource   = "coder-foundry"
+    foundry_api_key    = "foundry-test-key"
+    foundry_auth_token = "foundry-test-token"
+  }
+
+  expect_failures = [
+    var.use_foundry,
+  ]
+}
+
+run "test_use_foundry_rejects_ai_gateway" {
+  command = plan
+
+  variables {
+    agent_id          = "test-agent-foundry-ai-gateway"
+    use_foundry       = true
+    foundry_resource  = "coder-foundry"
+    enable_ai_gateway = true
+  }
+
+  expect_failures = [
+    var.use_foundry,
+  ]
+}
+
+run "test_use_foundry_rejects_bedrock" {
+  command = plan
+
+  variables {
+    agent_id         = "test-agent-foundry-bedrock"
+    use_foundry      = true
+    foundry_resource = "coder-foundry"
+    use_bedrock      = true
+  }
+
+  expect_failures = [
+    var.use_foundry,
+  ]
+}
+
+run "test_use_foundry_rejects_vertex" {
+  command = plan
+
+  variables {
+    agent_id         = "test-agent-foundry-vertex"
+    use_foundry      = true
+    foundry_resource = "coder-foundry"
+    use_vertex       = true
+  }
+
+  expect_failures = [
+    var.use_foundry,
+  ]
+}
+
+run "test_use_foundry_rejects_anthropic_auth" {
+  command = plan
+
+  variables {
+    agent_id          = "test-agent-foundry-anthropic-auth"
+    use_foundry       = true
+    foundry_resource  = "coder-foundry"
+    anthropic_api_key = "sk-test"
+  }
+
+  expect_failures = [
+    var.use_foundry,
+  ]
+}
+
+run "test_use_foundry_rejects_anthropic_base_url" {
+  command = plan
+
+  variables {
+    agent_id           = "test-agent-foundry-anthropic-base-url"
+    use_foundry        = true
+    foundry_resource   = "coder-foundry"
+    anthropic_base_url = "https://gateway.example.com/anthropic"
+  }
+
+  expect_failures = [
+    var.use_foundry,
+  ]
+}
+
 run "test_anthropic_base_url_custom" {
   command = plan
 

--- a/registry/coder/modules/claude-code/scripts/install.sh.tftpl
+++ b/registry/coder/modules/claude-code/scripts/install.sh.tftpl
@@ -20,6 +20,7 @@ ARG_ENABLE_AI_GATEWAY='${ARG_ENABLE_AI_GATEWAY}'
 ARG_MANAGED_SETTINGS_JSON=$(echo -n '${ARG_MANAGED_SETTINGS_JSON}' | base64 -d)
 ARG_USE_BEDROCK='${ARG_USE_BEDROCK}'
 ARG_USE_VERTEX='${ARG_USE_VERTEX}'
+ARG_USE_FOUNDRY='${ARG_USE_FOUNDRY}'
 ARG_ANTHROPIC_BASE_URL='${ARG_ANTHROPIC_BASE_URL}'
 ARG_API_KEY_HELPER_SCRIPT=$(echo -n '${ARG_API_KEY_HELPER_SCRIPT}' | base64 -d)
 
@@ -37,6 +38,7 @@ printf "ARG_ENABLE_AI_GATEWAY: %s\n" "$${ARG_ENABLE_AI_GATEWAY}"
 printf "ARG_MANAGED_SETTINGS_JSON: %s\n" "$${ARG_MANAGED_SETTINGS_JSON}"
 printf "ARG_USE_BEDROCK: %s\n" "$${ARG_USE_BEDROCK}"
 printf "ARG_USE_VERTEX: %s\n" "$${ARG_USE_VERTEX}"
+printf "ARG_USE_FOUNDRY: %s\n" "$${ARG_USE_FOUNDRY}"
 printf "ARG_ANTHROPIC_BASE_URL: %s\n" "$${ARG_ANTHROPIC_BASE_URL}"
 printf "ARG_API_KEY_HELPER_SCRIPT: %s\n" "$${ARG_API_KEY_HELPER_SCRIPT:+(set)}"
 
@@ -248,6 +250,9 @@ function configure_standalone_mode() {
   elif [ "$${ARG_USE_VERTEX}" = "true" ]; then
     echo "Using Google Vertex AI (CLAUDE_CODE_USE_VERTEX=1); Anthropic API key not required."
     have_auth="true"
+  elif [ "$${ARG_USE_FOUNDRY}" = "true" ]; then
+    echo "Using Microsoft Foundry (CLAUDE_CODE_USE_FOUNDRY=1); Anthropic API key not required."
+    have_auth="true"
   elif [ -n "$${ARG_ANTHROPIC_BASE_URL}" ]; then
     echo "Using custom ANTHROPIC_BASE_URL ($${ARG_ANTHROPIC_BASE_URL}); Anthropic API key not required."
     have_auth="true"
@@ -257,7 +262,7 @@ function configure_standalone_mode() {
   fi
 
   if [ "$${have_auth}" = "false" ]; then
-    echo "Note: No authentication configured (anthropic_api_key, claude_code_oauth_token, enable_ai_gateway, use_bedrock, use_vertex, anthropic_base_url, api_key_helper), skipping onboarding bypass"
+    echo "Note: No authentication configured (anthropic_api_key, claude_code_oauth_token, enable_ai_gateway, use_bedrock, use_vertex, use_foundry, anthropic_base_url, api_key_helper), skipping onboarding bypass"
     return
   fi
 


### PR DESCRIPTION
## Why

Claude Code supports Microsoft Foundry as an enterprise inference provider, but the Registry module cannot currently configure that backend. Users must wire the provider environment manually and the module does not recognize Foundry authentication when preparing standalone mode.

## Changes

- Add `use_foundry` with support for either a Foundry resource name or full base URL.
- Export the official Foundry provider, endpoint, API key, and bearer token environment variables.
- Use the Azure default credential chain when no Foundry credential is provided, while keeping optional credentials sensitive.
- Reject ambiguous endpoints, multiple Foundry credentials, and combinations with other inference backends or direct Anthropic authentication.
- Recognize Foundry as configured authentication in the install script.
- Document managed identity, model deployment pinning, and all supported authentication paths.
- Add Terraform coverage and a container test for the no-static-key Foundry path.

## Type of Change

- [ ] New module
- [ ] New template
- [ ] Bug fix
- [x] Feature/enhancement
- [x] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder/modules/claude-code`  
**New version:** `v5.5.0`  
**Breaking change:** [ ] Yes [x] No

## Validation

- `terraform test -no-color` — 41 passed, 0 failed.
- `bun test main.test.ts` — 27 passed, 212 assertions, 0 failed.
- `bun test main.test.ts -t use-foundry-with-resource-no-api-key` — 1 passed, 15 assertions.
- `terraform validate -no-color` — passed.
- `terraform fmt -check -diff main.tf main.tftest.hcl` — passed.

## Testing & Validation

- [x] Tests pass (`bun test`)
- [x] Code formatted (targeted Prettier and Terraform formatting checks)
- [x] Changes tested locally

## Related Issues

None
