### PR TITLE
fix(codex): use official standalone installer

### DIFF
--- a/registry/coder-labs/modules/codex/README.md
+++ b/registry/coder-labs/modules/codex/README.md
@@ -13,7 +13,7 @@ Install and configure the [Codex CLI](https://github.com/openai/codex) in your w
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.3.2"
+  version        = "5.3.3"
   agent_id       = coder_agent.main.id
   openai_api_key = var.openai_api_key
 }
@@ -33,7 +33,7 @@ locals {
 
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.3.2"
+  version        = "5.3.3"
   agent_id       = coder_agent.main.id
   workdir        = local.codex_workdir
   openai_api_key = var.openai_api_key
@@ -64,7 +64,7 @@ resource "coder_app" "codex" {
 ```tf
 module "codex" {
   source            = "registry.coder.com/coder-labs/codex/coder"
-  version           = "5.3.2"
+  version           = "5.3.3"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   enable_ai_gateway = true
@@ -88,7 +88,7 @@ When `enable_ai_gateway = true`, the module configures Codex to use the `aigatew
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.3.2"
+  version        = "5.3.3"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   openai_api_key = var.openai_api_key
@@ -134,7 +134,7 @@ The module exposes the `scripts` output: an ordered list of `coder exp sync` nam
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.3.2"
+  version        = "5.3.3"
   agent_id       = coder_agent.main.id
   openai_api_key = var.openai_api_key
 }

--- a/registry/coder-labs/modules/codex/README.md
+++ b/registry/coder-labs/modules/codex/README.md
@@ -13,7 +13,7 @@ Install and configure the [Codex CLI](https://github.com/openai/codex) in your w
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.3.3"
+  version        = "5.4.0"
   agent_id       = coder_agent.main.id
   openai_api_key = var.openai_api_key
 }
@@ -33,7 +33,7 @@ locals {
 
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.3.3"
+  version        = "5.4.0"
   agent_id       = coder_agent.main.id
   workdir        = local.codex_workdir
   openai_api_key = var.openai_api_key
@@ -64,7 +64,7 @@ resource "coder_app" "codex" {
 ```tf
 module "codex" {
   source            = "registry.coder.com/coder-labs/codex/coder"
-  version           = "5.3.3"
+  version           = "5.4.0"
   agent_id          = coder_agent.main.id
   workdir           = "/home/coder/project"
   enable_ai_gateway = true
@@ -88,7 +88,7 @@ When `enable_ai_gateway = true`, the module configures Codex to use the `aigatew
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.3.3"
+  version        = "5.4.0"
   agent_id       = coder_agent.main.id
   workdir        = "/home/coder/project"
   openai_api_key = var.openai_api_key
@@ -134,7 +134,7 @@ The module exposes the `scripts` output: an ordered list of `coder exp sync` nam
 ```tf
 module "codex" {
   source         = "registry.coder.com/coder-labs/codex/coder"
-  version        = "5.3.3"
+  version        = "5.4.0"
   agent_id       = coder_agent.main.id
   openai_api_key = var.openai_api_key
 }

--- a/registry/coder-labs/modules/codex/main.test.ts
+++ b/registry/coder-labs/modules/codex/main.test.ts
@@ -192,36 +192,6 @@ const runInstallScript = async (
   ]);
 };
 
-const CODEX_TARGET = "x86_64-unknown-linux-musl";
-
-const writeCodexArchive = async (
-  id: string,
-  options?: { binaryName?: string; binaryContent?: string },
-) => {
-  const binaryName = options?.binaryName ?? `codex-${CODEX_TARGET}`;
-  await execContainer(id, [
-    "bash",
-    "-c",
-    "rm -rf /tmp/codex-fixture && mkdir -p /tmp/codex-fixture",
-  ]);
-  await writeExecutable({
-    containerId: id,
-    filePath: `/tmp/codex-fixture/${binaryName}`,
-    content:
-      options?.binaryContent ??
-      '#!/bin/bash\nif [[ "$1" == "--version" ]]; then echo "codex test version"; exit 0; fi\nexit 0\n',
-  });
-  const archive = await execContainer(id, [
-    "tar",
-    "-czf",
-    "/tmp/codex-test-archive.tar.gz",
-    "-C",
-    "/tmp/codex-fixture",
-    binaryName,
-  ]);
-  expect(archive.exitCode).toBe(0);
-};
-
 const writeCurlMock = async (id: string, exitCode = 0) => {
   await writeExecutable({
     containerId: id,
@@ -229,15 +199,34 @@ const writeCurlMock = async (id: string, exitCode = 0) => {
     content: [
       "#!/bin/bash",
       "printf '%s\\n' \"$*\" > /tmp/codex-curl-args",
-      "output=''",
-      "while (($#)); do",
-      '  case "$1" in',
-      '    --output|-o) output="$2"; shift 2 ;;',
-      "    *) shift ;;",
-      "  esac",
-      "done",
       `if [[ ${exitCode} -ne 0 ]]; then exit ${exitCode}; fi`,
-      'cp /tmp/codex-test-archive.tar.gz "$output"',
+      "cat /tmp/codex-installer-fixture.sh",
+    ].join("\n"),
+  });
+};
+
+const writeCodexInstaller = async (
+  id: string,
+  options?: { exitCode?: number; installCodex?: boolean },
+) => {
+  const exitCode = options?.exitCode ?? 0;
+  await writeExecutable({
+    containerId: id,
+    filePath: "/tmp/codex-installer-fixture.sh",
+    content: [
+      "#!/bin/sh",
+      'printf "CODEX_INSTALL_DIR=%s\\nCODEX_RELEASE=%s\\nCODEX_NON_INTERACTIVE=%s\\n" "$CODEX_INSTALL_DIR" "$CODEX_RELEASE" "$CODEX_NON_INTERACTIVE" > /tmp/codex-installer-env',
+      "if [ " + exitCode + " -ne 0 ]; then exit " + exitCode + "; fi",
+      ...(options?.installCodex === false
+        ? []
+        : [
+            'mkdir -p "$CODEX_INSTALL_DIR"',
+            "cat > \"$CODEX_INSTALL_DIR/codex\" <<'EOF'",
+            "#!/bin/sh",
+            'if [ "$1" = "--version" ]; then echo "codex test version"; fi',
+            "EOF",
+            'chmod +x "$CODEX_INSTALL_DIR/codex"',
+          ]),
     ].join("\n"),
   });
 };
@@ -277,16 +266,23 @@ describe("codex", async () => {
         codex_version: version,
       },
     });
-    await writeCodexArchive(id);
+    await writeCodexInstaller(id);
     await writeCurlMock(id);
     await runScripts(id, scripts, coderEnvVars);
     const log = await installLog(id);
     const curlArgs = await readFileContainer(id, "/tmp/codex-curl-args");
     expect(log).toContain("Installed Codex CLI: codex test version");
-    expect(curlArgs).toContain(`rust-v${version}/codex-${CODEX_TARGET}.tar.gz`);
+    const installerEnv = await readFileContainer(
+      id,
+      "/tmp/codex-installer-env",
+    );
+    expect(curlArgs).toContain("https://chatgpt.com/codex/install.sh");
     expect(curlArgs).toContain("--retry 2");
     expect(curlArgs).toContain("--connect-timeout 10");
     expect(curlArgs).toContain("--max-time 300");
+    expect(installerEnv).toContain("CODEX_INSTALL_DIR=/home/coder/.local/bin");
+    expect(installerEnv).toContain(`CODEX_RELEASE=${version}`);
+    expect(installerEnv).toContain("CODEX_NON_INTERACTIVE=1");
   });
 
   test("openai-api-key", async () => {
@@ -549,15 +545,18 @@ describe("codex", async () => {
         install_codex: "true",
       },
     });
-    await writeCodexArchive(id);
+    await writeCodexInstaller(id);
     await writeCurlMock(id);
     await runScripts(id, scripts, coderEnvVars);
     const log = await installLog(id);
     const curlArgs = await readFileContainer(id, "/tmp/codex-curl-args");
     expect(log).toContain("Installed Codex CLI: codex test version");
-    expect(curlArgs).toContain(
-      `releases/latest/download/codex-${CODEX_TARGET}.tar.gz`,
+    const installerEnv = await readFileContainer(
+      id,
+      "/tmp/codex-installer-env",
     );
+    expect(curlArgs).toContain("https://chatgpt.com/codex/install.sh");
+    expect(installerEnv).toContain("CODEX_RELEASE=latest");
   });
 
   test("codex-download-failure-is-terminal", async () => {
@@ -565,61 +564,40 @@ describe("codex", async () => {
       skipCodexMock: true,
       moduleVariables: { install_codex: "true" },
     });
+    await writeCodexInstaller(id);
     await writeCurlMock(id, 28);
     const result = await runInstallScript(id, scripts.install);
     expect(result.exitCode).not.toBe(0);
     const log = await installLog(id);
-    expect(log).toContain(
-      "Codex could not be downloaded after up to 3 attempts.",
-    );
+    expect(log).toContain("Codex installation failed.");
     expect(log).not.toContain("Installed Codex CLI");
   });
 
-  test("invalid-codex-archive-is-rejected", async () => {
+  test("codex-installer-failure-is-terminal", async () => {
     const { id, scripts } = await setup({
       skipCodexMock: true,
       moduleVariables: { install_codex: "true" },
     });
-    await writeExecutable({
-      containerId: id,
-      filePath: "/tmp/codex-test-archive.tar.gz",
-      content: "not a tar archive",
-    });
+    await writeCodexInstaller(id, { exitCode: 7 });
     await writeCurlMock(id);
     const result = await runInstallScript(id, scripts.install);
     expect(result.exitCode).not.toBe(0);
     const log = await installLog(id);
-    expect(log).toContain("Codex download was not a valid archive.");
+    expect(log).toContain("Codex installation failed.");
     expect(log).not.toContain("Installed Codex CLI");
   });
 
-  test("codex-archive-must-contain-expected-binary", async () => {
+  test("codex-installer-must-install-an-executable", async () => {
     const { id, scripts } = await setup({
       skipCodexMock: true,
       moduleVariables: { install_codex: "true" },
     });
-    await writeCodexArchive(id, { binaryName: "unexpected-codex" });
+    await writeCodexInstaller(id, { installCodex: false });
     await writeCurlMock(id);
     const result = await runInstallScript(id, scripts.install);
     expect(result.exitCode).not.toBe(0);
     const log = await installLog(id);
-    expect(log).toContain("Codex archive did not contain the expected binary.");
-    expect(log).not.toContain("Installed Codex CLI");
-  });
-
-  test("downloaded-codex-binary-must-run", async () => {
-    const { id, scripts } = await setup({
-      skipCodexMock: true,
-      moduleVariables: { install_codex: "true" },
-    });
-    await writeCodexArchive(id, {
-      binaryContent: "#!/bin/bash\nexit 7\n",
-    });
-    await writeCurlMock(id);
-    const result = await runInstallScript(id, scripts.install);
-    expect(result.exitCode).not.toBe(0);
-    const log = await installLog(id);
-    expect(log).toContain("Downloaded Codex binary could not be executed.");
+    expect(log).toContain("Codex binary was not found or is not executable.");
     expect(log).not.toContain("Installed Codex CLI");
   });
 

--- a/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
+++ b/registry/coder-labs/modules/codex/scripts/install.sh.tftpl
@@ -76,50 +76,6 @@ function ensure_codex_in_path() {
   add_path_to_shell_profiles "$${CODEX_DIR}"
 }
 
-function download_codex() (
-  local target="$1"
-  local url="$2"
-  local tmp_dir archive archive_contents candidate
-
-  tmp_dir=$(mktemp -d)
-  trap 'rm -rf "$${tmp_dir}"' EXIT
-  archive="$${tmp_dir}/codex.tar.gz"
-  archive_contents="$${tmp_dir}/archive-contents"
-  candidate="$${tmp_dir}/codex-$${target}"
-
-  if ! curl --fail --silent --show-error --location \
-    --retry 2 --retry-delay 1 --retry-all-errors \
-    --connect-timeout 10 --max-time 300 \
-    --output "$${archive}" "$${url}"; then
-    echo "Codex could not be downloaded after up to 3 attempts." >&2
-    return 1
-  fi
-
-  if ! tar -tzf "$${archive}" > "$${archive_contents}" 2> /dev/null; then
-    echo "Codex download was not a valid archive." >&2
-    return 1
-  fi
-
-  if ! grep -qx "codex-$${target}" "$${archive_contents}"; then
-    echo "Codex archive did not contain the expected binary." >&2
-    return 1
-  fi
-
-  if ! tar -xzf "$${archive}" -C "$${tmp_dir}" "codex-$${target}"; then
-    echo "Codex archive could not be extracted." >&2
-    return 1
-  fi
-
-  chmod +x "$${candidate}"
-  if ! "$${candidate}" --version > /dev/null; then
-    echo "Downloaded Codex binary could not be executed." >&2
-    return 1
-  fi
-
-  mkdir -p "$HOME/.local/bin"
-  mv "$${candidate}" "$HOME/.local/bin/codex"
-)
-
 function install_codex() {
   if [ "$${ARG_INSTALL}" != "true" ]; then
     echo "Skipping Codex installation as per configuration."
@@ -130,19 +86,16 @@ function install_codex() {
 
   printf "%s Installing Codex CLI\n" "$${BOLD}"
 
-  local arch
-  arch=$(uname -m)
-  local target="$${arch}-unknown-linux-musl"
-  local version="$${ARG_CODEX_VERSION}"
-
-  local url="https://github.com/openai/codex/releases/download/rust-v$${version}/codex-$${target}.tar.gz"
-
-  if [ "$${version}" = "latest" ]; then
-    url="https://github.com/openai/codex/releases/latest/download/codex-$${target}.tar.gz"
+  if ! curl --fail --silent --show-error --location \
+    --retry 2 --retry-delay 1 --retry-all-errors \
+    --connect-timeout 10 --max-time 300 \
+    https://chatgpt.com/codex/install.sh \
+    | CODEX_INSTALL_DIR="$HOME/.local/bin" \
+      CODEX_RELEASE="$${ARG_CODEX_VERSION}" \
+      CODEX_NON_INTERACTIVE=1 sh; then
+    echo "Codex installation failed." >&2
+    return 1
   fi
-
-  printf "Downloading %s\n" "$${url}"
-  download_codex "$${target}" "$${url}"
 
   export PATH="$HOME/.local/bin:$PATH"
   ensure_codex_in_path


### PR DESCRIPTION
## Why

The module downloads only the bare Codex executable from GitHub releases. Starting with Codex 0.153.0, that omits the companion `codex-code-mode-host` and bundled `rg`, so Code Mode is unavailable and exec-tool calls fail closed.

## Changes

- Install Codex through the official standalone installer so the CLI, Code Mode host, bundled ripgrep, and supporting resources stay together.
- Forward the configured version, installation directory, and non-interactive mode through the installer's documented environment variables.
- Bump the module examples from 5.3.2 to 5.4.0.

## Type of Change

- [ ] New module
- [ ] New template
- [x] Bug fix
- [ ] Feature/enhancement
- [ ] Documentation
- [ ] Other

## Module Information

**Path:** `registry/coder-labs/modules/codex`  
**New version:** `v5.4.0`  
**Breaking change:** [ ] Yes [x] No

## Related Issues

Closes #1103.