### PR TITLE
docs(registry/coder/modules/filebrowser): deprecate module and point to copyparty

### DIFF
--- a/registry/coder/modules/filebrowser/README.md
+++ b/registry/coder/modules/filebrowser/README.md
@@ -19,7 +19,7 @@ A file browser for your workspace.
 module "filebrowser" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/filebrowser/coder"
-  version  = "1.1.5"
+  version  = "1.1.6"
   agent_id = coder_agent.main.id
 }
 ```
@@ -34,7 +34,7 @@ module "filebrowser" {
 module "filebrowser" {
   count    = data.coder_workspace.me.start_count
   source   = "registry.coder.com/coder/filebrowser/coder"
-  version  = "1.1.5"
+  version  = "1.1.6"
   agent_id = coder_agent.main.id
   folder   = "/home/coder/project"
 }
@@ -46,7 +46,7 @@ module "filebrowser" {
 module "filebrowser" {
   count         = data.coder_workspace.me.start_count
   source        = "registry.coder.com/coder/filebrowser/coder"
-  version       = "1.1.5"
+  version       = "1.1.6"
   agent_id      = coder_agent.main.id
   database_path = ".config/filebrowser.db"
 }
@@ -60,7 +60,7 @@ When `subdomain = false`, you must also set `agent_name` to the name of your `co
 module "filebrowser" {
   count      = data.coder_workspace.me.start_count
   source     = "registry.coder.com/coder/filebrowser/coder"
-  version    = "1.1.5"
+  version    = "1.1.6"
   agent_id   = coder_agent.main.id
   agent_name = "main"
   subdomain  = false

--- a/registry/coder/modules/filebrowser/README.md
+++ b/registry/coder/modules/filebrowser/README.md
@@ -11,7 +11,7 @@ tags: [filebrowser, files, web]
 > [!WARNING]
 > **This module is deprecated.** The upstream [File Browser](https://github.com/filebrowser/filebrowser) project has been wound down and its repository archived, so it no longer receives releases, bug fixes, or security patches.
 >
-> Existing workspaces will keep working, but we recommend against adopting this module for new templates. For a maintained alternative, see the community [`copyparty`](https://registry.coder.com/modules/djarbz/copyparty) module, or browse other file-serving modules: [https://registry.coder.com/modules?search=tag%3Afiles](https://registry.coder.com/modules?search=tag%3Afiles).
+> Existing workspaces will keep working, but we recommend against adopting this module for new templates. For alternatives, look at the [`copyparty`](https://registry.coder.com/modules/djarbz/copyparty) module or [https://registry.coder.com/modules?search=tag%3Afiles](https://registry.coder.com/modules?search=tag%3Afiles).
 
 A file browser for your workspace.
 

--- a/registry/coder/modules/filebrowser/README.md
+++ b/registry/coder/modules/filebrowser/README.md
@@ -3,10 +3,15 @@ display_name: File Browser
 description: A file browser for your workspace
 icon: ../../../../.icons/filebrowser.svg
 verified: true
-tags: [filebrowser, web]
+tags: [filebrowser, files, web]
 ---
 
 # File Browser
+
+> [!WARNING]
+> **This module is deprecated.** The upstream [File Browser](https://github.com/filebrowser/filebrowser) project has been wound down and its repository archived, so it no longer receives releases, bug fixes, or security patches.
+>
+> Existing workspaces will keep working, but we recommend against adopting this module for new templates. For a maintained alternative, see the community [`copyparty`](https://registry.coder.com/modules/djarbz/copyparty) module, or browse other file-serving modules: [https://registry.coder.com/modules?search=tag%3Afiles](https://registry.coder.com/modules?search=tag%3Afiles).
 
 A file browser for your workspace.
 


### PR DESCRIPTION
## Summary

Mark the `filebrowser` module as deprecated. The upstream [File Browser](https://github.com/filebrowser/filebrowser) project has been wound down and its repository archived, so it no longer receives releases, bug fixes, or security patches. Existing workspaces keep working, but new templates should avoid it.

## Changes

- Add a `> [!WARNING]` admonition to the module README explaining the deprecation and pointing users to the community [`copyparty`](https://registry.coder.com/modules/djarbz/copyparty) module as a maintained alternative.
- Link a generic tag search so users can discover file-serving alternatives as more land: https://registry.coder.com/modules?search=tag%3Afiles
- Add the generic `files` tag to the frontmatter (`filebrowser, files, web`) so `filebrowser` and `copyparty` group under a neutral, tool-agnostic tag instead of only the deprecated tool's own name.
- Bump the module version 1.1.5 -> 1.1.6 so the registry publishes a new release carrying the updated README.

## Notes

- The registry has no `deprecated` frontmatter field, and `cmd/readmevalidation` rejects unknown keys, so a README admonition is the supported way to surface deprecation on the registry site today.
- A patch version bump is required so the registry publishes a new release; without it the updated README would not be shown.
- `copyparty` is a community module (`verified: false`); it is presented as a community alternative rather than an official endorsement.

## Validation

- `go run ./cmd/readmevalidation` passes.
- `bunx prettier --check` passes.

Related to REG-94 / DEVEX-923 (evaluate alternatives to the filebrowser module).

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻
