### PR TITLE
feat(.github/scorecard,.github/workflows): route scorecard inference through cdrstable.dev AI Gateway

### DIFF
--- a/.github/scorecard/score-modules.ts
+++ b/.github/scorecard/score-modules.ts
@@ -4,7 +4,11 @@
  * posts (or updates) one GitHub Discussion per module in coder/registry.
  *
  * Env (required):
- *   ANTHROPIC_API_KEY         Anthropic API key
+ *   ANTHROPIC_API_KEY         Coder token for the dedicated "registry-scorecard"
+ *                             service account on cdrstable.dev. Routed through
+ *                             cdrstable.dev's AI Gateway instead of a raw
+ *                             sk-ant-* key (same pattern as coder/bullwinkle);
+ *                             AI Gateway forwards it upstream to Anthropic.
  *   GITHUB_DISCUSSIONS_TOKEN  GitHub PAT with Discussions read/write
  *
  * Usage:
@@ -38,6 +42,11 @@ const MODULES_DIR = path.join(REGISTRY_ROOT, "registry", "coder", "modules");
 const SCORECARD_PATH = path.join(import.meta.dir, "SCORECARD.md");
 
 const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL ?? "claude-sonnet-4-5";
+// cdrstable.dev's AI Gateway anthropic passthrough. Requires both
+// Coder-Session-Token (outer Coder auth) and x-api-key (the anthropic-shaped
+// header the passthrough handler itself expects) set to the same token.
+const ANTHROPIC_BASE_URL =
+  "https://cdrstable.dev/api/v2/ai-gateway/anthropic/v1";
 const MAX_FILE_BYTES = 30_000;
 
 // A module reference: bare names mean the coder namespace, and
@@ -329,10 +338,11 @@ Output ONLY the scorecard markdown in EXACTLY this structure (this example shows
 
 Do not add any prose before or after the scorecard.`;
 
-  const res = await fetch("https://api.anthropic.com/v1/messages", {
+  const res = await fetch(`${ANTHROPIC_BASE_URL}/messages`, {
     method: "POST",
     headers: {
       "x-api-key": process.env.ANTHROPIC_API_KEY!,
+      "Coder-Session-Token": process.env.ANTHROPIC_API_KEY!,
       "anthropic-version": "2023-06-01",
       "content-type": "application/json",
     },

--- a/.github/workflows/module-scorecard-check.yaml
+++ b/.github/workflows/module-scorecard-check.yaml
@@ -24,7 +24,10 @@
 # inert text for the LLM prompt. Nothing from the PR head is executed.
 #
 # Required repository secrets:
-#   SCORECARD_ANTHROPIC_API_KEY  Anthropic API key used for scoring
+#   SCORECARD_CDRSTABLE_TOKEN  cdrstable.dev token for the dedicated
+#                              "registry-scorecard" service account, used for
+#                              scoring via cdrstable.dev's AI Gateway (Anthropic
+#                              passthrough) instead of a raw Anthropic key.
 #
 # The baseline lookup reads discussions with the built-in GITHUB_TOKEN
 # (discussions: read below); no PAT is needed.
@@ -110,7 +113,7 @@ jobs:
       - name: Score changed modules
         if: steps.changed.outputs.modules != ''
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.SCORECARD_ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.SCORECARD_CDRSTABLE_TOKEN }}
           GITHUB_DISCUSSIONS_TOKEN: ${{ github.token }}
           MODULES: ${{ steps.changed.outputs.modules }}
         run: bun run .github/scorecard/score-modules.ts --modules "${MODULES}" --pr-report /tmp/scorecard-report.md

--- a/.github/workflows/module-scorecards.yaml
+++ b/.github/workflows/module-scorecards.yaml
@@ -9,7 +9,10 @@
 # index is rebuilt either way.
 #
 # Required repository secrets:
-#   SCORECARD_ANTHROPIC_API_KEY  Anthropic API key used for scoring
+#   SCORECARD_CDRSTABLE_TOKEN  cdrstable.dev token for the dedicated
+#                              "registry-scorecard" service account, used for
+#                              scoring via cdrstable.dev's AI Gateway (Anthropic
+#                              passthrough) instead of a raw Anthropic key.
 #
 # Discussions are written with the built-in GITHUB_TOKEN (discussions: write
 # below), so no PAT is needed and there is nothing to expire or rotate.
@@ -88,7 +91,7 @@ jobs:
 
       - name: Score modules and update module discussions
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.SCORECARD_ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.SCORECARD_CDRSTABLE_TOKEN }}
           GITHUB_DISCUSSIONS_TOKEN: ${{ github.token }}
         run: bun run .github/scorecard/score-modules.ts ${{ steps.scope.outputs.args }}
 


### PR DESCRIPTION
Module scorecard scoring called `api.anthropic.com` directly with a raw Anthropic key (`SCORECARD_ANTHROPIC_API_KEY`). This switches it to cdrstable.dev's AI Gateway anthropic passthrough instead, authenticated as a dedicated `registry-scorecard` service account, same pattern as [coder/bullwinkle's Phase 0 migration](https://github.com/coder/bullwinkle) off a raw `sk-ant-*` key.

- `score-modules.ts` now posts to `https://cdrstable.dev/api/v2/ai-gateway/anthropic/v1/messages`. The passthrough on this deployment needs both `Coder-Session-Token` (outer Coder auth) and `x-api-key` (the anthropic-shaped header the passthrough handler itself expects) set to the same token.
- Renamed the required repository secret from `SCORECARD_ANTHROPIC_API_KEY` to `SCORECARD_CDRSTABLE_TOKEN` in both workflows and their doc comments. The new secret is already set on this repo.

Verified with a live `--dry-run` scoring run against `coder/code-server` through the new path (real Claude output came back).

<details>
<summary>Setup done outside this diff</summary>

- Created a `registry-scorecard` service account on cdrstable.dev (same shape as the existing `bullwinkle` service account).
- Issued a long-lived token for it and set it as the `SCORECARD_CDRSTABLE_TOKEN` repository secret.

</details>

---
🤖 Generated with [Coder Agents](https://coder.com) on behalf of @bpmct